### PR TITLE
chore: upgrade Go to 1.26 in CI workflows

### DIFF
--- a/.github/workflows/cross-repo-test.yml
+++ b/.github/workflows/cross-repo-test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26"
           cache-dependency-path: lvt/go.sum
 
       - name: Copy built client to lvt testing
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26"
 
       - name: Copy built client to lvt testing
         run: |


### PR DESCRIPTION
## Summary
- Update CI workflow Go versions from 1.23 to 1.26 in cross-repo-test.yml

## Test plan
- [x] No Go code changes (TypeScript repo)
- [x] CI workflow syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)