### PR TITLE
fix: handle plain data objects gracefully in tree renderer

### DIFF
--- a/state/tree-renderer.ts
+++ b/state/tree-renderer.ts
@@ -434,20 +434,14 @@ export class TreeRenderer {
     }
 
     if (typeof value === "object") {
-      this.logger.error(
-        "Object value reached string conversion; this will render as [object Object]."
+      // Plain data objects (without tree structure) are state values that shouldn't be rendered.
+      // This happens when state contains objects like EditingItem that are used by server-side
+      // templates but aren't meant to be rendered directly in the DOM.
+      // Skip them silently instead of converting to "[object Object]".
+      this.logger.debug(
+        "Skipping plain object value (not a tree node) - this is normal for state-only data"
       );
-
-      if (this.logger.isDebugEnabled()) {
-        this.logger.debug("Value diagnostics:", {
-          valueType: typeof value,
-          isArray: Array.isArray(value),
-          keys: Object.keys(value as Record<string, unknown>),
-          hasStatics: Boolean((value as any).s),
-          hasDynamics: Boolean((value as any).d),
-          value,
-        });
-      }
+      return "";
     }
 
     return String(value);


### PR DESCRIPTION
## Summary

When state contains plain objects (like `EditingItem`) that are used by server-side templates but aren't tree nodes, skip them silently instead of logging an error and converting to `"[object Object]"`.

## Context

This serves as a **defense-in-depth layer** alongside the server-side fix ([livetemplate/livetemplate#74](https://github.com/livetemplate/livetemplate/pull/74)) that prevents raw structs from entering the tree dynamics.

## Changes

- Change error log to debug log for plain object values
- Return empty string instead of `"[object Object]"`
- Remove verbose diagnostics (no longer needed)

## Before/After

**Before:** Plain objects logged an error and rendered as `[object Object]`

**After:** Plain objects are silently skipped with a debug log

## Test plan

- [x] Builds successfully
- [x] Works with server-side fix in livetemplate#74

🤖 Generated with [Claude Code](https://claude.com/claude-code)