### PR TITLE
fix: use numeric constant instead of WebSocket.OPEN

### DIFF
--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -386,7 +386,7 @@ export class LiveTemplateClient {
     }
 
     const readyState = this.webSocketManager.getReadyState();
-    return readyState === WebSocket.OPEN;
+    return readyState === 1; // WebSocket.OPEN = 1
   }
 
   /**
@@ -414,7 +414,7 @@ export class LiveTemplateClient {
       this.logger.debug("Using HTTP mode for send");
       (window as any).__lvtSendPath = "http";
       this.sendHTTP(message);
-    } else if (readyState === WebSocket.OPEN) {
+    } else if (readyState === 1) { // WebSocket.OPEN = 1
       // WebSocket mode
       this.logger.debug("Sending via WebSocket");
       (window as any).__lvtSendPath = "websocket";

--- a/transport/websocket.ts
+++ b/transport/websocket.ts
@@ -57,7 +57,7 @@ export class WebSocketTransport {
   }
 
   send(data: string): void {
-    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+    if (this.socket && this.socket.readyState === 1) {  // WebSocket.OPEN = 1
       this.socket.send(data);
     }
   }


### PR DESCRIPTION
## Problem

In certain execution contexts (e.g., during WebSocket reconnection or after multiple connection cycles), the `WebSocket` global object's constants can become `undefined` even when the WebSocket connection is active.

This causes readyState comparisons like `readyState === WebSocket.OPEN` to fail:
- `readyState = 1` (WebSocket is OPEN)
- `WebSocket.OPEN = undefined` 
- `1 === undefined` → `false`
- Result: Incorrect HTTP fallback despite WebSocket being available

## Solution

Use the numeric constant `1` directly instead of `WebSocket.OPEN` for readyState comparisons.

## Changes

- `livetemplate-client.ts`: Fixed `isReady()` and `send()` methods (2 locations)
- `transport/websocket.ts`: Fixed `send()` method (1 location)

## Testing

- Verified delete operations now use WebSocket instead of falling back to HTTP
- All e2e tests passing

## Impact

Fixes issue where operations would incorrectly fall back to HTTP in full test suites despite having an open WebSocket connection.