### PR TITLE
feat: support auto-generated _k keys in range item matching

### DIFF
--- a/state/tree-renderer.ts
+++ b/state/tree-renderer.ts
@@ -792,6 +792,11 @@ export class TreeRenderer {
     statics: any[],
     statePath?: string
   ): string | null {
+    // First check for auto-generated _k field (always takes priority)
+    if (item._k && typeof item._k === "string") {
+      return item._k;
+    }
+
     if (!statePath || !this.rangeIdKeys[statePath]) {
       return null;
     }


### PR DESCRIPTION
## Summary
- Check for auto-generated `_k` field first in `getItemKey()` to support range items without explicit key attributes

## Context
This is the client-side counterpart to [livetemplate/livetemplate#108](https://github.com/livetemplate/livetemplate/pull/108).

When templates don't define explicit key attributes (like `data-key="{{.ID}}"`), the server now injects a content-based hash into each item's `_k` field. This change ensures the client checks `_k` first, allowing proper key matching.

## Test plan
- [x] All 193 existing tests pass
- [x] Works with server-side auto-key injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)