### PR TITLE
feat: polyfill command/commandfor for cross-browser dialog support

### DIFF
--- a/dom/invoker-polyfill.ts
+++ b/dom/invoker-polyfill.ts
@@ -38,7 +38,7 @@ export function setupInvokerPolyfill(): void {
   document.addEventListener("click", handleClick);
 }
 
-/** Reset polyfill state. Exported for testing only. */
+/** @internal Reset polyfill state. Test-only — do not call from production code. */
 export function teardownInvokerPolyfill(): void {
   if (installed) {
     document.removeEventListener("click", handleClick);

--- a/dom/invoker-polyfill.ts
+++ b/dom/invoker-polyfill.ts
@@ -1,0 +1,46 @@
+/**
+ * Polyfill for the HTML Invoker Commands API (command/commandfor).
+ * Enables <button command="show-modal" commandfor="dialog-id"> to work
+ * cross-browser by calling .showModal()/.close() on the target <dialog>.
+ *
+ * No-op when native support is detected.
+ * Spec: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/command
+ */
+
+let installed = false;
+
+function handleClick(e: Event): void {
+  const button = (e.target as Element).closest(
+    "button[commandfor]"
+  ) as HTMLButtonElement | null;
+  if (!button) return;
+
+  const targetId = button.getAttribute("commandfor");
+  if (!targetId) return;
+
+  const command = button.getAttribute("command");
+  const target = document.getElementById(targetId);
+  if (!target || !(target instanceof HTMLDialogElement)) return;
+
+  if (command === "show-modal" && !target.open) {
+    target.showModal();
+  } else if (command === "close" && target.open) {
+    target.close();
+  }
+}
+
+export function setupInvokerPolyfill(): void {
+  if ("commandForElement" in HTMLButtonElement.prototype) return;
+  if (installed) return;
+
+  installed = true;
+  document.addEventListener("click", handleClick);
+}
+
+/** Reset polyfill state. Exported for testing only. */
+export function teardownInvokerPolyfill(): void {
+  if (installed) {
+    document.removeEventListener("click", handleClick);
+    installed = false;
+  }
+}

--- a/dom/invoker-polyfill.ts
+++ b/dom/invoker-polyfill.ts
@@ -10,10 +10,11 @@
 let installed = false;
 
 function handleClick(e: Event): void {
-  const button = (e.target as Element).closest(
-    "button[commandfor]"
-  ) as HTMLButtonElement | null;
-  if (!button) return;
+  const el = e.target;
+  if (!el || !(el instanceof Element)) return;
+
+  const button = el.closest("button[commandfor]") as HTMLButtonElement | null;
+  if (!button || button.disabled) return;
 
   const targetId = button.getAttribute("commandfor");
   if (!targetId) return;

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -24,6 +24,7 @@ import { ObserverManager } from "./dom/observer-manager";
 import { LoadingIndicator } from "./dom/loading-indicator";
 import { FormDisabler } from "./dom/form-disabler";
 import { setupReactiveAttributeListeners } from "./dom/reactive-attributes";
+import { setupInvokerPolyfill } from "./dom/invoker-polyfill";
 import { TreeRenderer } from "./state/tree-renderer";
 import { FormLifecycleManager } from "./state/form-lifecycle-manager";
 import { ChangeAutoWirer } from "./state/change-auto-wirer";
@@ -392,6 +393,9 @@ export class LiveTemplateClient {
 
     // Set up reactive attribute listeners for lvt-el:*:on:* attributes
     setupReactiveAttributeListeners();
+
+    // Polyfill command/commandfor for dialog open/close (Chrome 135+ only natively)
+    setupInvokerPolyfill();
 
     // Set up lifecycle listeners for lvt-fx:*:on:{lifecycle} attributes
     setupFxLifecycleListeners(this.wrapperElement);

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -394,7 +394,6 @@ export class LiveTemplateClient {
     // Set up reactive attribute listeners for lvt-el:*:on:* attributes
     setupReactiveAttributeListeners();
 
-    // Polyfill command/commandfor for dialog open/close (Chrome 135+ only natively)
     setupInvokerPolyfill();
 
     // Set up lifecycle listeners for lvt-fx:*:on:{lifecycle} attributes

--- a/tests/invoker-polyfill.test.ts
+++ b/tests/invoker-polyfill.test.ts
@@ -1,0 +1,213 @@
+import { setupInvokerPolyfill, teardownInvokerPolyfill } from "../dom/invoker-polyfill";
+
+/**
+ * jsdom does not implement HTMLDialogElement.showModal() or .close().
+ * Add mock implementations to a dialog element for testing.
+ */
+function mockDialogMethods(dialog: HTMLDialogElement): {
+  showModal: jest.Mock;
+  close: jest.Mock;
+} {
+  const showModal = jest.fn(() => {
+    dialog.setAttribute("open", "");
+  });
+  const close = jest.fn(() => {
+    dialog.removeAttribute("open");
+  });
+  (dialog as any).showModal = showModal;
+  (dialog as any).close = close;
+  return { showModal, close };
+}
+
+describe("setupInvokerPolyfill", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    teardownInvokerPolyfill();
+    document.body.innerHTML = "";
+  });
+
+  it("show-modal opens a closed dialog", () => {
+    const dialog = document.createElement("dialog");
+    dialog.id = "test-dialog";
+    const { showModal } = mockDialogMethods(dialog);
+    document.body.appendChild(dialog);
+
+    const button = document.createElement("button");
+    button.setAttribute("command", "show-modal");
+    button.setAttribute("commandfor", "test-dialog");
+    document.body.appendChild(button);
+
+    setupInvokerPolyfill();
+    button.click();
+
+    expect(showModal).toHaveBeenCalled();
+    expect(dialog.open).toBe(true);
+  });
+
+  it("close closes an open dialog", () => {
+    const dialog = document.createElement("dialog");
+    dialog.id = "test-dialog";
+    dialog.setAttribute("open", "");
+    const { close } = mockDialogMethods(dialog);
+    document.body.appendChild(dialog);
+
+    const button = document.createElement("button");
+    button.setAttribute("command", "close");
+    button.setAttribute("commandfor", "test-dialog");
+    document.body.appendChild(button);
+
+    setupInvokerPolyfill();
+    button.click();
+
+    expect(close).toHaveBeenCalled();
+    expect(dialog.open).toBe(false);
+  });
+
+  it("ignores buttons without commandfor", () => {
+    const dialog = document.createElement("dialog");
+    dialog.id = "test-dialog";
+    const { showModal } = mockDialogMethods(dialog);
+    document.body.appendChild(dialog);
+
+    const button = document.createElement("button");
+    button.setAttribute("command", "show-modal");
+    document.body.appendChild(button);
+
+    setupInvokerPolyfill();
+    button.click();
+
+    expect(showModal).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-dialog targets", () => {
+    const div = document.createElement("div");
+    div.id = "not-a-dialog";
+    document.body.appendChild(div);
+
+    const button = document.createElement("button");
+    button.setAttribute("command", "show-modal");
+    button.setAttribute("commandfor", "not-a-dialog");
+    document.body.appendChild(button);
+
+    setupInvokerPolyfill();
+
+    expect(() => button.click()).not.toThrow();
+  });
+
+  it("ignores nonexistent targets", () => {
+    const button = document.createElement("button");
+    button.setAttribute("command", "show-modal");
+    button.setAttribute("commandfor", "nonexistent");
+    document.body.appendChild(button);
+
+    setupInvokerPolyfill();
+
+    expect(() => button.click()).not.toThrow();
+  });
+
+  it("does not call showModal on already-open dialog", () => {
+    const dialog = document.createElement("dialog");
+    dialog.id = "test-dialog";
+    dialog.setAttribute("open", "");
+    const { showModal } = mockDialogMethods(dialog);
+    document.body.appendChild(dialog);
+
+    const button = document.createElement("button");
+    button.setAttribute("command", "show-modal");
+    button.setAttribute("commandfor", "test-dialog");
+    document.body.appendChild(button);
+
+    setupInvokerPolyfill();
+    button.click();
+
+    expect(showModal).not.toHaveBeenCalled();
+  });
+
+  it("does not call close on already-closed dialog", () => {
+    const dialog = document.createElement("dialog");
+    dialog.id = "test-dialog";
+    const { close } = mockDialogMethods(dialog);
+    document.body.appendChild(dialog);
+
+    const button = document.createElement("button");
+    button.setAttribute("command", "close");
+    button.setAttribute("commandfor", "test-dialog");
+    document.body.appendChild(button);
+
+    setupInvokerPolyfill();
+    button.click();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it("handles clicks on child elements inside the button", () => {
+    const dialog = document.createElement("dialog");
+    dialog.id = "test-dialog";
+    const { showModal } = mockDialogMethods(dialog);
+    document.body.appendChild(dialog);
+
+    const button = document.createElement("button");
+    button.setAttribute("command", "show-modal");
+    button.setAttribute("commandfor", "test-dialog");
+    const icon = document.createElement("span");
+    icon.textContent = "+";
+    button.appendChild(icon);
+    document.body.appendChild(button);
+
+    setupInvokerPolyfill();
+
+    // Click the child <span>, not the button directly
+    icon.click();
+
+    expect(showModal).toHaveBeenCalled();
+  });
+
+  it("skips polyfill when native support exists", () => {
+    // Simulate native support by adding commandForElement to prototype
+    Object.defineProperty(HTMLButtonElement.prototype, "commandForElement", {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    const dialog = document.createElement("dialog");
+    dialog.id = "test-dialog";
+    const { showModal } = mockDialogMethods(dialog);
+    document.body.appendChild(dialog);
+
+    const button = document.createElement("button");
+    button.setAttribute("command", "show-modal");
+    button.setAttribute("commandfor", "test-dialog");
+    document.body.appendChild(button);
+
+    setupInvokerPolyfill();
+    button.click();
+
+    // Polyfill should not have installed its listener
+    expect(showModal).not.toHaveBeenCalled();
+
+    // Clean up the mock property
+    delete (HTMLButtonElement.prototype as any).commandForElement;
+  });
+
+  it("ignores unknown commands", () => {
+    const dialog = document.createElement("dialog");
+    dialog.id = "test-dialog";
+    const { showModal, close } = mockDialogMethods(dialog);
+    document.body.appendChild(dialog);
+
+    const button = document.createElement("button");
+    button.setAttribute("command", "toggle-popover");
+    button.setAttribute("commandfor", "test-dialog");
+    document.body.appendChild(button);
+
+    setupInvokerPolyfill();
+    button.click();
+
+    expect(showModal).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+});

--- a/tests/invoker-polyfill.test.ts
+++ b/tests/invoker-polyfill.test.ts
@@ -26,6 +26,7 @@ describe("setupInvokerPolyfill", () => {
 
   afterEach(() => {
     teardownInvokerPolyfill();
+    delete (HTMLButtonElement.prototype as any).commandForElement;
     document.body.innerHTML = "";
   });
 
@@ -206,9 +207,7 @@ describe("setupInvokerPolyfill", () => {
 
     // Polyfill should not have installed its listener
     expect(showModal).not.toHaveBeenCalled();
-
-    // Clean up the mock property
-    delete (HTMLButtonElement.prototype as any).commandForElement;
+    // commandForElement cleanup is handled by afterEach
   });
 
   it("ignores unknown commands", () => {

--- a/tests/invoker-polyfill.test.ts
+++ b/tests/invoker-polyfill.test.ts
@@ -108,6 +108,24 @@ describe("setupInvokerPolyfill", () => {
     expect(() => button.click()).not.toThrow();
   });
 
+  it("ignores disabled buttons", () => {
+    const dialog = document.createElement("dialog");
+    dialog.id = "test-dialog";
+    const { showModal } = mockDialogMethods(dialog);
+    document.body.appendChild(dialog);
+
+    const button = document.createElement("button");
+    button.setAttribute("command", "show-modal");
+    button.setAttribute("commandfor", "test-dialog");
+    button.disabled = true;
+    document.body.appendChild(button);
+
+    setupInvokerPolyfill();
+    button.click();
+
+    expect(showModal).not.toHaveBeenCalled();
+  });
+
   it("does not call showModal on already-open dialog", () => {
     const dialog = document.createElement("dialog");
     dialog.id = "test-dialog";


### PR DESCRIPTION
## Summary

- Adds a lightweight polyfill for the HTML Invoker Commands API (`command`/`commandfor`) so `<button command="show-modal" commandfor="dialog-id">` works in Firefox and Safari (not just Chrome 135+)
- The polyfill calls `.showModal()` / `.close()` on target `<dialog>` elements, keeping dialog open/close in Tier 1 (standard HTML, no `lvt-*` attributes needed)
- Feature detection via `commandForElement` makes the polyfill a no-op when browsers add native support

## Context

The Dialog Routing docs describe `command`/`commandfor` as a Tier 1 pattern for opening/closing `<dialog>`, but it only works natively in Chrome 135+. This was discovered during lvt PR #292 (14 e2e failures in CI Docker). Rather than downgrading dialog routing to Tier 2 (`lvt-el:toggleAttr` + `data-lvt-target`), this polyfill makes the documented pattern actually work cross-browser.

The existing `commandfor` exclusion in `event-delegation.ts:136` already prevents these buttons from triggering server actions — this polyfill completes the picture by handling the client-side dialog behavior.

## Test plan

- [x] 10 unit tests covering: show-modal, close, child element clicks, non-dialog targets, nonexistent targets, already-open/closed guards, feature detection skip, unknown commands
- [ ] E2E test with new `dialog-patterns` example (separate PR in examples repo, depends on this release)
- [ ] Verify polyfill is no-op in Chrome 135+ (feature detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)