### PR TITLE
fix: cross-handler SPA navigation, navigation edge cases, and Tier 1 file uploads

### DIFF
--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -340,7 +340,18 @@ export class EventDelegator {
                   (input) => input.files && input.files.length > 0
                 );
                 if (hasFiles) {
-                  tier1FormData = new FormData(targetElement);
+                  // Pass the submitter so its name/value is included in
+                  // FormData. Without this, multi-button forms lose the
+                  // clicked button's name/value (e.g.
+                  // <button name="action" value="save">).
+                  const submitter = (e as SubmitEvent).submitter as
+                    | HTMLButtonElement
+                    | HTMLInputElement
+                    | null;
+                  tier1FormData = new FormData(
+                    targetElement,
+                    submitter ?? undefined
+                  );
                 }
               }
 

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -355,6 +355,12 @@ export class EventDelegator {
                   if (submitter?.name) {
                     tier1FormData.set(submitter.name, submitter.value);
                   }
+                  // Set the action field here (not inside sendHTTPMultipart)
+                  // so the client-owned FormData is fully prepared before
+                  // being passed to another method. This keeps
+                  // sendHTTPMultipart from mutating a caller-supplied
+                  // FormData object.
+                  tier1FormData.set("lvt-action", action);
                 }
               }
 

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -22,7 +22,7 @@ export interface EventDelegationContext {
   getRateLimitedHandlers(): WeakMap<Element, Map<string, Function>>;
   parseValue(value: string): any;
   send(message: any): void;
-  sendHTTPMultipart(form: HTMLFormElement, action: string, formData?: FormData): void;
+  sendHTTPMultipart(form: HTMLFormElement, action: string, formData: FormData): void;
   setActiveSubmission(
     form: HTMLFormElement | null,
     button: HTMLButtonElement | null,

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -22,7 +22,7 @@ export interface EventDelegationContext {
   getRateLimitedHandlers(): WeakMap<Element, Map<string, Function>>;
   parseValue(value: string): any;
   send(message: any): void;
-  sendHTTPMultipart(form: HTMLFormElement, action: string): void;
+  sendHTTPMultipart(form: HTMLFormElement, action: string, formData?: FormData): void;
   setActiveSubmission(
     form: HTMLFormElement | null,
     button: HTMLButtonElement | null,
@@ -302,6 +302,26 @@ export class EventDelegator {
                 });
               }
 
+              // Tier 1 file upload detection — must happen BEFORE setActiveSubmission
+              // which disables the fieldset. Once the fieldset is disabled, FormData
+              // excludes all its child fields, so we must build FormData here if we
+              // need it for HTTP multipart upload.
+              let tier1FormData: FormData | null = null;
+              if (
+                eventType === "submit" &&
+                targetElement instanceof HTMLFormElement
+              ) {
+                const tier1FileInputs = targetElement.querySelectorAll<HTMLInputElement>(
+                  'input[type="file"]:not([lvt-upload])'
+                );
+                const hasFiles = Array.from(tier1FileInputs).some(
+                  (input) => input.files && input.files.length > 0
+                );
+                if (hasFiles) {
+                  tier1FormData = new FormData(targetElement);
+                }
+              }
+
               if (
                 eventType === "submit" &&
                 targetElement instanceof HTMLFormElement
@@ -352,21 +372,12 @@ export class EventDelegator {
                 this.context.getWebSocketReadyState()
               );
 
-              // Tier 1 file uploads: forms with file inputs (without lvt-upload)
-              // are submitted via HTTP fetch with FormData instead of WebSocket.
-              // Binary files can't be sent efficiently over WebSocket (base64 overhead).
-              if (targetElement instanceof HTMLFormElement) {
-                const tier1FileInputs = targetElement.querySelectorAll<HTMLInputElement>(
-                  'input[type="file"]:not([lvt-upload])'
-                );
-                const hasFiles = Array.from(tier1FileInputs).some(
-                  (input) => input.files && input.files.length > 0
-                );
-                if (hasFiles) {
-                  this.logger.debug("Tier 1 file upload detected, using HTTP fetch");
-                  this.context.sendHTTPMultipart(targetElement, action);
-                  return;
-                }
+              // Tier 1 file uploads: send via HTTP fetch with FormData captured
+              // BEFORE the fieldset was disabled by setActiveSubmission.
+              if (tier1FormData !== null && targetElement instanceof HTMLFormElement) {
+                this.logger.debug("Tier 1 file upload detected, using HTTP fetch");
+                this.context.sendHTTPMultipart(targetElement, action, tier1FormData);
+                return;
               }
 
               this.context.send(message);

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -35,11 +35,45 @@ export interface EventDelegationContext {
 /**
  * Handles all DOM event delegation concerns for LiveTemplateClient.
  */
+// All event types registered by setupEventDelegation. Exported so
+// teardownForWrapper() can remove them all without drift.
+export const DELEGATED_EVENT_TYPES = [
+  "click",
+  "submit",
+  "change",
+  "input",
+  "search",
+  "keydown",
+  "keyup",
+  "focus",
+  "blur",
+  "mouseenter",
+  "mouseleave",
+] as const;
+
 export class EventDelegator {
   constructor(
     private readonly context: EventDelegationContext,
     private readonly logger: Logger
   ) {}
+
+  /**
+   * Remove all document-level event listeners registered by
+   * setupEventDelegation for a specific wrapper ID. Call this before
+   * a cross-handler navigation changes the wrapper's data-lvt-id, to
+   * prevent listener leaks.
+   */
+  teardownForWrapper(wrapperId: string | null): void {
+    if (!wrapperId) return;
+    for (const eventType of DELEGATED_EVENT_TYPES) {
+      const listenerKey = `__lvt_delegated_${eventType}_${wrapperId}`;
+      const existingListener = (document as any)[listenerKey];
+      if (existingListener) {
+        document.removeEventListener(eventType, existingListener, false);
+        delete (document as any)[listenerKey];
+      }
+    }
+  }
 
   private extractButtonData(button: HTMLButtonElement | HTMLInputElement, data: Record<string, any>): void {
     if (button.value) {
@@ -57,19 +91,7 @@ export class EventDelegator {
     const wrapperElement = this.context.getWrapperElement();
     if (!wrapperElement) return;
 
-    const eventTypes = [
-      "click",
-      "submit",
-      "change",
-      "input",
-      "search", // Fired when clearing input type="search" via X button
-      "keydown",
-      "keyup",
-      "focus",
-      "blur",
-      "mouseenter",
-      "mouseleave",
-    ];
+    const eventTypes = DELEGATED_EVENT_TYPES;
     const wrapperId = wrapperElement.getAttribute("data-lvt-id");
     const rateLimitedHandlers = this.context.getRateLimitedHandlers();
 

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -374,9 +374,14 @@ export class EventDelegator {
 
               // Tier 1 file uploads: send via HTTP fetch with FormData captured
               // BEFORE the fieldset was disabled by setActiveSubmission.
-              if (tier1FormData !== null && targetElement instanceof HTMLFormElement) {
+              // tier1FormData is only set when targetElement is a form.
+              if (tier1FormData !== null) {
                 this.logger.debug("Tier 1 file upload detected, using HTTP fetch");
-                this.context.sendHTTPMultipart(targetElement, action, tier1FormData);
+                this.context.sendHTTPMultipart(
+                  targetElement as HTMLFormElement,
+                  action,
+                  tier1FormData
+                );
                 return;
               }
 

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -340,18 +340,21 @@ export class EventDelegator {
                   (input) => input.files && input.files.length > 0
                 );
                 if (hasFiles) {
-                  // Pass the submitter so its name/value is included in
-                  // FormData. Without this, multi-button forms lose the
-                  // clicked button's name/value (e.g.
-                  // <button name="action" value="save">).
+                  // Include the submitter's name/value so multi-button
+                  // forms preserve the clicked button's entry (e.g.
+                  // <button name="action" value="save">). We avoid the
+                  // two-argument FormData constructor (Chrome 112+,
+                  // Firefox 111+, Safari 16.4+ — March 2023) and set
+                  // the submitter value manually for broader browser
+                  // compatibility.
                   const submitter = (e as SubmitEvent).submitter as
                     | HTMLButtonElement
                     | HTMLInputElement
                     | null;
-                  tier1FormData = new FormData(
-                    targetElement,
-                    submitter ?? undefined
-                  );
+                  tier1FormData = new FormData(targetElement);
+                  if (submitter?.name) {
+                    tier1FormData.set(submitter.name, submitter.value);
+                  }
                 }
               }
 

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -32,7 +32,10 @@ export class LinkInterceptor {
     const listenerKey = `__lvt_link_intercept_${wrapperId}`;
     const existing = (document as any)[listenerKey];
     if (existing) {
-      document.removeEventListener("click", existing);
+      // Explicit capture flag (false) for consistency with
+      // EventDelegator.teardownForWrapper — defaults match but
+      // explicit is clearer.
+      document.removeEventListener("click", existing, false);
       delete (document as any)[listenerKey];
     }
   }

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -9,9 +9,13 @@ export interface LinkInterceptorContext {
  * Intercepts <a> clicks within the LiveTemplate wrapper for SPA navigation.
  * Same-origin links are fetched via fetch() and the wrapper content is replaced.
  * External links, target="_blank", download, and lvt-nav:no-intercept are skipped.
+ *
+ * Uses AbortController to cancel in-flight fetches when a new navigation
+ * starts (rapid clicks, back/forward during fetch).
  */
 export class LinkInterceptor {
   private popstateListener: (() => void) | null = null;
+  private abortController: AbortController | null = null;
 
   constructor(
     private readonly context: LinkInterceptorContext,
@@ -70,10 +74,15 @@ export class LinkInterceptor {
   }
 
   private async navigate(href: string, pushState: boolean = true): Promise<void> {
+    // Cancel any in-flight navigation fetch
+    this.abortController?.abort();
+    this.abortController = new AbortController();
+
     try {
       const response = await fetch(href, {
         credentials: "include",
         headers: { Accept: "text/html" },
+        signal: this.abortController.signal,
       });
 
       if (!response.ok) {
@@ -82,12 +91,18 @@ export class LinkInterceptor {
       }
 
       const html = await response.text();
-      this.context.handleNavigationResponse(html);
 
+      // Push state BEFORE handling response so that cross-handler
+      // navigation reconnects the WebSocket to the correct URL.
+      // connect() derives the WebSocket path from window.location.
       if (pushState) {
         window.history.pushState(null, "", href);
       }
-    } catch {
+
+      this.context.handleNavigationResponse(html);
+    } catch (e: unknown) {
+      // AbortError means a new navigation superseded this one — ignore
+      if (e instanceof DOMException && e.name === "AbortError") return;
       window.location.href = href;
     }
   }

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -26,8 +26,18 @@ export class LinkInterceptor {
    * Remove the click listener registered by setup() for a specific
    * wrapper ID. Call this before cross-handler navigation changes the
    * wrapper's data-lvt-id, to prevent orphaned listeners.
+   *
+   * Also aborts any in-flight navigate() fetch so it cannot call
+   * handleNavigationResponse after teardown and trigger a duplicate
+   * or out-of-date navigation.
    */
   teardownForWrapper(wrapperId: string | null): void {
+    // Abort any in-flight fetch — whether or not a wrapper ID is passed.
+    // The caller may be tearing down before a cross-handler transition,
+    // and we don't want a pending fetch to land post-teardown.
+    this.abortController?.abort();
+    this.abortController = null;
+
     if (!wrapperId) return;
     const listenerKey = `__lvt_link_intercept_${wrapperId}`;
     const existing = (document as any)[listenerKey];

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -22,6 +22,21 @@ export class LinkInterceptor {
     private readonly logger: Logger
   ) {}
 
+  /**
+   * Remove the click listener registered by setup() for a specific
+   * wrapper ID. Call this before cross-handler navigation changes the
+   * wrapper's data-lvt-id, to prevent orphaned listeners.
+   */
+  teardownForWrapper(wrapperId: string | null): void {
+    if (!wrapperId) return;
+    const listenerKey = `__lvt_link_intercept_${wrapperId}`;
+    const existing = (document as any)[listenerKey];
+    if (existing) {
+      document.removeEventListener("click", existing);
+      delete (document as any)[listenerKey];
+    }
+  }
+
   setup(wrapper: Element): void {
     const wrapperId = wrapper.getAttribute("data-lvt-id");
     const listenerKey = `__lvt_link_intercept_${wrapperId}`;

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -166,7 +166,7 @@ export class LiveTemplateClient {
         getRateLimitedHandlers: () => this.rateLimitedHandlers,
         parseValue: (value: string) => this.parseValue(value),
         send: (message: any) => this.send(message),
-        sendHTTPMultipart: (form: HTMLFormElement, action: string, formData?: FormData) =>
+        sendHTTPMultipart: (form: HTMLFormElement, action: string, formData: FormData) =>
           this.sendHTTPMultipart(form, action, formData),
         setActiveSubmission: (
           form: HTMLFormElement | null,
@@ -560,32 +560,24 @@ export class LiveTemplateClient {
    * Used for Tier 1 file uploads where binary files are submitted via
    * HTTP fetch instead of WebSocket (avoids base64 encoding overhead).
    *
-   * The optional formData parameter allows callers to pass pre-captured
-   * form data (e.g., captured BEFORE setActiveSubmission disabled the
-   * fieldset, which would otherwise exclude all fields from FormData).
-   * When a prebuilt FormData is passed, the caller is responsible for
-   * setting the "lvt-action" entry — this method will not mutate it.
+   * IMPORTANT: Callers must pass pre-captured form data (formData).
+   * FormData must be built BEFORE setActiveSubmission disables the
+   * form's fieldset — otherwise FormData would be empty because
+   * disabled fieldsets exclude all child fields. The caller is also
+   * responsible for setting the "lvt-action" entry; this method will
+   * not mutate the passed FormData.
    */
-  sendHTTPMultipart(form: HTMLFormElement, action: string, formData?: FormData): void {
+  sendHTTPMultipart(form: HTMLFormElement, action: string, formData: FormData): void {
     this.doSendHTTPMultipart(form, action, formData);
   }
 
   private async doSendHTTPMultipart(
     form: HTMLFormElement,
     action: string,
-    prebuiltFormData?: FormData
+    formData: FormData
   ): Promise<void> {
     try {
       const liveUrl = this.getLiveUrl();
-      let formData: FormData;
-      if (prebuiltFormData) {
-        // Caller has already populated lvt-action — don't mutate.
-        formData = prebuiltFormData;
-      } else {
-        // Build fresh FormData and set our own action.
-        formData = new FormData(form);
-        formData.set("lvt-action", action);
-      }
 
       const response = await fetch(liveUrl, {
         method: "POST",
@@ -635,10 +627,12 @@ export class LiveTemplateClient {
     const doc = parser.parseFromString(html, "text/html");
     const oldId = this.wrapperElement.getAttribute("data-lvt-id");
 
-    // Update document title from the fetched page
-    const newTitle = doc.querySelector("title");
-    if (newTitle) {
-      document.title = newTitle.textContent || "";
+    // Update document title from the fetched page. Only apply if the
+    // new title is non-empty — blanking the title would be surprising
+    // and unhelpful.
+    const newTitleText = doc.querySelector("title")?.textContent;
+    if (newTitleText) {
+      document.title = newTitleText;
     }
 
     // Try same-handler wrapper first (same data-lvt-id)

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -563,10 +563,8 @@ export class LiveTemplateClient {
    * The optional formData parameter allows callers to pass pre-captured
    * form data (e.g., captured BEFORE setActiveSubmission disabled the
    * fieldset, which would otherwise exclude all fields from FormData).
-   *
-   * NOTE: If a prebuilt FormData is passed, it will be mutated — this
-   * method sets the "lvt-action" entry on it. Callers should treat the
-   * passed FormData as consumed and not reuse it afterwards.
+   * When a prebuilt FormData is passed, the caller is responsible for
+   * setting the "lvt-action" entry — this method will not mutate it.
    */
   sendHTTPMultipart(form: HTMLFormElement, action: string, formData?: FormData): void {
     this.doSendHTTPMultipart(form, action, formData);
@@ -579,10 +577,15 @@ export class LiveTemplateClient {
   ): Promise<void> {
     try {
       const liveUrl = this.getLiveUrl();
-      // Note: this mutates prebuiltFormData if provided. Callers must
-      // not reuse the passed FormData after this call.
-      const formData = prebuiltFormData || new FormData(form);
-      formData.set("lvt-action", action);
+      let formData: FormData;
+      if (prebuiltFormData) {
+        // Caller has already populated lvt-action — don't mutate.
+        formData = prebuiltFormData;
+      } else {
+        // Build fresh FormData and set our own action.
+        formData = new FormData(form);
+        formData.set("lvt-action", action);
+      }
 
       const response = await fetch(liveUrl, {
         method: "POST",

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -689,28 +689,25 @@ export class LiveTemplateClient {
       // Reconnect to the new handler. The server sends an initial tree
       // that produces the same DOM as the fetched HTML.
       //
+      // Escape the wrapper ID to defend against (pathological) server
+      // responses with special characters that would break the
+      // attribute selector. Only `"` and `\` need escaping inside a
+      // double-quoted attribute value selector (`[attr="..."]`), and
+      // we prefer a manual escape over CSS.escape() which is not
+      // available in jsdom test environments.
+      //
       // Epoch semantics: if a newer navigation supersedes this one, any
       // work it already did (disconnect, setup, new connect) is still
       // valid for the newer navigation — we must NOT tear it down.
-      //   - Success branch: do nothing if superseded. The newer
-      //     navigation called disconnect() synchronously when it
-      //     started, so this connect's transport was already replaced
-      //     before it could resolve. Calling this.disconnect() here
-      //     would kill the newer navigation's connection.
-      //   - Failure branch: only reload if still current. A failure
-      //     from a superseded attempt is irrelevant.
-      const checkEpoch = (): boolean => myEpoch === this.navigationEpoch;
-      this.connect(`[data-lvt-id="${newId}"]`).then(
-        () => {
-          // No-op if superseded: the newer navigation owns the transport.
-          if (!checkEpoch()) return;
-        },
-        (err) => {
-          if (!checkEpoch()) return;
-          this.logger.error("Cross-handler reconnect failed:", err);
-          window.location.reload();
-        }
-      );
+      // The success branch has no work to do either way, so we only
+      // guard the failure branch to avoid stale reloads.
+      const escapedId = newId.replace(/[\\"]/g, "\\$&");
+      const selector = `[data-lvt-id="${escapedId}"]`;
+      this.connect(selector).catch((err) => {
+        if (myEpoch !== this.navigationEpoch) return;
+        this.logger.error("Cross-handler reconnect failed:", err);
+        window.location.reload();
+      });
       return;
     }
 

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -563,6 +563,10 @@ export class LiveTemplateClient {
    * The optional formData parameter allows callers to pass pre-captured
    * form data (e.g., captured BEFORE setActiveSubmission disabled the
    * fieldset, which would otherwise exclude all fields from FormData).
+   *
+   * NOTE: If a prebuilt FormData is passed, it will be mutated — this
+   * method sets the "lvt-action" entry on it. Callers should treat the
+   * passed FormData as consumed and not reuse it afterwards.
    */
   sendHTTPMultipart(form: HTMLFormElement, action: string, formData?: FormData): void {
     this.doSendHTTPMultipart(form, action, formData);
@@ -575,6 +579,8 @@ export class LiveTemplateClient {
   ): Promise<void> {
     try {
       const liveUrl = this.getLiveUrl();
+      // Note: this mutates prebuiltFormData if provided. Callers must
+      // not reuse the passed FormData after this call.
       const formData = prebuiltFormData || new FormData(form);
       formData.set("lvt-action", action);
 
@@ -711,11 +717,24 @@ export class LiveTemplateClient {
       // we prefer a manual escape over CSS.escape() which is not
       // available in jsdom test environments.
       //
-      // Epoch semantics: if a newer navigation supersedes this one, any
-      // work it already did (disconnect, setup, new connect) is still
-      // valid for the newer navigation — we must NOT tear it down.
-      // The success branch has no work to do either way, so we only
-      // guard the failure branch to avoid stale reloads.
+      // Epoch semantics: the failure branch is guarded by the epoch
+      // check to avoid stale reloads. The success branch has no work
+      // to do — there's nothing for handleNavigationResponse to undo
+      // on success.
+      //
+      // Known limitation: if two cross-handler navigations run in rapid
+      // succession (A then B), A's connect() might still be executing
+      // its post-await setup (useHTTP assignment, initial state
+      // rendering, event delegation) when B starts. Because there's
+      // only one WebSocketManager transport at a time, B's disconnect()
+      // kills A's in-flight transport, and B's setup happens on the
+      // wrapper with B's ID. If A's post-await code runs AFTER B sets
+      // the wrapper ID, A's querySelector lookup would already be
+      // stale (it captured the wrapper synchronously before the await).
+      // A true fix requires making connect() itself cancellable with
+      // an AbortSignal, which is out of scope for this PR. In practice,
+      // two successive SPA navigations within a single event loop tick
+      // are rare, and the idempotent setup methods minimize fallout.
       const escapedId = newId.replace(/[\\"]/g, "\\$&");
       const selector = `[data-lvt-id="${escapedId}"]`;
       this.connect(selector).catch((err) => {

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -641,8 +641,10 @@ export class LiveTemplateClient {
         return;
       }
 
-      // Clean up stale event listeners keyed to the old wrapper ID
-      this.cleanupListenersForWrapper(oldId);
+      // Clean up stale event listeners keyed to the old wrapper ID.
+      // Each component knows its own listener keys, so we delegate.
+      this.linkInterceptor.teardownForWrapper(oldId);
+      this.eventDelegator.teardownForWrapper(oldId);
 
       // Supersede any previous in-flight connect() from an earlier navigation
       const myEpoch = ++this.navigationEpoch;
@@ -662,23 +664,36 @@ export class LiveTemplateClient {
       // Scroll to top for cross-handler navigation
       window.scrollTo(0, 0);
 
-      // Update liveUrl to the current page (pushState already ran in
-      // LinkInterceptor.navigate before this method is called).
+      // Update the live URL used by the WebSocket manager to derive the
+      // reconnect path. We mutate options.liveUrl (the options object is
+      // the client's internal working copy — we never expose it or reuse
+      // the caller's reference beyond the constructor) so the subsequent
+      // connect() call picks up the new path without needing to thread
+      // the URL through connect()'s signature.
       this.options.liveUrl =
         window.location.pathname + window.location.search;
 
       // Reconnect to the new handler. The server sends an initial tree
       // that produces the same DOM as the fetched HTML. If another
       // navigation supersedes this one, the epoch check discards the
-      // stale result.
-      this.connect(`[data-lvt-id="${newId}"]`).catch((err) => {
-        if (myEpoch !== this.navigationEpoch) {
-          // Superseded by a newer navigation — ignore this failure
-          return;
+      // stale result — both in the success (.then) and failure (.catch)
+      // branches. A stale success means another navigation started while
+      // this one was still connecting, so we must disconnect what we
+      // just connected.
+      const checkEpoch = (): boolean => myEpoch === this.navigationEpoch;
+      this.connect(`[data-lvt-id="${newId}"]`).then(
+        () => {
+          if (!checkEpoch()) {
+            // Superseded — tear down the stale connection we just opened
+            this.disconnect();
+          }
+        },
+        (err) => {
+          if (!checkEpoch()) return;
+          this.logger.error("Cross-handler reconnect failed:", err);
+          window.location.reload();
         }
-        this.logger.error("Cross-handler reconnect failed:", err);
-        window.location.reload();
-      });
+      );
       return;
     }
 
@@ -694,33 +709,6 @@ export class LiveTemplateClient {
     }
     this.eventDelegator.setupEventDelegation();
     this.linkInterceptor.setup(this.wrapperElement);
-  }
-
-  /**
-   * Remove stale event listeners keyed to a specific wrapper ID.
-   * Called before cross-handler navigation changes the wrapper ID,
-   * to prevent orphaned listeners from accumulating.
-   */
-  private cleanupListenersForWrapper(wrapperId: string | null): void {
-    if (!wrapperId) return;
-
-    // Clean up link interceptor listener
-    const linkKey = `__lvt_link_intercept_${wrapperId}`;
-    const linkListener = (document as any)[linkKey];
-    if (linkListener) {
-      document.removeEventListener("click", linkListener);
-      delete (document as any)[linkKey];
-    }
-
-    // Clean up delegated event listeners
-    for (const eventType of ["click", "submit", "change", "input"]) {
-      const delegatedKey = `__lvt_delegated_${eventType}_${wrapperId}`;
-      const delegatedListener = (document as any)[delegatedKey];
-      if (delegatedListener) {
-        document.removeEventListener(eventType, delegatedListener, false);
-        delete (document as any)[delegatedKey];
-      }
-    }
   }
 
   /**

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -78,6 +78,12 @@ export class LiveTemplateClient {
   // Message tracking for deterministic E2E testing
   private messageCount: number = 0;
 
+  // Cross-handler navigation: track the latest in-flight connect() so a
+  // subsequent navigation can supersede an earlier one. Incremented on
+  // each cross-handler navigation; handlers check the epoch to avoid
+  // applying stale connection results.
+  private navigationEpoch: number = 0;
+
   constructor(options: LiveTemplateClientOptions = {}) {
     const { logger: providedLogger, logLevel, debug, ...restOptions } = options;
     const resolvedLevel = logLevel ?? (debug ? "debug" : "info");
@@ -628,15 +634,30 @@ export class LiveTemplateClient {
     const newWrapper = doc.querySelector("[data-lvt-id]");
     if (newWrapper) {
       const newId = newWrapper.getAttribute("data-lvt-id");
+      // Guard: attribute exists (we queried by [data-lvt-id]) but could be empty
+      if (!newId) {
+        this.logger.warn("Cross-handler navigation: new wrapper has empty data-lvt-id");
+        window.location.reload();
+        return;
+      }
 
       // Clean up stale event listeners keyed to the old wrapper ID
       this.cleanupListenersForWrapper(oldId);
 
+      // Supersede any previous in-flight connect() from an earlier navigation
+      const myEpoch = ++this.navigationEpoch;
+
       this.disconnect();
-      this.wrapperElement.setAttribute("data-lvt-id", newId!);
+      this.wrapperElement.setAttribute("data-lvt-id", newId);
       this.wrapperElement.replaceChildren(
         ...Array.from(newWrapper.childNodes).map((n) => n.cloneNode(true))
       );
+
+      // Set up event delegation and link interception immediately so the
+      // new content has working listeners BEFORE the async connect() runs.
+      // connect() will re-run these internally, but we can't wait for it.
+      this.eventDelegator.setupEventDelegation();
+      this.linkInterceptor.setup(this.wrapperElement);
 
       // Scroll to top for cross-handler navigation
       window.scrollTo(0, 0);
@@ -645,15 +666,26 @@ export class LiveTemplateClient {
       // LinkInterceptor.navigate before this method is called).
       this.options.liveUrl =
         window.location.pathname + window.location.search;
+
       // Reconnect to the new handler. The server sends an initial tree
-      // that produces the same DOM as the fetched HTML.
-      this.connect(`[data-lvt-id="${newId}"]`).catch(() => {
-        window.location.href = window.location.href;
+      // that produces the same DOM as the fetched HTML. If another
+      // navigation supersedes this one, the epoch check discards the
+      // stale result.
+      this.connect(`[data-lvt-id="${newId}"]`).catch((err) => {
+        if (myEpoch !== this.navigationEpoch) {
+          // Superseded by a newer navigation — ignore this failure
+          return;
+        }
+        this.logger.error("Cross-handler reconnect failed:", err);
+        window.location.reload();
       });
       return;
     }
 
-    // Non-LiveTemplate page — use body content fallback
+    // Non-LiveTemplate page — disconnect the old WebSocket (it's pointing
+    // to a handler whose DOM is about to be replaced) and use body
+    // content fallback.
+    this.disconnect();
     const body = doc.querySelector("body");
     if (body) {
       this.wrapperElement.replaceChildren(

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -153,8 +153,8 @@ export class LiveTemplateClient {
         getRateLimitedHandlers: () => this.rateLimitedHandlers,
         parseValue: (value: string) => this.parseValue(value),
         send: (message: any) => this.send(message),
-        sendHTTPMultipart: (form: HTMLFormElement, action: string) =>
-          this.sendHTTPMultipart(form, action),
+        sendHTTPMultipart: (form: HTMLFormElement, action: string, formData?: FormData) =>
+          this.sendHTTPMultipart(form, action, formData),
         setActiveSubmission: (
           form: HTMLFormElement | null,
           button: HTMLButtonElement | null,
@@ -537,15 +537,23 @@ export class LiveTemplateClient {
    * Send form with file inputs via HTTP POST multipart/form-data.
    * Used for Tier 1 file uploads where binary files are submitted via
    * HTTP fetch instead of WebSocket (avoids base64 encoding overhead).
+   *
+   * The optional formData parameter allows callers to pass pre-captured
+   * form data (e.g., captured BEFORE setActiveSubmission disabled the
+   * fieldset, which would otherwise exclude all fields from FormData).
    */
-  sendHTTPMultipart(form: HTMLFormElement, action: string): void {
-    this.doSendHTTPMultipart(form, action);
+  sendHTTPMultipart(form: HTMLFormElement, action: string, formData?: FormData): void {
+    this.doSendHTTPMultipart(form, action, formData);
   }
 
-  private async doSendHTTPMultipart(form: HTMLFormElement, action: string): Promise<void> {
+  private async doSendHTTPMultipart(
+    form: HTMLFormElement,
+    action: string,
+    prebuiltFormData?: FormData
+  ): Promise<void> {
     try {
       const liveUrl = this.options.liveUrl || "/live";
-      const formData = new FormData(form);
+      const formData = prebuiltFormData || new FormData(form);
       formData.set("lvt-action", action);
 
       const response = await fetch(liveUrl, {
@@ -580,30 +588,107 @@ export class LiveTemplateClient {
    * Extracts the wrapper content from the full HTML page and replaces
    * the current wrapper content. Content comes from same-origin fetch
    * responses only (link interceptor skips external origins).
+   *
+   * Supports both same-handler navigation (same data-lvt-id) and
+   * cross-handler navigation (different data-lvt-id). Cross-handler
+   * navigation disconnects the old WebSocket, replaces the wrapper
+   * content and ID, and reconnects to the new handler. The URL must
+   * already be updated via pushState before this method is called
+   * (done in LinkInterceptor.navigate) so the WebSocket connects to
+   * the correct handler.
    */
   private handleNavigationResponse(html: string): void {
     if (!this.wrapperElement) return;
 
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, "text/html");
-    const lvtId = this.wrapperElement.getAttribute("data-lvt-id");
-    const newWrapper = lvtId
-      ? doc.querySelector(`[data-lvt-id="${lvtId}"]`)
-      : null;
+    const oldId = this.wrapperElement.getAttribute("data-lvt-id");
 
-    if (newWrapper) {
-      // Replace wrapper content with same-origin server response
-      // Safe: content is from our own server via same-origin fetch
-      this.wrapperElement.replaceChildren(...Array.from(newWrapper.childNodes).map(n => n.cloneNode(true)));
-    } else {
-      const body = doc.querySelector("body");
-      if (body) {
-        this.wrapperElement.replaceChildren(...Array.from(body.childNodes).map(n => n.cloneNode(true)));
-      }
+    // Update document title from the fetched page
+    const newTitle = doc.querySelector("title");
+    if (newTitle) {
+      document.title = newTitle.textContent || "";
     }
 
+    // Try same-handler wrapper first (same data-lvt-id)
+    const sameWrapper = oldId
+      ? doc.querySelector(`[data-lvt-id="${oldId}"]`)
+      : null;
+
+    if (sameWrapper) {
+      this.wrapperElement.replaceChildren(
+        ...Array.from(sameWrapper.childNodes).map((n) => n.cloneNode(true))
+      );
+      this.eventDelegator.setupEventDelegation();
+      this.linkInterceptor.setup(this.wrapperElement);
+      return;
+    }
+
+    // Check for a different handler's wrapper (cross-handler navigation)
+    const newWrapper = doc.querySelector("[data-lvt-id]");
+    if (newWrapper) {
+      const newId = newWrapper.getAttribute("data-lvt-id");
+
+      // Clean up stale event listeners keyed to the old wrapper ID
+      this.cleanupListenersForWrapper(oldId);
+
+      this.disconnect();
+      this.wrapperElement.setAttribute("data-lvt-id", newId!);
+      this.wrapperElement.replaceChildren(
+        ...Array.from(newWrapper.childNodes).map((n) => n.cloneNode(true))
+      );
+
+      // Scroll to top for cross-handler navigation
+      window.scrollTo(0, 0);
+
+      // Update liveUrl to the current page (pushState already ran in
+      // LinkInterceptor.navigate before this method is called).
+      this.options.liveUrl =
+        window.location.pathname + window.location.search;
+      // Reconnect to the new handler. The server sends an initial tree
+      // that produces the same DOM as the fetched HTML.
+      this.connect(`[data-lvt-id="${newId}"]`).catch(() => {
+        window.location.href = window.location.href;
+      });
+      return;
+    }
+
+    // Non-LiveTemplate page — use body content fallback
+    const body = doc.querySelector("body");
+    if (body) {
+      this.wrapperElement.replaceChildren(
+        ...Array.from(body.childNodes).map((n) => n.cloneNode(true))
+      );
+    }
     this.eventDelegator.setupEventDelegation();
     this.linkInterceptor.setup(this.wrapperElement);
+  }
+
+  /**
+   * Remove stale event listeners keyed to a specific wrapper ID.
+   * Called before cross-handler navigation changes the wrapper ID,
+   * to prevent orphaned listeners from accumulating.
+   */
+  private cleanupListenersForWrapper(wrapperId: string | null): void {
+    if (!wrapperId) return;
+
+    // Clean up link interceptor listener
+    const linkKey = `__lvt_link_intercept_${wrapperId}`;
+    const linkListener = (document as any)[linkKey];
+    if (linkListener) {
+      document.removeEventListener("click", linkListener);
+      delete (document as any)[linkKey];
+    }
+
+    // Clean up delegated event listeners
+    for (const eventType of ["click", "submit", "change", "input"]) {
+      const delegatedKey = `__lvt_delegated_${eventType}_${wrapperId}`;
+      const delegatedListener = (document as any)[delegatedKey];
+      if (delegatedListener) {
+        document.removeEventListener(eventType, delegatedListener, false);
+        delete (document as any)[delegatedKey];
+      }
+    }
   }
 
   /**

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -669,24 +669,30 @@ export class LiveTemplateClient {
       // the client's internal working copy — we never expose it or reuse
       // the caller's reference beyond the constructor) so the subsequent
       // connect() call picks up the new path without needing to thread
-      // the URL through connect()'s signature.
+      // the URL through connect()'s signature. Hash fragments are
+      // intentionally excluded — the WebSocket path comes from
+      // pathname+search only.
       this.options.liveUrl =
         window.location.pathname + window.location.search;
 
       // Reconnect to the new handler. The server sends an initial tree
-      // that produces the same DOM as the fetched HTML. If another
-      // navigation supersedes this one, the epoch check discards the
-      // stale result — both in the success (.then) and failure (.catch)
-      // branches. A stale success means another navigation started while
-      // this one was still connecting, so we must disconnect what we
-      // just connected.
+      // that produces the same DOM as the fetched HTML.
+      //
+      // Epoch semantics: if a newer navigation supersedes this one, any
+      // work it already did (disconnect, setup, new connect) is still
+      // valid for the newer navigation — we must NOT tear it down.
+      //   - Success branch: do nothing if superseded. The newer
+      //     navigation called disconnect() synchronously when it
+      //     started, so this connect's transport was already replaced
+      //     before it could resolve. Calling this.disconnect() here
+      //     would kill the newer navigation's connection.
+      //   - Failure branch: only reload if still current. A failure
+      //     from a superseded attempt is irrelevant.
       const checkEpoch = (): boolean => myEpoch === this.navigationEpoch;
       this.connect(`[data-lvt-id="${newId}"]`).then(
         () => {
-          if (!checkEpoch()) {
-            // Superseded — tear down the stale connection we just opened
-            this.disconnect();
-          }
+          // No-op if superseded: the newer navigation owns the transport.
+          if (!checkEpoch()) return;
         },
         (err) => {
           if (!checkEpoch()) return;

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -84,6 +84,13 @@ export class LiveTemplateClient {
   // applying stale connection results.
   private navigationEpoch: number = 0;
 
+  // Override for the live URL used by HTTP send and multipart methods.
+  // Updated on cross-handler navigation so HTTP requests go to the new
+  // handler path. When null, falls back to options.liveUrl. We avoid
+  // mutating the options object so callers holding a reference don't
+  // observe side-effects.
+  private liveUrlOverride: string | null = null;
+
   constructor(options: LiveTemplateClientOptions = {}) {
     const { logger: providedLogger, logLevel, debug, ...restOptions } = options;
     const resolvedLevel = logLevel ?? (debug ? "debug" : "info");
@@ -506,11 +513,20 @@ export class LiveTemplateClient {
   }
 
   /**
+   * Get the current live URL for HTTP methods. Falls back to
+   * options.liveUrl when no override is set. Cross-handler navigation
+   * uses setLiveUrl() to update the override without mutating options.
+   */
+  private getLiveUrl(): string {
+    return this.liveUrlOverride || this.options.liveUrl || "/live";
+  }
+
+  /**
    * Send action via HTTP POST
    */
   private async sendHTTP(message: any): Promise<void> {
     try {
-      const liveUrl = this.options.liveUrl || "/live";
+      const liveUrl = this.getLiveUrl();
       const response = await fetch(liveUrl, {
         method: "POST",
         credentials: "include", // Include cookies for session
@@ -558,7 +574,7 @@ export class LiveTemplateClient {
     prebuiltFormData?: FormData
   ): Promise<void> {
     try {
-      const liveUrl = this.options.liveUrl || "/live";
+      const liveUrl = this.getLiveUrl();
       const formData = prebuiltFormData || new FormData(form);
       formData.set("lvt-action", action);
 
@@ -668,14 +684,11 @@ export class LiveTemplateClient {
       // Scroll to top for cross-handler navigation
       window.scrollTo(0, 0);
 
-      // Update the live URL used by the WebSocket manager to derive the
-      // reconnect path. We mutate options.liveUrl (the options object is
-      // the client's internal working copy — we never expose it or reuse
-      // the caller's reference beyond the constructor) so the subsequent
-      // connect() call picks up the new path without needing to thread
-      // the URL through connect()'s signature. Hash fragments are
-      // intentionally excluded — the WebSocket path comes from
-      // pathname+search only.
+      // Update the live URL used by HTTP methods AND the WebSocket
+      // manager to derive the reconnect path. We use private overrides
+      // on both so the caller-provided options object is never mutated.
+      // Hash fragments are intentionally excluded — the WebSocket path
+      // comes from pathname+search only.
       //
       // liveUrl convention: it is always the CURRENT PAGE PATH, not a
       // separate endpoint. Each LiveTemplate handler route is both the
@@ -683,8 +696,10 @@ export class LiveTemplateClient {
       // page path and the WebSocket path are always the same. Apps that
       // need a different WebSocket endpoint should set `wsUrl`, which
       // takes precedence over `liveUrl` in WebSocketManager.
-      this.options.liveUrl =
+      const newLiveUrl =
         window.location.pathname + window.location.search;
+      this.liveUrlOverride = newLiveUrl;
+      this.webSocketManager.setLiveUrl(newLiveUrl);
 
       // Reconnect to the new handler. The server sends an initial tree
       // that produces the same DOM as the fetched HTML.

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -657,7 +657,11 @@ export class LiveTemplateClient {
 
       // Set up event delegation and link interception immediately so the
       // new content has working listeners BEFORE the async connect() runs.
-      // connect() will re-run these internally, but we can't wait for it.
+      // connect() will re-run these internally, which is safe: both setup
+      // methods are idempotent — they remove any existing listener with
+      // the same key before adding the new one. Calling them twice in
+      // quick succession results in a single active listener per event
+      // type per wrapper ID.
       this.eventDelegator.setupEventDelegation();
       this.linkInterceptor.setup(this.wrapperElement);
 
@@ -672,6 +676,13 @@ export class LiveTemplateClient {
       // the URL through connect()'s signature. Hash fragments are
       // intentionally excluded — the WebSocket path comes from
       // pathname+search only.
+      //
+      // liveUrl convention: it is always the CURRENT PAGE PATH, not a
+      // separate endpoint. Each LiveTemplate handler route is both the
+      // HTTP page and the WebSocket endpoint for that handler, so the
+      // page path and the WebSocket path are always the same. Apps that
+      // need a different WebSocket endpoint should set `wsUrl`, which
+      // takes precedence over `liveUrl` in WebSocketManager.
       this.options.liveUrl =
         window.location.pathname + window.location.search;
 
@@ -704,8 +715,11 @@ export class LiveTemplateClient {
     }
 
     // Non-LiveTemplate page — disconnect the old WebSocket (it's pointing
-    // to a handler whose DOM is about to be replaced) and use body
+    // to a handler whose DOM is about to be replaced) and tear down the
+    // old listeners keyed to the previous wrapper ID, then use body
     // content fallback.
+    this.linkInterceptor.teardownForWrapper(oldId);
+    this.eventDelegator.teardownForWrapper(oldId);
     this.disconnect();
     const body = doc.querySelector("body");
     if (body) {

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -276,6 +276,9 @@ describe("handleNavigationResponse", () => {
       const disconnectSpy = jest
         .spyOn(client, "disconnect")
         .mockImplementation(() => {});
+      const connectSpy = jest
+        .spyOn(client, "connect")
+        .mockResolvedValue(undefined);
 
       const html = [
         "<html><head><title>Handler B Title</title></head><body>",
@@ -290,6 +293,7 @@ describe("handleNavigationResponse", () => {
       expect(document.title).toBe("Handler B Title");
 
       disconnectSpy.mockRestore();
+      connectSpy.mockRestore();
     });
 
     it("does not change title when response has no title element", () => {
@@ -343,6 +347,38 @@ describe("handleNavigationResponse", () => {
       expect(disconnectSpy).toHaveBeenCalledTimes(1);
 
       disconnectSpy.mockRestore();
+    });
+
+    it("tears down stale listeners on non-LiveTemplate fallback", () => {
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+      // Spy on teardownForWrapper to verify it's called with the old ID
+      const linkTeardownSpy = jest.spyOn(
+        (client as any).linkInterceptor,
+        "teardownForWrapper"
+      );
+      const eventTeardownSpy = jest.spyOn(
+        (client as any).eventDelegator,
+        "teardownForWrapper"
+      );
+
+      const html = [
+        "<html><body>",
+        "<div><p>Plain HTML page</p></div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      // Both teardown methods must be called with the old wrapper ID
+      // before the fallback path re-registers listeners.
+      expect(linkTeardownSpy).toHaveBeenCalledWith("lvt-handler-a");
+      expect(eventTeardownSpy).toHaveBeenCalledWith("lvt-handler-a");
+
+      disconnectSpy.mockRestore();
+      linkTeardownSpy.mockRestore();
+      eventTeardownSpy.mockRestore();
     });
   });
 

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -62,6 +62,9 @@ describe("handleNavigationResponse", () => {
       const disconnectSpy = jest
         .spyOn(client, "disconnect")
         .mockImplementation(() => {});
+      const connectSpy = jest
+        .spyOn(client, "connect")
+        .mockResolvedValue(undefined);
 
       const html = [
         "<html><body>",
@@ -77,12 +80,16 @@ describe("handleNavigationResponse", () => {
       expect(wrapper.textContent).toContain("Handler B content");
 
       disconnectSpy.mockRestore();
+      connectSpy.mockRestore();
     });
 
     it("disconnects old handler", () => {
       const disconnectSpy = jest
         .spyOn(client, "disconnect")
         .mockImplementation(() => {});
+      const connectSpy = jest
+        .spyOn(client, "connect")
+        .mockResolvedValue(undefined);
 
       const html = [
         "<html><body>",
@@ -97,6 +104,7 @@ describe("handleNavigationResponse", () => {
       expect(disconnectSpy).toHaveBeenCalledTimes(1);
 
       disconnectSpy.mockRestore();
+      connectSpy.mockRestore();
     });
 
     it("reconnects to the new handler", () => {
@@ -153,6 +161,9 @@ describe("handleNavigationResponse", () => {
       const disconnectSpy = jest
         .spyOn(client, "disconnect")
         .mockImplementation(() => {});
+      const connectSpy = jest
+        .spyOn(client, "connect")
+        .mockResolvedValue(undefined);
 
       // Simulate an existing listener keyed to old wrapper ID
       const oldListener = jest.fn();
@@ -175,12 +186,55 @@ describe("handleNavigationResponse", () => {
       ).toBeUndefined();
 
       disconnectSpy.mockRestore();
+      connectSpy.mockRestore();
+    });
+
+    it("sets up event delegation and link interception immediately (before async connect)", () => {
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+      // Make connect() return a promise that never resolves to prove the
+      // synchronous setup happens regardless of whether connect completes
+      const connectSpy = jest
+        .spyOn(client, "connect")
+        .mockReturnValue(new Promise(() => {}));
+      // Spy on the real internal setup methods
+      const eventSetupSpy = jest.spyOn(
+        (client as any).eventDelegator,
+        "setupEventDelegation"
+      );
+      const linkSetupSpy = jest.spyOn(
+        (client as any).linkInterceptor,
+        "setup"
+      );
+
+      const html = [
+        "<html><body>",
+        '<div data-lvt-id="lvt-handler-b">',
+        "<p>Handler B</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      // Both setup methods must have been called synchronously
+      expect(eventSetupSpy).toHaveBeenCalled();
+      expect(linkSetupSpy).toHaveBeenCalled();
+
+      disconnectSpy.mockRestore();
+      connectSpy.mockRestore();
+      eventSetupSpy.mockRestore();
+      linkSetupSpy.mockRestore();
     });
 
     it("scrolls to top on cross-handler navigation", () => {
       const disconnectSpy = jest
         .spyOn(client, "disconnect")
         .mockImplementation(() => {});
+      const connectSpy = jest
+        .spyOn(client, "connect")
+        .mockResolvedValue(undefined);
       const scrollSpy = jest
         .spyOn(window, "scrollTo")
         .mockImplementation(() => {});
@@ -198,6 +252,7 @@ describe("handleNavigationResponse", () => {
       expect(scrollSpy).toHaveBeenCalledWith(0, 0);
 
       disconnectSpy.mockRestore();
+      connectSpy.mockRestore();
       scrollSpy.mockRestore();
     });
   });
@@ -254,6 +309,10 @@ describe("handleNavigationResponse", () => {
 
   describe("non-LiveTemplate response", () => {
     it("uses body content when response has no data-lvt-id wrapper", () => {
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+
       const html = [
         "<html><body>",
         "<div><p>Plain HTML page</p></div>",
@@ -264,6 +323,26 @@ describe("handleNavigationResponse", () => {
 
       expect(wrapper.textContent).toContain("Plain HTML page");
       expect(wrapper.getAttribute("data-lvt-id")).toBe("lvt-handler-a");
+
+      disconnectSpy.mockRestore();
+    });
+
+    it("disconnects old WebSocket on non-LiveTemplate fallback", () => {
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+
+      const html = [
+        "<html><body>",
+        "<div><p>Plain HTML page</p></div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      expect(disconnectSpy).toHaveBeenCalledTimes(1);
+
+      disconnectSpy.mockRestore();
     });
   });
 

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -1,0 +1,283 @@
+import { LiveTemplateClient } from "../livetemplate-client";
+
+describe("handleNavigationResponse", () => {
+  let client: LiveTemplateClient;
+  let wrapper: HTMLDivElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = ""; // safe: test cleanup, matches existing pattern
+    document.title = "Initial Title";
+
+    wrapper = document.createElement("div");
+    wrapper.setAttribute("data-lvt-id", "lvt-handler-a");
+    wrapper.appendChild(document.createTextNode("Handler A content"));
+    document.body.appendChild(wrapper);
+
+    client = new LiveTemplateClient();
+    (client as any).wrapperElement = wrapper;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = ""; // safe: test cleanup
+  });
+
+  const callHandleNavigationResponse = (html: string) => {
+    (client as any).handleNavigationResponse(html);
+  };
+
+  describe("same-handler navigation", () => {
+    it("replaces wrapper children when response has same data-lvt-id", () => {
+      const html = [
+        "<html><head><title>Same Page</title></head><body>",
+        '<div data-lvt-id="lvt-handler-a">',
+        "<p>Updated content from same handler</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      expect(wrapper.textContent).toContain("Updated content from same handler");
+      expect(wrapper.getAttribute("data-lvt-id")).toBe("lvt-handler-a");
+    });
+
+    it("preserves wrapper element identity", () => {
+      const originalWrapper = wrapper;
+      const html = [
+        "<html><body>",
+        '<div data-lvt-id="lvt-handler-a">',
+        "<p>New content</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      expect((client as any).wrapperElement).toBe(originalWrapper);
+    });
+  });
+
+  describe("cross-handler navigation", () => {
+    it("updates wrapper ID when response has different data-lvt-id", () => {
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+
+      const html = [
+        "<html><body>",
+        '<div data-lvt-id="lvt-handler-b">',
+        "<p>Handler B content</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      expect(wrapper.getAttribute("data-lvt-id")).toBe("lvt-handler-b");
+      expect(wrapper.textContent).toContain("Handler B content");
+
+      disconnectSpy.mockRestore();
+    });
+
+    it("disconnects old handler", () => {
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+
+      const html = [
+        "<html><body>",
+        '<div data-lvt-id="lvt-handler-b">',
+        "<p>Handler B</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      expect(disconnectSpy).toHaveBeenCalledTimes(1);
+
+      disconnectSpy.mockRestore();
+    });
+
+    it("reconnects to the new handler", () => {
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+      const connectSpy = jest
+        .spyOn(client, "connect")
+        .mockResolvedValue(undefined);
+
+      const html = [
+        "<html><body>",
+        '<div data-lvt-id="lvt-handler-b">',
+        "<p>Handler B</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      expect(connectSpy).toHaveBeenCalledWith(
+        '[data-lvt-id="lvt-handler-b"]'
+      );
+
+      disconnectSpy.mockRestore();
+      connectSpy.mockRestore();
+    });
+
+    it("falls back to page reload if reconnect fails", () => {
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+      const connectSpy = jest
+        .spyOn(client, "connect")
+        .mockRejectedValue(new Error("connection failed"));
+
+      const html = [
+        "<html><body>",
+        '<div data-lvt-id="lvt-handler-b">',
+        "<p>Handler B</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      expect(() => callHandleNavigationResponse(html)).not.toThrow();
+      expect(disconnectSpy).toHaveBeenCalled();
+      expect(connectSpy).toHaveBeenCalled();
+
+      disconnectSpy.mockRestore();
+      connectSpy.mockRestore();
+    });
+
+    it("cleans up stale event listeners from old wrapper ID", () => {
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+
+      // Simulate an existing listener keyed to old wrapper ID
+      const oldListener = jest.fn();
+      (document as any)["__lvt_link_intercept_lvt-handler-a"] = oldListener;
+      document.addEventListener("click", oldListener);
+
+      const html = [
+        "<html><body>",
+        '<div data-lvt-id="lvt-handler-b">',
+        "<p>Handler B</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      // Old listener key should be removed
+      expect(
+        (document as any)["__lvt_link_intercept_lvt-handler-a"]
+      ).toBeUndefined();
+
+      disconnectSpy.mockRestore();
+    });
+
+    it("scrolls to top on cross-handler navigation", () => {
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+      const scrollSpy = jest
+        .spyOn(window, "scrollTo")
+        .mockImplementation(() => {});
+
+      const html = [
+        "<html><body>",
+        '<div data-lvt-id="lvt-handler-b">',
+        "<p>Handler B</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      expect(scrollSpy).toHaveBeenCalledWith(0, 0);
+
+      disconnectSpy.mockRestore();
+      scrollSpy.mockRestore();
+    });
+  });
+
+  describe("title updates", () => {
+    it("updates document.title from response", () => {
+      const html = [
+        "<html><head><title>New Page Title</title></head><body>",
+        '<div data-lvt-id="lvt-handler-a">',
+        "<p>Content</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      expect(document.title).toBe("New Page Title");
+    });
+
+    it("updates title on cross-handler navigation", () => {
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+
+      const html = [
+        "<html><head><title>Handler B Title</title></head><body>",
+        '<div data-lvt-id="lvt-handler-b">',
+        "<p>Handler B</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      expect(document.title).toBe("Handler B Title");
+
+      disconnectSpy.mockRestore();
+    });
+
+    it("does not change title when response has no title element", () => {
+      const html = [
+        "<html><body>",
+        '<div data-lvt-id="lvt-handler-a">',
+        "<p>No title page</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      expect(document.title).toBe("Initial Title");
+    });
+  });
+
+  describe("non-LiveTemplate response", () => {
+    it("uses body content when response has no data-lvt-id wrapper", () => {
+      const html = [
+        "<html><body>",
+        "<div><p>Plain HTML page</p></div>",
+        "</body></html>",
+      ].join("");
+
+      callHandleNavigationResponse(html);
+
+      expect(wrapper.textContent).toContain("Plain HTML page");
+      expect(wrapper.getAttribute("data-lvt-id")).toBe("lvt-handler-a");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty response body gracefully", () => {
+      const html = "<html><body></body></html>";
+      expect(() => callHandleNavigationResponse(html)).not.toThrow();
+    });
+
+    it("does nothing when wrapperElement is null", () => {
+      (client as any).wrapperElement = null;
+      expect(() =>
+        callHandleNavigationResponse("<html><body></body></html>")
+      ).not.toThrow();
+    });
+  });
+});

--- a/transport/websocket.ts
+++ b/transport/websocket.ts
@@ -130,8 +130,21 @@ export interface WebSocketConnectResult {
 
 export class WebSocketManager {
   private transport: WebSocketTransport | null = null;
+  // Optional override for liveUrl, set by the client on cross-handler
+  // navigation. When set, takes precedence over options.liveUrl. This
+  // avoids mutating the caller-provided options object.
+  private liveUrlOverride: string | null = null;
 
   constructor(private readonly config: WebSocketManagerConfig) {}
+
+  /**
+   * Update the live URL used for WebSocket reconnection. Called by the
+   * client on cross-handler navigation so the next connect() uses the
+   * new page path without mutating the shared options object.
+   */
+  setLiveUrl(liveUrl: string): void {
+    this.liveUrlOverride = liveUrl;
+  }
 
   async connect(): Promise<WebSocketConnectResult> {
     const liveUrl = this.getLiveUrl();
@@ -198,7 +211,7 @@ export class WebSocketManager {
   }
 
   private getWebSocketUrl(): string {
-    const liveUrl = this.config.options.liveUrl || "/live";
+    const liveUrl = this.liveUrlOverride || this.config.options.liveUrl || "/live";
     const baseUrl = this.config.options.wsUrl;
     if (baseUrl) {
       return baseUrl;
@@ -208,7 +221,11 @@ export class WebSocketManager {
   }
 
   private getLiveUrl(): string {
-    return this.config.options.liveUrl || window.location.pathname + window.location.search;
+    return (
+      this.liveUrlOverride ||
+      this.config.options.liveUrl ||
+      window.location.pathname + window.location.search
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes multiple issues with SPA navigation and Tier 1 file uploads, discovered while building the `patterns` example app.

## 1. Cross-handler SPA navigation

When navigating between different LiveTemplate handlers (different `data-lvt-id`), the client now:

1. Detects the wrapper ID mismatch
2. Cleans up stale event listeners keyed to the old wrapper ID
3. Disconnects the old WebSocket
4. Replaces the wrapper content and ID
5. Updates `document.title` from the fetched page
6. Scrolls to top
7. Updates `liveUrl` to the current page path
8. Reconnects WebSocket to the new handler

**Root cause:** `handleNavigationResponse()` searched for a wrapper with the **old** `data-lvt-id` in the fetched HTML. Since each handler generates a unique random wrapper ID, the search always failed for cross-handler navigation, causing broken DOM updates. Additionally, `liveUrl` was cached at construction time and never updated, so reconnect would go to the wrong handler path.

## 2. Navigation edge cases

Research of Phoenix LiveView, Turbo Drive, htmx, and Livewire revealed several unhandled edge cases:

- **Rapid clicks race condition:** Added `AbortController` so rapid link clicks or back/forward during a pending fetch cancels the in-flight request.
- **Title tag not updated:** Extract `<title>` from fetched HTML and apply to `document.title`.
- **Stale click listeners:** Clean up old click listener keyed to old wrapper ID before cross-handler navigation.
- **No scroll to top:** `window.scrollTo(0, 0)` on cross-handler navigation.
- **pushState ordering:** Moved before `handleNavigationResponse` so the WebSocket reconnects to the correct URL.

## 3. Tier 1 file upload bug

`sendHTTPMultipart()` was creating `FormData` from the form **after** `setActiveSubmission()` had disabled the surrounding `<fieldset>`. Since disabled fieldsets exclude all child fields from `FormData`, the multipart body only contained `lvt-action` — all text inputs, files, etc. were missing.

**Fix:** Capture the `FormData` **before** `setActiveSubmission` disables the fieldset, then pass it to `sendHTTPMultipart`.

## Test plan

- [x] 14 new tests in `tests/navigation.test.ts` covering same-handler, cross-handler, title update, listener cleanup, scroll, edge cases
- [x] All 329 client tests pass (20 test suites)
- [x] E2E tests in `examples/patterns`: `TestCrossHandlerNavigation` (7 subtests), `TestFileUpload/Tier1_Upload_With_File`, `TestPreserveInputs/Submit_With_File_Attached`
- [x] Full patterns example E2E suite passes (9 test functions, 40+ subtests)
- [ ] Manual browser verification with patterns example

## Deferred follow-ups

Filed separate issues for:
- #59 — Cancel form submissions during navigation
- #60 — Loading indicator during nav fetch
- #61 — Scroll position restore on back/forward
- #62 — bfcache handling
- #63 — Asset version detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
