### PR TITLE
fix: use wss:// for WebSocket on HTTPS pages

### DIFF
--- a/transport/websocket.ts
+++ b/transport/websocket.ts
@@ -203,7 +203,8 @@ export class WebSocketManager {
     if (baseUrl) {
       return baseUrl;
     }
-    return `ws://${window.location.host}${liveUrl}`;
+    const wsScheme = window.location.protocol === "https:" ? "wss:" : "ws:";
+    return `${wsScheme}//${window.location.host}${liveUrl}`;
   }
 
   private getLiveUrl(): string {


### PR DESCRIPTION
## Summary

- Fixed WebSocket URL always using `ws://` regardless of page protocol
- On HTTPS pages, browsers block mixed-content WebSocket connections with `SecurityError`
- Now detects `window.location.protocol` and uses `wss:` for HTTPS pages

## Root Cause

`transport/websocket.ts:206` always constructed:
```ts
return `ws://${window.location.host}${liveUrl}`;
```

Behind TLS-terminating reverse proxies (Fly.io, Cloudflare, AWS ALB), the page loads over HTTPS but the client tried to open a `ws://` WebSocket — browsers reject this as mixed content.

## Fix

```ts
const wsScheme = window.location.protocol === "https:" ? "wss:" : "ws:";
return `${wsScheme}//${window.location.host}${liveUrl}`;
```

## Test plan

- [x] All 213 client tests pass
- [x] Verified with chromedp E2E test against Fly.io deployment (HTTPS → wss:// → WebSocket connected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)