### PR TITLE
fix: cross-handler SPA nav, infinite scroll race, animation cleanup

### DIFF
--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -4,6 +4,11 @@ import { isDOMEventTrigger, SYNTHETIC_TRIGGERS } from "./reactive-attributes";
 
 const FX_LIFECYCLE_SET = new Set(["pending", "success", "error", "done"]);
 
+// Tracks elements whose entry animation has already played. Kept as a
+// module-level WeakSet (rather than stashed on the DOM node) so it's
+// type-safe and automatically cleaned up when elements are GC'd.
+const animatedElements = new WeakSet<Element>();
+
 /**
  * Parse a lvt-fx:{effect}[:on:[{action}:]{trigger}] attribute name.
  * Returns the trigger type or null for implicit (no :on:).
@@ -161,10 +166,10 @@ function applyFxEffect(htmlElement: HTMLElement, effect: string, config: string)
       // "Entry animation" semantics: play once per element lifetime. Every
       // tree update re-walks lvt-fx:* attributes, so without this guard an
       // unchanged row re-fires the animation on every patch. Morphdom
-      // creates fresh DOM nodes for new rows (flag starts undefined and
-      // the animation fires once); reused nodes retain the flag and skip.
-      if ((htmlElement as any).__lvtAnimated) break;
-      (htmlElement as any).__lvtAnimated = true;
+      // creates fresh DOM nodes for new rows (not in the WeakSet → animate);
+      // reused nodes are already in the set and skip.
+      if (animatedElements.has(htmlElement)) break;
+      animatedElements.add(htmlElement);
 
       const duration = parseInt(
         computed.getPropertyValue("--lvt-animate-duration").trim() || "500", 10
@@ -188,9 +193,13 @@ function applyFxEffect(htmlElement: HTMLElement, effect: string, config: string)
       if (!animationValue) break;
       htmlElement.style.animation = animationValue;
       htmlElement.addEventListener("animationend", () => {
-        htmlElement.style.animation = "";
-        htmlElement.style.removeProperty("--lvt-animate-duration");
-        if (htmlElement.getAttribute("style") === "") {
+        // Only remove the animation we set. Do NOT remove
+        // --lvt-animate-duration: users may have set it inline themselves
+        // (e.g. style="--lvt-animate-duration: 800") to override duration,
+        // and removing would wipe their intent. Clean up the style
+        // attribute entirely only if nothing is left on it.
+        htmlElement.style.removeProperty("animation");
+        if (htmlElement.style.length === 0) {
           htmlElement.removeAttribute("style");
         }
       }, { once: true });

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -158,27 +158,41 @@ function applyFxEffect(htmlElement: HTMLElement, effect: string, config: string)
       break;
     }
     case "animate": {
+      // "Entry animation" semantics: play once per element lifetime. Every
+      // tree update re-walks lvt-fx:* attributes, so without this guard an
+      // unchanged row re-fires the animation on every patch. Morphdom
+      // creates fresh DOM nodes for new rows (flag starts undefined and
+      // the animation fires once); reused nodes retain the flag and skip.
+      if ((htmlElement as any).__lvtAnimated) break;
+      (htmlElement as any).__lvtAnimated = true;
+
       const duration = parseInt(
-        computed.getPropertyValue("--lvt-animate-duration").trim() || "300", 10
+        computed.getPropertyValue("--lvt-animate-duration").trim() || "500", 10
       );
       const animation = config || "fade";
-      htmlElement.style.setProperty("--lvt-animate-duration", `${duration}ms`);
 
+      let animationValue = "";
       switch (animation) {
         case "fade":
-          htmlElement.style.animation = `lvt-fade-in var(--lvt-animate-duration) ease-out`;
+          animationValue = `lvt-fade-in ${duration}ms ease-out`;
           break;
         case "slide":
-          htmlElement.style.animation = `lvt-slide-in var(--lvt-animate-duration) ease-out`;
+          animationValue = `lvt-slide-in ${duration}ms ease-out`;
           break;
         case "scale":
-          htmlElement.style.animation = `lvt-scale-in var(--lvt-animate-duration) ease-out`;
+          animationValue = `lvt-scale-in ${duration}ms ease-out`;
           break;
         default:
           console.warn(`Unknown lvt-fx:animate mode: ${animation}`);
       }
+      if (!animationValue) break;
+      htmlElement.style.animation = animationValue;
       htmlElement.addEventListener("animationend", () => {
         htmlElement.style.animation = "";
+        htmlElement.style.removeProperty("--lvt-animate-duration");
+        if (htmlElement.getAttribute("style") === "") {
+          htmlElement.removeAttribute("style");
+        }
       }, { once: true });
       break;
     }

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -7,6 +7,14 @@ const FX_LIFECYCLE_SET = new Set(["pending", "success", "error", "done"]);
 // Tracks elements whose entry animation has already played. Kept as a
 // module-level WeakSet (rather than stashed on the DOM node) so it's
 // type-safe and automatically cleaned up when elements are GC'd.
+//
+// Semantic: once per element lifetime. An element added to this set will
+// NEVER animate again, even if the same node is updated in place. This is
+// intentional — lvt-fx:animate is an entry animation, not a per-update
+// flash. Morphdom creates fresh DOM nodes for newly-inserted range items
+// (which are not in the set, so they animate) while reusing nodes for
+// in-place updates (already in the set, so they skip). Use cases that
+// want a visible pulse on every update should reach for lvt-fx:highlight.
 const animatedElements = new WeakSet<Element>();
 
 /**

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -21,7 +21,13 @@ let animatedElements = new WeakSet<Element>();
  * Test-only: reset the module-level animatedElements WeakSet. Required
  * for tests that reuse the same DOM nodes across cases — without this,
  * an element animated in case 1 would be silently skipped in case 2.
- * Production code should never need to call this.
+ * Production code should never call this.
+ *
+ * The double-underscore prefix and the `@internal` tag signal that
+ * this is not part of the public API. TypeScript's API Extractor and
+ * similar tools exclude `@internal` exports from generated d.ts files.
+ *
+ * @internal
  */
 export function __resetAnimatedElementsForTesting(): void {
   animatedElements = new WeakSet<Element>();

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -15,7 +15,17 @@ const FX_LIFECYCLE_SET = new Set(["pending", "success", "error", "done"]);
 // (which are not in the set, so they animate) while reusing nodes for
 // in-place updates (already in the set, so they skip). Use cases that
 // want a visible pulse on every update should reach for lvt-fx:highlight.
-const animatedElements = new WeakSet<Element>();
+let animatedElements = new WeakSet<Element>();
+
+/**
+ * Test-only: reset the module-level animatedElements WeakSet. Required
+ * for tests that reuse the same DOM nodes across cases — without this,
+ * an element animated in case 1 would be silently skipped in case 2.
+ * Production code should never need to call this.
+ */
+export function __resetAnimatedElementsForTesting(): void {
+  animatedElements = new WeakSet<Element>();
+}
 
 /**
  * Parse a lvt-fx:{effect}[:on:[{action}:]{trigger}] attribute name.

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -23,9 +23,12 @@ let animatedElements = new WeakSet<Element>();
  * an element animated in case 1 would be silently skipped in case 2.
  * Production code should never call this.
  *
- * The double-underscore prefix and the `@internal` tag signal that
- * this is not part of the public API. TypeScript's API Extractor and
- * similar tools exclude `@internal` exports from generated d.ts files.
+ * The double-underscore prefix and the `@internal` tag signal that this
+ * is not part of the public API. The `@internal` tag is only enforced
+ * when TypeScript's API Extractor (or equivalent) is configured to
+ * strip it from generated `.d.ts` files — this project does not
+ * currently run API Extractor, so the tag is aspirational enforcement
+ * backed by the `__` naming convention and this docstring.
  *
  * @internal
  */

--- a/dom/observer-manager.ts
+++ b/dom/observer-manager.ts
@@ -51,12 +51,19 @@ export class ObserverManager {
 
     const sentinel = document.getElementById("scroll-sentinel");
     if (!sentinel) {
-      // Sentinel removed (HasMore flipped false): release the old observer.
+      // Sentinel removed (HasMore flipped false): release the old observer
+      // AND clear any in-flight load_more throttle. Without releaseLoadMore
+      // here, a HasMore flip-flop (server removes sentinel, then restores
+      // it moments later without dispatching an lvt:updated action=load_more
+      // in between) would leave loadMorePending=true with a 30s safety
+      // timer armed — silently dropping the next intersection until the
+      // timer fires.
       if (this.infiniteScrollObserver) {
         this.infiniteScrollObserver.disconnect();
         this.infiniteScrollObserver = null;
         this.observedSentinel = null;
       }
+      this.releaseLoadMore();
       return;
     }
 

--- a/dom/observer-manager.ts
+++ b/dom/observer-manager.ts
@@ -11,6 +11,12 @@ export interface ObserverContext {
 export class ObserverManager {
   private infiniteScrollObserver: IntersectionObserver | null = null;
   private mutationObserver: MutationObserver | null = null;
+  private observedSentinel: Element | null = null;
+
+  // Throttles infinite-scroll dispatches: one in-flight load_more at a time.
+  // Without this, rapid observer re-fires stack concurrent actions and the
+  // server's per-response diffs compose into duplicate rows on the client.
+  private loadMorePending = false;
 
   constructor(
     private readonly context: ObserverContext,
@@ -23,6 +29,18 @@ export class ObserverManager {
 
     const sentinel = document.getElementById("scroll-sentinel");
     if (!sentinel) {
+      // Sentinel removed (HasMore flipped false): release the old observer.
+      if (this.infiniteScrollObserver) {
+        this.infiniteScrollObserver.disconnect();
+        this.infiniteScrollObserver = null;
+        this.observedSentinel = null;
+      }
+      return;
+    }
+
+    // Reuse the existing observer when the sentinel node is the same —
+    // avoids allocating a fresh IntersectionObserver per DOM mutation.
+    if (this.infiniteScrollObserver && this.observedSentinel === sentinel) {
       return;
     }
 
@@ -32,10 +50,14 @@ export class ObserverManager {
 
     this.infiniteScrollObserver = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting) {
-          this.logger.debug("Sentinel visible, sending load_more action");
-          this.context.send({ action: "load_more" });
+        if (!entries[0].isIntersecting) return;
+        if (this.loadMorePending) {
+          this.logger.debug("Sentinel visible but load_more already pending, skipping");
+          return;
         }
+        this.loadMorePending = true;
+        this.logger.debug("Sentinel visible, sending load_more action");
+        this.context.send({ action: "load_more" });
       },
       {
         rootMargin: "200px",
@@ -43,6 +65,7 @@ export class ObserverManager {
     );
 
     this.infiniteScrollObserver.observe(sentinel);
+    this.observedSentinel = sentinel;
     this.logger.debug("Observer set up successfully");
   }
 
@@ -55,6 +78,7 @@ export class ObserverManager {
     }
 
     this.mutationObserver = new MutationObserver(() => {
+      this.loadMorePending = false;
       this.setupInfiniteScrollObserver();
     });
 
@@ -75,5 +99,7 @@ export class ObserverManager {
       this.mutationObserver.disconnect();
       this.mutationObserver = null;
     }
+    this.observedSentinel = null;
+    this.loadMorePending = false;
   }
 }

--- a/dom/observer-manager.ts
+++ b/dom/observer-manager.ts
@@ -25,6 +25,14 @@ export class ObserverManager {
   // toggling, a highlight flashing) between the dispatch and the response
   // would otherwise clear the flag early and allow a concurrent send.
   private loadMorePending = false;
+  // Safety net: if the server never responds with an lvt:updated event
+  // for load_more (network error, server-side exception, server just
+  // dropped the message), the flag above would stay true forever and
+  // infinite scroll would be silently deadlocked until page reload.
+  // This timeout releases the throttle after 30s so the next sentinel
+  // intersection can re-trigger the load.
+  private loadMoreTimeoutId: number | null = null;
+  private static readonly LOAD_MORE_TIMEOUT_MS = 30000;
 
   constructor(
     private readonly context: ObserverContext,
@@ -70,6 +78,7 @@ export class ObserverManager {
           return;
         }
         this.loadMorePending = true;
+        this.armLoadMoreTimeout();
         this.logger.debug("Sentinel visible, sending load_more action");
         this.context.send({ action: "load_more" });
       },
@@ -93,7 +102,7 @@ export class ObserverManager {
     this.updatedListener = (e: Event) => {
       const detail = (e as CustomEvent).detail;
       if (detail?.action !== "load_more") return;
-      this.loadMorePending = false;
+      this.releaseLoadMore();
       // Force a fresh IntersectionObserver so its immediate callback fires
       // with the post-mutation intersection state — lets the auto-advance
       // cascade continue if the sentinel is still visible after the new
@@ -103,6 +112,33 @@ export class ObserverManager {
     };
     wrapper.addEventListener("lvt:updated", this.updatedListener);
     this.updatedListenerWrapper = wrapper;
+  }
+
+  private armLoadMoreTimeout(): void {
+    this.clearLoadMoreTimeout();
+    this.loadMoreTimeoutId = window.setTimeout(() => {
+      this.logger.warn(
+        `load_more response not received within ${ObserverManager.LOAD_MORE_TIMEOUT_MS}ms; releasing throttle`
+      );
+      this.loadMoreTimeoutId = null;
+      this.loadMorePending = false;
+      // Force the next intersection to re-trigger by rebuilding the
+      // observer, since the sentinel may still be visible.
+      this.observedSentinel = null;
+      this.setupInfiniteScrollObserver();
+    }, ObserverManager.LOAD_MORE_TIMEOUT_MS);
+  }
+
+  private releaseLoadMore(): void {
+    this.loadMorePending = false;
+    this.clearLoadMoreTimeout();
+  }
+
+  private clearLoadMoreTimeout(): void {
+    if (this.loadMoreTimeoutId !== null) {
+      clearTimeout(this.loadMoreTimeoutId);
+      this.loadMoreTimeoutId = null;
+    }
   }
 
   setupInfiniteScrollMutationObserver(): void {
@@ -144,6 +180,6 @@ export class ObserverManager {
     this.updatedListener = null;
     this.updatedListenerWrapper = null;
     this.observedSentinel = null;
-    this.loadMorePending = false;
+    this.releaseLoadMore();
   }
 }

--- a/dom/observer-manager.ts
+++ b/dom/observer-manager.ts
@@ -12,10 +12,18 @@ export class ObserverManager {
   private infiniteScrollObserver: IntersectionObserver | null = null;
   private mutationObserver: MutationObserver | null = null;
   private observedSentinel: Element | null = null;
+  private updatedListener: ((e: Event) => void) | null = null;
+  private updatedListenerWrapper: Element | null = null;
 
   // Throttles infinite-scroll dispatches: one in-flight load_more at a time.
   // Without this, rapid observer re-fires stack concurrent actions and the
   // server's per-response diffs compose into duplicate rows on the client.
+  //
+  // Cleared precisely when the server confirms the load_more response has
+  // been applied (via the `lvt:updated` event with `action === "load_more"`),
+  // NOT on every DOM mutation — an unrelated mutation (e.g. a flash message
+  // toggling, a highlight flashing) between the dispatch and the response
+  // would otherwise clear the flag early and allow a concurrent send.
   private loadMorePending = false;
 
   constructor(
@@ -26,6 +34,12 @@ export class ObserverManager {
   setupInfiniteScrollObserver(): void {
     const wrapperElement = this.context.getWrapperElement();
     if (!wrapperElement) return;
+
+    // Attach the lvt:updated listener once per wrapper. The event fires
+    // after every tree update carrying the dispatched action's name in
+    // its detail; we use action === "load_more" as the precise signal
+    // that the throttle can be lifted.
+    this.ensureUpdatedListener(wrapperElement);
 
     const sentinel = document.getElementById("scroll-sentinel");
     if (!sentinel) {
@@ -69,6 +83,28 @@ export class ObserverManager {
     this.logger.debug("Observer set up successfully");
   }
 
+  private ensureUpdatedListener(wrapper: Element): void {
+    if (this.updatedListener && this.updatedListenerWrapper === wrapper) return;
+    // Detach any listener from the previous wrapper (e.g. after cross-
+    // handler navigation swaps the wrapper element).
+    if (this.updatedListener && this.updatedListenerWrapper) {
+      this.updatedListenerWrapper.removeEventListener("lvt:updated", this.updatedListener);
+    }
+    this.updatedListener = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.action !== "load_more") return;
+      this.loadMorePending = false;
+      // Force a fresh IntersectionObserver so its immediate callback fires
+      // with the post-mutation intersection state — lets the auto-advance
+      // cascade continue if the sentinel is still visible after the new
+      // rows are appended.
+      this.observedSentinel = null;
+      this.setupInfiniteScrollObserver();
+    };
+    wrapper.addEventListener("lvt:updated", this.updatedListener);
+    this.updatedListenerWrapper = wrapper;
+  }
+
   setupInfiniteScrollMutationObserver(): void {
     const wrapperElement = this.context.getWrapperElement();
     if (!wrapperElement) return;
@@ -77,8 +113,11 @@ export class ObserverManager {
       this.mutationObserver.disconnect();
     }
 
+    // The mutation observer catches structural changes that replace the
+    // sentinel DOM node (e.g. morphdom recreating it on a page-level
+    // restructure). setupInfiniteScrollObserver's identity check makes
+    // the common case — same sentinel, new mutation — a cheap no-op.
     this.mutationObserver = new MutationObserver(() => {
-      this.loadMorePending = false;
       this.setupInfiniteScrollObserver();
     });
 
@@ -99,6 +138,11 @@ export class ObserverManager {
       this.mutationObserver.disconnect();
       this.mutationObserver = null;
     }
+    if (this.updatedListener && this.updatedListenerWrapper) {
+      this.updatedListenerWrapper.removeEventListener("lvt:updated", this.updatedListener);
+    }
+    this.updatedListener = null;
+    this.updatedListenerWrapper = null;
     this.observedSentinel = null;
     this.loadMorePending = false;
   }

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -427,16 +427,28 @@ export class LiveTemplateClient {
     this.webSocketManager.disconnect();
     this.ws = null;
     this.useHTTP = false;
-    this.observerManager.teardown();
-    this.changeAutoWirer.teardown();
-    this.formLifecycleManager.reset();
-    this.loadingIndicator.hide();
-    this.formDisabler.enable(this.wrapperElement);
     this.eventDelegator.teardownDOMEventTriggerDelegation();
     if (this.wrapperElement) {
       teardownFxDOMEventTriggers(this.wrapperElement);
       teardownFxLifecycleListeners(this.wrapperElement);
     }
+    this.resetSessionState();
+  }
+
+  // resetSessionState clears all per-session manager state. Called by both
+  // disconnect() (with additional transport/event teardown) and reset().
+  // Essential for cross-handler SPA navigation: without treeRenderer.reset(),
+  // accumulated tree state from the old handler merges into the new one.
+  private resetSessionState(): void {
+    this.treeRenderer.reset();
+    this.focusManager.reset();
+    this.observerManager.teardown();
+    this.changeAutoWirer.teardown();
+    this.formLifecycleManager.reset();
+    this.loadingIndicator.hide();
+    this.formDisabler.enable(this.wrapperElement);
+    this.lvtId = null;
+    this.isInitialized = false;
   }
 
   /**
@@ -1030,14 +1042,7 @@ export class LiveTemplateClient {
    * Reset client state (useful for testing)
    */
   reset(): void {
-    this.treeRenderer.reset();
-    this.focusManager.reset();
-    this.observerManager.teardown();
-    this.changeAutoWirer.teardown();
-    this.formLifecycleManager.reset();
-    this.loadingIndicator.hide();
-    this.formDisabler.enable(this.wrapperElement);
-    this.lvtId = null;
+    this.resetSessionState();
   }
 
   /**

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1048,7 +1048,21 @@ export class LiveTemplateClient {
   }
 
   /**
-   * Reset client state (useful for testing)
+   * Reset client state (useful for testing).
+   *
+   * Puts the client back into its pre-initialization state: tree state,
+   * focus state, observers, change auto-wirer, form lifecycle, loading
+   * indicator, form disabler, lvtId, AND isInitialized are all cleared.
+   *
+   * Behavioral note: `isInitialized` is set to false here. Prior to the
+   * introduction of `resetSessionState()`, `reset()` left this flag sticky,
+   * which was an inconsistency — a "reset" that didn't actually put the
+   * client in a pre-init state. After calling reset(), the next payload
+   * is treated as an initial render: the loading indicator will briefly
+   * appear, forms are re-enabled, and `data-lvt-loading` is cleared. If
+   * callers of reset() expected the prior sticky behavior, they should
+   * not rely on init-only side effects firing exactly once per client
+   * lifetime.
    */
   reset(): void {
     this.resetSessionState();

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -439,6 +439,15 @@ export class LiveTemplateClient {
   // disconnect() (with additional transport/event teardown) and reset().
   // Essential for cross-handler SPA navigation: without treeRenderer.reset(),
   // accumulated tree state from the old handler merges into the new one.
+  //
+  // Note on isInitialized: setting this to false is intentional and is
+  // a behavioral change from the prior reset() which left it sticky.
+  // The prior behavior was an inconsistency — "reset" that didn't
+  // actually put the client in a pre-init state. After reset, the next
+  // payload is treated as an initial render: loading indicator shows,
+  // forms are enabled, data-lvt-loading is removed. This matches the
+  // post-disconnect contract and the documented "useful for testing"
+  // intent — tests can observe the init transition a second time.
   private resetSessionState(): void {
     this.treeRenderer.reset();
     this.focusManager.reset();

--- a/livetemplate.css
+++ b/livetemplate.css
@@ -4,10 +4,15 @@
  * These custom properties configure lvt-fx:* directives.
  * Override them in your own stylesheets to customize behavior.
  *
+ * Duration values should include the "ms" unit so the variable remains
+ * a valid CSS time value and can be used directly in animation/transition
+ * properties. The directives parse these with parseInt which strips the
+ * unit, so both forms work, but "500ms" is the recommended form.
+ *
  * Usage:
- *   [lvt-fx\:scroll] { --lvt-scroll-behavior: smooth; }
- *   [lvt-fx\:highlight] { --lvt-highlight-color: yellow; --lvt-highlight-duration: 1000; }
- *   [lvt-fx\:animate] { --lvt-animate-duration: 500; }
+ *   [lvt-fx\:scroll]    { --lvt-scroll-behavior: smooth; }
+ *   [lvt-fx\:highlight] { --lvt-highlight-color: yellow; --lvt-highlight-duration: 1000ms; }
+ *   [lvt-fx\:animate]   { --lvt-animate-duration: 500ms; }
  */
 
 :root {
@@ -16,11 +21,14 @@
   --lvt-scroll-threshold: 100;
 
   /* Highlight directive defaults */
-  --lvt-highlight-duration: 500;
+  --lvt-highlight-duration: 500ms;
   --lvt-highlight-color: #ffc107;
 
-  /* Animate directive defaults */
-  --lvt-animate-duration: 500;
+  /* Animate directive defaults — includes unit so the var can be used
+     directly in CSS animation/transition properties. The TS directive
+     reads it with parseInt() which strips the unit, so the shorthand
+     construction still works. */
+  --lvt-animate-duration: 500ms;
 }
 
 /* Flash messages from {{.lvt.FlashTag "key"}} render as <output data-flash>.

--- a/livetemplate.css
+++ b/livetemplate.css
@@ -20,7 +20,16 @@
   --lvt-highlight-color: #ffc107;
 
   /* Animate directive defaults */
-  --lvt-animate-duration: 300;
+  --lvt-animate-duration: 500;
+}
+
+/* Flash messages from {{.lvt.FlashTag "key"}} render as <output data-flash>.
+   Pico defaults <output> to inline with no spacing; give it breathing room
+   from preceding form controls. */
+output[data-flash] {
+  display: block;
+  margin-top: 1rem;
+  padding: 0.5rem 0;
 }
 
 /* === Layout === */

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -236,7 +236,12 @@ describe("handleAnimateDirectives", () => {
 
     handleAnimateDirectives(document.body);
 
-    expect(target.style.getPropertyValue("--lvt-animate-duration")).toBe("1000ms");
+    // The directive inlines the duration directly into the animation
+    // shorthand rather than writing back a sanitized custom property.
+    // This prevents a phantom --lvt-animate-duration inline property
+    // from lingering after animationend cleanup.
+    expect(target.style.animation).toContain("1000ms");
+    expect(target.style.animation).toContain("lvt-fade-in");
   });
 
   it("clears animation on animationend", () => {
@@ -250,6 +255,27 @@ describe("handleAnimateDirectives", () => {
     target.dispatchEvent(new Event("animationend"));
 
     expect(target.style.animation).toBe("");
+  });
+
+  it("removes style attribute entirely on animationend when no other styles remain", () => {
+    // Build the element via DOM APIs (innerHTML would trigger our project's
+    // XSS reminder hook in tests). Attribute setup is equivalent.
+    document.body.replaceChildren();
+    const target = document.createElement("div");
+    target.id = "target";
+    target.setAttribute("lvt-fx:animate", "fade");
+    document.body.appendChild(target);
+
+    handleAnimateDirectives(document.body);
+    // Before animationend: style="animation: lvt-fade-in ...;"
+    expect(target.hasAttribute("style")).toBe(true);
+
+    target.dispatchEvent(new Event("animationend"));
+
+    // After animationend: style attribute fully removed so downstream
+    // inline-style checks see a clean element. This is the fix that lets
+    // patterns-app UI standards validation succeed on animated rows.
+    expect(target.hasAttribute("style")).toBe(false);
   });
 
   it("injects CSS keyframes only once", () => {

--- a/tests/observer-manager.test.ts
+++ b/tests/observer-manager.test.ts
@@ -116,7 +116,7 @@ describe("ObserverManager", () => {
       );
     });
 
-    it("disconnects previous observer before setting up new one", () => {
+    it("reuses the existing observer when the sentinel is unchanged", () => {
       document.body.innerHTML = `
         <div id="wrapper">
           <div id="scroll-sentinel"></div>
@@ -131,7 +131,41 @@ describe("ObserverManager", () => {
       manager.setupInfiniteScrollObserver();
       manager.setupInfiniteScrollObserver();
 
-      // Should have logged setup twice (once per call)
+      // Same sentinel node → only one setup; subsequent calls are no-ops.
+      const setupCalls = mockConsole.debug.mock.calls.filter(
+        (call) => call[1] === "Observer set up successfully"
+      );
+      expect(setupCalls.length).toBe(1);
+    });
+
+    it("rebuilds the observer when the sentinel node identity changes", () => {
+      // Build fresh wrapper + sentinel via DOM APIs to avoid the XSS-reminder
+      // hook in tests that scans innerHTML assignments.
+      document.body.replaceChildren();
+      const wrapper = document.createElement("div");
+      wrapper.id = "wrapper";
+      const sentinel1 = document.createElement("div");
+      sentinel1.id = "scroll-sentinel";
+      wrapper.appendChild(sentinel1);
+      document.body.appendChild(wrapper);
+
+      mockContext = {
+        getWrapperElement: () => document.getElementById("wrapper"),
+        send: mockSend,
+      };
+      manager = new ObserverManager(mockContext, mockLogger);
+
+      manager.setupInfiniteScrollObserver();
+
+      // Replace sentinel with a fresh node (simulates morphdom recreating
+      // the element on a structural transition).
+      sentinel1.remove();
+      const sentinel2 = document.createElement("div");
+      sentinel2.id = "scroll-sentinel";
+      wrapper.appendChild(sentinel2);
+
+      manager.setupInfiniteScrollObserver();
+
       const setupCalls = mockConsole.debug.mock.calls.filter(
         (call) => call[1] === "Observer set up successfully"
       );

--- a/tests/observer-manager.test.ts
+++ b/tests/observer-manager.test.ts
@@ -200,6 +200,51 @@ describe("ObserverManager", () => {
       expect(mockSend).toHaveBeenCalledTimes(2);
     });
 
+    it("clears the load_more throttle when the sentinel disappears", () => {
+      // Regression test for HasMore flip-flop scenario:
+      //   1. Sentinel visible → load_more sent, throttle armed.
+      //   2. Server flips HasMore to false → sentinel removed from DOM.
+      //   3. Server flips HasMore back to true → sentinel reappears.
+      //   4. Next intersection must re-trigger load_more (not be silently
+      //      dropped waiting on the 30s safety timer).
+      document.body.replaceChildren();
+      const wrapper = document.createElement("div");
+      wrapper.id = "wrapper";
+      const sentinel1 = document.createElement("div");
+      sentinel1.id = "scroll-sentinel";
+      wrapper.appendChild(sentinel1);
+      document.body.appendChild(wrapper);
+
+      mockContext = {
+        getWrapperElement: () => document.getElementById("wrapper"),
+        send: mockSend,
+      };
+      manager = new ObserverManager(mockContext, mockLogger);
+      manager.setupInfiniteScrollObserver();
+
+      // Step 1: arm the throttle by triggering intersection.
+      MockIntersectionObserver.instances[0].triggerIntersection(true);
+      expect(mockSend).toHaveBeenCalledTimes(1);
+
+      // Step 2: sentinel removed (HasMore flipped false).
+      sentinel1.remove();
+      manager.setupInfiniteScrollObserver();
+      // No observer should be active at this point.
+      expect(MockIntersectionObserver.instances[0].disconnected).toBe(true);
+
+      // Step 3: sentinel reappears.
+      const sentinel2 = document.createElement("div");
+      sentinel2.id = "scroll-sentinel";
+      wrapper.appendChild(sentinel2);
+      manager.setupInfiniteScrollObserver();
+
+      // Step 4: next intersection must fire — throttle must be clear.
+      const latest =
+        MockIntersectionObserver.instances[MockIntersectionObserver.instances.length - 1];
+      latest.triggerIntersection(true);
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
     it("clears the load_more safety timeout when lvt:updated fires", () => {
       document.body.replaceChildren();
       const wrapper = document.createElement("div");

--- a/tests/observer-manager.test.ts
+++ b/tests/observer-manager.test.ts
@@ -60,6 +60,7 @@ describe("ObserverManager", () => {
   let mockConsole: { debug: jest.Mock; info: jest.Mock; warn: jest.Mock; error: jest.Mock };
 
   beforeEach(() => {
+    jest.useFakeTimers();
     document.body.innerHTML = "";
     MockIntersectionObserver.reset();
     mockSend = jest.fn();
@@ -76,9 +77,13 @@ describe("ObserverManager", () => {
   });
 
   afterEach(() => {
+    // Teardown BEFORE swapping back to real timers so any pending fake
+    // setTimeout IDs inside ObserverManager are cleared against the fake
+    // timer backend they were scheduled on.
     if (manager) {
       manager.teardown();
     }
+    jest.useRealTimers();
   });
 
   describe("setupInfiniteScrollObserver", () => {
@@ -148,6 +153,85 @@ describe("ObserverManager", () => {
         (call) => call[1] === "Observer set up successfully"
       );
       expect(setupCalls.length).toBe(1);
+    });
+
+    it("releases the load_more throttle if the server never responds", () => {
+      // Build fresh wrapper + sentinel via DOM APIs to avoid the XSS-reminder
+      // hook in tests that scans innerHTML assignments.
+      document.body.replaceChildren();
+      const wrapper = document.createElement("div");
+      wrapper.id = "wrapper";
+      const sentinel = document.createElement("div");
+      sentinel.id = "scroll-sentinel";
+      wrapper.appendChild(sentinel);
+      document.body.appendChild(wrapper);
+
+      mockContext = {
+        getWrapperElement: () => document.getElementById("wrapper"),
+        send: mockSend,
+      };
+      manager = new ObserverManager(mockContext, mockLogger);
+      manager.setupInfiniteScrollObserver();
+
+      // First intersection → send load_more, arm the 30s safety timeout.
+      MockIntersectionObserver.instances[0].triggerIntersection(true);
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(mockSend).toHaveBeenCalledWith({ action: "load_more" });
+
+      // While "pending" is true, subsequent intersections must be ignored.
+      MockIntersectionObserver.instances[0].triggerIntersection(true);
+      expect(mockSend).toHaveBeenCalledTimes(1);
+
+      // Server never responds. Advance past the 30s safety net.
+      jest.advanceTimersByTime(30001);
+
+      // A warning must be logged and a fresh observer allocated so the
+      // next intersection can re-fire. MockIntersectionObserver.instances
+      // should now have a second entry.
+      expect(mockConsole.warn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringMatching(/load_more response not received/)
+      );
+      expect(MockIntersectionObserver.instances.length).toBeGreaterThanOrEqual(2);
+
+      // The next intersection re-arms the throttle and sends again.
+      const latest = MockIntersectionObserver.instances[MockIntersectionObserver.instances.length - 1];
+      latest.triggerIntersection(true);
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it("clears the load_more safety timeout when lvt:updated fires", () => {
+      document.body.replaceChildren();
+      const wrapper = document.createElement("div");
+      wrapper.id = "wrapper";
+      const sentinel = document.createElement("div");
+      sentinel.id = "scroll-sentinel";
+      wrapper.appendChild(sentinel);
+      document.body.appendChild(wrapper);
+
+      mockContext = {
+        getWrapperElement: () => document.getElementById("wrapper"),
+        send: mockSend,
+      };
+      manager = new ObserverManager(mockContext, mockLogger);
+      manager.setupInfiniteScrollObserver();
+
+      MockIntersectionObserver.instances[0].triggerIntersection(true);
+      expect(mockSend).toHaveBeenCalledTimes(1);
+
+      // Simulate the server's lvt:updated event for load_more.
+      wrapper.dispatchEvent(
+        new CustomEvent("lvt:updated", { detail: { action: "load_more" } })
+      );
+
+      // Advance well past the 30s safety window — no warning should fire
+      // because the timeout was cleared on the legitimate response.
+      jest.advanceTimersByTime(60000);
+
+      expect(mockConsole.warn).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringMatching(/load_more response not received/)
+      );
     });
 
     it("rebuilds the observer when the sentinel node identity changes", () => {

--- a/tests/observer-manager.test.ts
+++ b/tests/observer-manager.test.ts
@@ -1,8 +1,17 @@
 import { ObserverManager, ObserverContext } from "../dom/observer-manager";
 import { createLogger } from "../utils/logger";
 
-// Mock IntersectionObserver
+// Mock IntersectionObserver. Tracks instances and disconnect calls so tests
+// can assert not just that a fresh observer was built, but that the old one
+// was torn down — guards against silent leaks where a stale observer keeps
+// firing callbacks against a detached sentinel.
 class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+  static reset(): void {
+    MockIntersectionObserver.instances.length = 0;
+  }
+
+  disconnected = false;
   callback: IntersectionObserverCallback;
   options?: IntersectionObserverInit;
   elements: Element[] = [];
@@ -10,6 +19,7 @@ class MockIntersectionObserver {
   constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
     this.callback = callback;
     this.options = options;
+    MockIntersectionObserver.instances.push(this);
   }
 
   observe(element: Element) {
@@ -21,6 +31,7 @@ class MockIntersectionObserver {
   }
 
   disconnect() {
+    this.disconnected = true;
     this.elements = [];
   }
 
@@ -50,6 +61,7 @@ describe("ObserverManager", () => {
 
   beforeEach(() => {
     document.body.innerHTML = "";
+    MockIntersectionObserver.reset();
     mockSend = jest.fn();
     mockConsole = {
       debug: jest.fn(),
@@ -170,6 +182,13 @@ describe("ObserverManager", () => {
         (call) => call[1] === "Observer set up successfully"
       );
       expect(setupCalls.length).toBe(2);
+
+      // The old observer MUST be disconnected before the new one is created —
+      // otherwise it keeps firing callbacks against the detached sentinel and
+      // leaks memory until GC collects a chain that the observer itself holds.
+      expect(MockIntersectionObserver.instances.length).toBe(2);
+      expect(MockIntersectionObserver.instances[0].disconnected).toBe(true);
+      expect(MockIntersectionObserver.instances[1].disconnected).toBe(false);
     });
   });
 
@@ -240,8 +259,13 @@ describe("ObserverManager", () => {
       manager.setupInfiniteScrollObserver();
       manager.setupInfiniteScrollMutationObserver();
 
-      // Should not throw
       expect(() => manager.teardown()).not.toThrow();
+
+      // IntersectionObserver instance created by setupInfiniteScrollObserver
+      // must be disconnected — verifies teardown actually cleans up, not just
+      // that it doesn't throw.
+      expect(MockIntersectionObserver.instances.length).toBe(1);
+      expect(MockIntersectionObserver.instances[0].disconnected).toBe(true);
     });
 
     it("is safe to call when no observers are set up", () => {

--- a/tests/websocket.test.ts
+++ b/tests/websocket.test.ts
@@ -1,5 +1,6 @@
 import {
   WebSocketTransport,
+  WebSocketManager,
   checkWebSocketAvailability,
   fetchInitialState,
 } from "../transport/websocket";
@@ -437,6 +438,148 @@ describe("checkWebSocketAvailability", () => {
 
     expect(result).toBe(true);
     expect(mockConsole.warn).toHaveBeenCalled();
+  });
+});
+
+describe("WebSocketManager connect", () => {
+  let mockSocket: MockWebSocket | null = null;
+  let mockFetch: jest.Mock;
+  let mockLogger: ReturnType<typeof createLogger>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockSocket = null;
+    (global as any).WebSocket = jest.fn().mockImplementation((url: string) => {
+      mockSocket = new MockWebSocket(url);
+      return mockSocket;
+    });
+    // checkWebSocketAvailability HEAD request succeeds with WS enabled.
+    mockFetch = jest.fn().mockResolvedValue({
+      headers: {
+        get: (name: string) =>
+          name === "X-LiveTemplate-WebSocket" ? "enabled" : null,
+      },
+    });
+    (global as any).fetch = mockFetch;
+    mockLogger = createLogger({
+      level: "warn",
+      sink: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as unknown as Console,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  const makeManager = (handlers: {
+    onConnected?: jest.Mock;
+    onDisconnected?: jest.Mock;
+    onMessage?: jest.Mock;
+    onError?: jest.Mock;
+  }) =>
+    new WebSocketManager({
+      options: { liveUrl: "/live", wsUrl: "ws://localhost:8080" } as any,
+      onConnected: handlers.onConnected || jest.fn(),
+      onDisconnected: handlers.onDisconnected || jest.fn(),
+      onMessage: handlers.onMessage || jest.fn(),
+      onError: handlers.onError,
+      logger: mockLogger,
+    });
+
+  it("calls onConnected and NOT onDisconnected on successful open", async () => {
+    const onConnected = jest.fn();
+    const onDisconnected = jest.fn();
+    const manager = makeManager({ onConnected, onDisconnected });
+
+    const connectPromise = manager.connect();
+    // Flush the HEAD-check microtask so checkWebSocketAvailability resolves
+    // and WebSocketTransport.connect() runs.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    mockSocket!.simulateOpen();
+    const result = await connectPromise;
+
+    expect(result.usingWebSocket).toBe(true);
+    expect(onConnected).toHaveBeenCalledTimes(1);
+    expect(onDisconnected).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call onDisconnected when socket closes before opening (HTTP fallback)", async () => {
+    const onConnected = jest.fn();
+    const onDisconnected = jest.fn();
+    // Initial HTTP state fetch (after fallback) returns null.
+    const mockInitial = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ tree: null }),
+    });
+    // Chain: first call is HEAD check (WS enabled), second is GET initial state.
+    mockFetch
+      .mockReset()
+      .mockResolvedValueOnce({
+        headers: {
+          get: (name: string) =>
+            name === "X-LiveTemplate-WebSocket" ? "enabled" : null,
+        },
+      })
+      .mockImplementationOnce(mockInitial);
+
+    const manager = makeManager({ onConnected, onDisconnected });
+
+    const connectPromise = manager.connect();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Socket closes BEFORE onOpen fires — spurious-disconnected scenario.
+    mockSocket!.simulateClose();
+    // Let the rejection propagate, the catch block run, and fetchInitialState resolve.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const result = await connectPromise;
+
+    expect(result.usingWebSocket).toBe(false);
+    expect(onConnected).not.toHaveBeenCalled();
+    // Critical: we never connected, so we must NOT signal "disconnected"
+    // to downstream — that would falsely flip UI state.
+    expect(onDisconnected).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call onDisconnected on the 10s open-timeout path", async () => {
+    const onConnected = jest.fn();
+    const onDisconnected = jest.fn();
+    mockFetch
+      .mockReset()
+      .mockResolvedValueOnce({
+        headers: {
+          get: (name: string) =>
+            name === "X-LiveTemplate-WebSocket" ? "enabled" : null,
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ tree: null }),
+      });
+
+    const manager = makeManager({ onConnected, onDisconnected });
+
+    const connectPromise = manager.connect();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // No onOpen/onClose/onError — simulate a silent middlebox drop.
+    jest.advanceTimersByTime(10001);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const result = await connectPromise;
+
+    expect(result.usingWebSocket).toBe(false);
+    expect(onConnected).not.toHaveBeenCalled();
+    // Even though the catch block calls transport.disconnect() (which triggers
+    // onClose), the hasConnected gate prevents a spurious onDisconnected.
+    expect(onDisconnected).not.toHaveBeenCalled();
   });
 });
 

--- a/transport/websocket.ts
+++ b/transport/websocket.ts
@@ -240,6 +240,15 @@ export class WebSocketManager {
       },
       onError: (event) => {
         this.config.onError?.(event);
+        // If we're already connected, onDisconnected is fired via the
+        // subsequent onClose — per WHATWG WebSocket spec, onclose always
+        // fires after onerror when the connection is lost post-open.
+        // We rely on that invariant here rather than double-firing
+        // onDisconnected (which would require tracking a separate
+        // "already disconnected" flag).
+        //
+        // If we're NOT yet connected, this rejects openPromise so the
+        // catch block falls back to HTTP. settleOpen is a no-op post-open.
         settleOpen(new Error("WebSocket errored before it opened"));
       },
     });

--- a/transport/websocket.ts
+++ b/transport/websocket.ts
@@ -179,14 +179,22 @@ export class WebSocketManager {
     // naturally via onClose/onError, or because the catch block
     // explicitly disconnects the transport after the 10s timeout).
     let hasConnected = false;
+    // Declared before settleOpen to avoid a temporal dead zone on the
+    // closure reference — settleOpen is called from onOpen/onClose/onError
+    // (all async, so safe today), but declaring the binding up front lets
+    // any future synchronous call path still work without a ReferenceError.
+    let openTimeoutId: ReturnType<typeof setTimeout> | null = null;
     const settleOpen = (err?: Error): void => {
       if (settled) return;
       settled = true;
-      clearTimeout(openTimeoutId);
+      if (openTimeoutId !== null) {
+        clearTimeout(openTimeoutId);
+        openTimeoutId = null;
+      }
       if (err) rejectOpen(err);
       else resolveOpen({ usingWebSocket: true });
     };
-    const openTimeoutId = setTimeout(() => {
+    openTimeoutId = setTimeout(() => {
       settleOpen(new Error("WebSocket open timed out after 10s"));
     }, 10000);
 

--- a/transport/websocket.ts
+++ b/transport/websocket.ts
@@ -218,13 +218,19 @@ export class WebSocketManager {
         }
       },
       onClose: () => {
-        // Only notify the client of disconnection if we'd actually
-        // connected. Close-before-open (failure path) must not masquerade
-        // as a disconnect, since no onConnected() ever fired.
+        // Branch on whether we'd actually connected:
+        //   - Success path (onOpen fired): notify client of disconnection
+        //     via onDisconnected(). Do NOT call settleOpen — it's already
+        //     resolved, and we'd needlessly construct an Error object
+        //     that shows up in any log/trace capturing rejection reasons.
+        //   - Failure path (close before open): reject the openPromise
+        //     with a descriptive Error. onDisconnected is NOT fired
+        //     because we were never "connected" from the client's POV.
         if (hasConnected) {
           this.config.onDisconnected();
+        } else {
+          settleOpen(new Error("WebSocket closed before it opened"));
         }
-        settleOpen(new Error("WebSocket closed before it opened"));
       },
       onReconnectAttempt: (attempt, delay) => {
         this.config.onReconnectAttempt?.(attempt, delay);

--- a/transport/websocket.ts
+++ b/transport/websocket.ts
@@ -162,13 +162,27 @@ export class WebSocketManager {
     // transport. Without this, observer callbacks during CONNECTING fall
     // back to HTTP, which hits a separate server state path than the WS
     // event loop — producing stale/desynced responses.
-    let resolveOpen: (value: WebSocketConnectResult) => void;
-    let rejectOpen: (reason?: unknown) => void;
+    //
+    // Three settle paths: onOpen (success), onClose/onError (immediate
+    // failure), and a 10s timeout (silent network drop — TCP may never
+    // surface a close/error event through a misbehaving middlebox).
+    let resolveOpen!: (value: WebSocketConnectResult) => void;
+    let rejectOpen!: (reason?: unknown) => void;
     const openPromise = new Promise<WebSocketConnectResult>((resolve, reject) => {
       resolveOpen = resolve;
       rejectOpen = reject;
     });
     let settled = false;
+    const settleOpen = (err?: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(openTimeoutId);
+      if (err) rejectOpen(err);
+      else resolveOpen({ usingWebSocket: true });
+    };
+    const openTimeoutId = setTimeout(() => {
+      settleOpen(new Error("WebSocket open timed out after 10s"));
+    }, 10000);
 
     this.transport = new WebSocketTransport({
       url: this.getWebSocketUrl(),
@@ -178,10 +192,7 @@ export class WebSocketManager {
       maxReconnectAttempts: 10, // 10 attempts before giving up
       onOpen: () => {
         this.config.onConnected();
-        if (!settled) {
-          settled = true;
-          resolveOpen({ usingWebSocket: true });
-        }
+        settleOpen();
       },
       onMessage: (event) => {
         try {
@@ -193,10 +204,7 @@ export class WebSocketManager {
       },
       onClose: () => {
         this.config.onDisconnected();
-        if (!settled) {
-          settled = true;
-          rejectOpen(new Error("WebSocket closed before it opened"));
-        }
+        settleOpen(new Error("WebSocket closed before it opened"));
       },
       onReconnectAttempt: (attempt, delay) => {
         this.config.onReconnectAttempt?.(attempt, delay);
@@ -206,10 +214,7 @@ export class WebSocketManager {
       },
       onError: (event) => {
         this.config.onError?.(event);
-        if (!settled) {
-          settled = true;
-          rejectOpen(new Error("WebSocket errored before it opened"));
-        }
+        settleOpen(new Error("WebSocket errored before it opened"));
       },
     });
 
@@ -219,6 +224,10 @@ export class WebSocketManager {
       return await openPromise;
     } catch (err) {
       this.config.logger.warn("WebSocket open failed, falling back to HTTP", err);
+      // Stop the transport so a late onOpen or auto-reconnect doesn't fire
+      // against a client that has already committed to HTTP mode.
+      this.transport?.disconnect();
+      this.transport = null;
       const initialState = await fetchInitialState(liveUrl, this.config.logger);
       return { usingWebSocket: false, initialState };
     }

--- a/transport/websocket.ts
+++ b/transport/websocket.ts
@@ -173,6 +173,12 @@ export class WebSocketManager {
       rejectOpen = reject;
     });
     let settled = false;
+    // Tracks whether onOpen ever fired. Gates onDisconnected so we don't
+    // fire a spurious "disconnected" notification on the HTTP fallback
+    // path where the socket closed before it ever opened (either
+    // naturally via onClose/onError, or because the catch block
+    // explicitly disconnects the transport after the 10s timeout).
+    let hasConnected = false;
     const settleOpen = (err?: Error): void => {
       if (settled) return;
       settled = true;
@@ -191,6 +197,7 @@ export class WebSocketManager {
       maxReconnectDelay: 16000, // 16 seconds maximum
       maxReconnectAttempts: 10, // 10 attempts before giving up
       onOpen: () => {
+        hasConnected = true;
         this.config.onConnected();
         settleOpen();
       },
@@ -203,7 +210,12 @@ export class WebSocketManager {
         }
       },
       onClose: () => {
-        this.config.onDisconnected();
+        // Only notify the client of disconnection if we'd actually
+        // connected. Close-before-open (failure path) must not masquerade
+        // as a disconnect, since no onConnected() ever fired.
+        if (hasConnected) {
+          this.config.onDisconnected();
+        }
         settleOpen(new Error("WebSocket closed before it opened"));
       },
       onReconnectAttempt: (attempt, delay) => {

--- a/transport/websocket.ts
+++ b/transport/websocket.ts
@@ -158,6 +158,18 @@ export class WebSocketManager {
       return { usingWebSocket: false, initialState };
     }
 
+    // Await onopen before resolving, so downstream setup runs with a ready
+    // transport. Without this, observer callbacks during CONNECTING fall
+    // back to HTTP, which hits a separate server state path than the WS
+    // event loop — producing stale/desynced responses.
+    let resolveOpen: (value: WebSocketConnectResult) => void;
+    let rejectOpen: (reason?: unknown) => void;
+    const openPromise = new Promise<WebSocketConnectResult>((resolve, reject) => {
+      resolveOpen = resolve;
+      rejectOpen = reject;
+    });
+    let settled = false;
+
     this.transport = new WebSocketTransport({
       url: this.getWebSocketUrl(),
       autoReconnect: this.config.options.autoReconnect,
@@ -166,6 +178,10 @@ export class WebSocketManager {
       maxReconnectAttempts: 10, // 10 attempts before giving up
       onOpen: () => {
         this.config.onConnected();
+        if (!settled) {
+          settled = true;
+          resolveOpen({ usingWebSocket: true });
+        }
       },
       onMessage: (event) => {
         try {
@@ -177,6 +193,10 @@ export class WebSocketManager {
       },
       onClose: () => {
         this.config.onDisconnected();
+        if (!settled) {
+          settled = true;
+          rejectOpen(new Error("WebSocket closed before it opened"));
+        }
       },
       onReconnectAttempt: (attempt, delay) => {
         this.config.onReconnectAttempt?.(attempt, delay);
@@ -186,11 +206,22 @@ export class WebSocketManager {
       },
       onError: (event) => {
         this.config.onError?.(event);
+        if (!settled) {
+          settled = true;
+          rejectOpen(new Error("WebSocket errored before it opened"));
+        }
       },
     });
 
     this.transport.connect();
-    return { usingWebSocket: true };
+
+    try {
+      return await openPromise;
+    } catch (err) {
+      this.config.logger.warn("WebSocket open failed, falling back to HTTP", err);
+      const initialState = await fetchInitialState(liveUrl, this.config.logger);
+      return { usingWebSocket: false, initialState };
+    }
   }
 
   disconnect(): void {


### PR DESCRIPTION
## Summary

Five related fixes discovered while building the LiveTemplate patterns example Session 2. Without these, the patterns app's Delete Row, Infinite Scroll, and cross-handler navigation demos exhibit visible bugs under normal user interaction.

## Fixes

### 1. Cross-handler SPA navigation desync (livetemplate-client.ts)

`TreeRenderer.treeState` was accumulated across handlers. Navigating from the index to a Session 2 pattern via SPA link click caused the new handler's initial tree update to merge with stale index treeState, producing a Frankenstein DOM that mixed both handlers' content.

- `disconnect()` now calls `treeRenderer.reset()` (runs before every cross-handler reconnect).
- Extracted `resetSessionState()` private helper to reconcile drift between `disconnect()` and `reset()` — they were missing different fields from each other's cleanup chain (`focusManager.reset()`, `lvtId = null`, `isInitialized = false`).

### 2. WebSocket transport: await onopen before connect() resolves (transport/websocket.ts)

`WebSocketManager.connect()` resolved its Promise synchronously after `new WebSocket(url)`, before the socket's `onopen` fired. Downstream setup ran with `readyState=0` (CONNECTING), and the first observer fire fell back to HTTP via `send()`'s fallback branch. The HTTP handler maintains a separate state store from the WS event loop (fresh clone per request for patterns without `lvt:"persist"` fields), so the HTTP response never updated the WS's `connSt.state` — producing stale pagination on the next WS action.

`connect()` now awaits `onopen` via a Promise, rejecting on premature close or error and falling through to HTTP mode on rejection.

### 3. Observer manager: load_more throttle + sentinel identity gate (dom/observer-manager.ts)

- **`loadMorePending` flag**: throttles infinite-scroll dispatches to one in-flight request at a time. Without this, rapid IntersectionObserver re-fires stack concurrent `load_more` actions; the server computes each response's diff from the same pre-mutation snapshot and the client applies diffs cumulatively → duplicate rows.
- **`observedSentinel` identity cache**: `setupInfiniteScrollObserver` is called from the MutationObserver callback on every DOM mutation. Previously allocated a fresh `IntersectionObserver` each time; now reuses the existing one when the sentinel node is unchanged.

### 4. Animate directive: once-per-lifetime + style cleanup (dom/directives.ts)

- Removed the inline `--lvt-animate-duration` write: the old code set it so `animation: ... var(--lvt-animate-duration)` could resolve, then left it behind after `animationend` — tripping downstream inline-style checks. Now interpolates the duration directly into the animation shorthand.
- `__lvtAnimated` per-element flag gives entry-animation semantics: play once per element lifetime. Every tree update re-walks `[lvt-fx:animate]` elements; without this guard an unchanged row re-arms the animation on every patch. Morphdom creates fresh nodes for new rows (flag starts undefined → animation fires); reused nodes retain the flag and skip.
- `animationend` now also removes the `style` attribute entirely when no other styles remain, so UI-standards inline-style checks see a clean element.

### 5. CSS: animate duration + flash padding (livetemplate.css)

- `--lvt-animate-duration` bumped from 300ms to 500ms. Matches the directives.ts fallback and gives entry animations enough time to be perceptible in post-SSR hydration.
- `output[data-flash]` gets `display: block; margin-top: 1rem; padding: 0.5rem 0;` — FlashTag messages previously abutted preceding form controls because Pico's default `<output>` is inline with no spacing.

## Tests

- 334 jest tests pass.
- Updated `tests/directives.test.ts`: revised the \"respects custom animation duration\" assertion to check `style.animation` content (not the removed custom property write); added \"removes style attribute entirely on animationend when no other styles remain\".
- Updated `tests/observer-manager.test.ts`: replaced \"disconnects previous observer before setting up new one\" with \"reuses the existing observer when the sentinel is unchanged\" (matching new semantics); added \"rebuilds the observer when the sentinel node identity changes\".

## Test plan

- [ ] CI jest suite green
- [ ] Visually verify in the patterns example app (companion examples PR): Delete Row slide-in visible on initial load; index → Delete Row via SPA click shows exactly 5 rows without stale category headers; Infinite Scroll auto-advances without duplicate rows; Bulk Update flash sits below the button with padding.
- [ ] Cut a new client release via `./scripts/release.sh` after merge so the examples CI picks up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)