### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,5 +62,11 @@ jobs:
               sleep "$delay"
             fi
           done
+          # NOTE: Reaching this line means `npm publish` above already
+          # succeeded — the package IS on npm, the registry just didn't
+          # report it back within ~100s of retries. Do NOT start a rollback
+          # from this failure alone; manually check `npm view` and the
+          # package page before taking any action.
           echo "Package @livetemplate/client@$PKG_VERSION was not visible on npm after 5 attempts."
+          echo "The publish step succeeded; this is almost certainly a registry propagation delay."
           exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,15 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # required for npm OIDC trusted publishing + provenance
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Pin to the release tag so the build matches what was tagged,
+          # not a later commit that may have landed on the branch.
+          ref: ${{ github.event.release.tag_name }}
 
       - uses: actions/setup-node@v4
         with:
@@ -24,13 +31,21 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Verify package.json version matches release tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: package.json=$PKG_VERSION tag=$TAG_VERSION"
+            exit 1
+          fi
+          echo "Version match: $PKG_VERSION"
+
+      - name: Publish to npm (OIDC trusted publisher, with provenance)
+        run: npm publish --provenance --access public
 
       - name: Verify published package
         run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          echo "Published version: $PACKAGE_VERSION"
-          npm view @livetemplate/client@$PACKAGE_VERSION
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "Published version: $PKG_VERSION"
+          npm view "@livetemplate/client@$PKG_VERSION"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,11 +62,11 @@ jobs:
               sleep "$delay"
             fi
           done
-          # NOTE: Reaching this line means `npm publish` above already
-          # succeeded — the package IS on npm, the registry just didn't
-          # report it back within ~100s of retries. Do NOT start a rollback
-          # from this failure alone; manually check `npm view` and the
-          # package page before taking any action.
-          echo "Package @livetemplate/client@$PKG_VERSION was not visible on npm after 5 attempts."
-          echo "The publish step succeeded; this is almost certainly a registry propagation delay."
-          exit 1
+          # Reaching this line means `npm publish` above already succeeded —
+          # the package IS on npm, the registry just didn't report it back
+          # within ~100s of retries. Surface this as a GitHub Actions warning
+          # (visible in the run summary) instead of a hard failure, so a
+          # successful release never shows as red CI and nobody mistakenly
+          # starts a rollback on a propagation lag. A genuine publish failure
+          # would have aborted the workflow at the `npm publish` step itself.
+          echo "::warning title=npm registry propagation lag::Package @livetemplate/client@$PKG_VERSION was not visible on npm after 5 verification attempts (~100s). The publish step succeeded, so this is almost certainly registry replication lag. Manually confirm with 'npm view @livetemplate/client@$PKG_VERSION' before taking any action."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,4 +48,19 @@ jobs:
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
           echo "Published version: $PKG_VERSION"
-          npm view "@livetemplate/client@$PKG_VERSION"
+          # npm read-after-write can lag 10–60s after a successful publish
+          # due to registry replication, so retry with progressive backoff
+          # before failing the workflow.
+          for attempt in 1 2 3 4 5; do
+            if npm view "@livetemplate/client@$PKG_VERSION"; then
+              echo "Package is visible on npm."
+              exit 0
+            fi
+            if [ "$attempt" -lt 5 ]; then
+              delay=$((attempt * 10))
+              echo "Package not yet visible on npm (attempt $attempt/5). Retrying in ${delay}s..."
+              sleep "$delay"
+            fi
+          done
+          echo "Package @livetemplate/client@$PKG_VERSION was not visible on npm after 5 attempts."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,8 +244,33 @@ The script will:
 3. Generate CHANGELOG.md
 4. Run tests and build
 5. Commit and tag
-6. Publish to npm
-7. Create GitHub release
+6. Push the tag and create a GitHub release
+
+Creating the GitHub release fires the `Publish` workflow
+(`.github/workflows/publish.yml`), which then:
+1. Checks out the release tag
+2. Re-runs tests and build
+3. Verifies `package.json` version matches the tag
+4. Publishes to npm using **OIDC trusted publishing** with `--provenance`
+   (no `NPM_TOKEN` secret — npm trusts the GitHub Actions OIDC identity,
+   configured once on npmjs.com under the package's Trusted Publishers)
+5. Runs a post-publish `npm view` check with retry/backoff
+
+### Watching a release
+
+- **Green workflow**: package is live. Confirm on the package page —
+  a "Provenance" badge should link back to the workflow run.
+- **Green workflow with a yellow "npm registry propagation lag"
+  warning annotation**: the `npm publish` step succeeded but the
+  post-publish `npm view` verification could not confirm visibility
+  within ~100s (npm registry replication can lag 10–60s and
+  occasionally longer). The package IS published — manually confirm
+  with `npm view @livetemplate/client@<version>` before taking any
+  action. Do **not** deprecate or roll back based on this warning alone.
+- **Failed workflow at `Publish to npm`**: real publish failure.
+  Fix and re-run from the Actions UI; no need to recreate the tag.
+- **Never use `npm unpublish`** — npm forbids it after 72h and it
+  breaks downstream installs. Use `npm deprecate` for bad versions.
 
 ## Protocol Changes
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -291,26 +291,11 @@ verify_package_contents() {
     log_info "Package contents verified"
 }
 
-# Publish to npm
-publish_npm() {
-    local new_version=$1
-
-    log_step "Publishing @livetemplate/client@$new_version to npm"
-
-    # Check if logged in
-    if ! npm whoami >/dev/null 2>&1; then
-        log_error "Not logged in to npm. Run 'npm login' first"
-        exit 1
-    fi
-
-    # Publish
-    npm publish || {
-        log_error "npm publish failed"
-        exit 1
-    }
-
-    log_info "Published to npm: https://www.npmjs.com/package/@livetemplate/client/v/$new_version"
-}
+# NOTE: npm publishing is intentionally NOT done here.
+# It runs in CI via .github/workflows/publish.yml, which is triggered by the
+# GitHub release created at the end of this script. Authentication is handled
+# by npm OIDC trusted publishing (no NPM_TOKEN secret required) and the
+# resulting package gets a verified provenance attestation on npmjs.com.
 
 # Extract release notes from CHANGELOG
 extract_release_notes() {
@@ -425,8 +410,8 @@ dry_run() {
     log_info "Would run tests and builds"
     log_info "Would commit with message: chore(release): v$new_version"
     log_info "Would create tag: v$new_version"
-    log_info "Would publish @livetemplate/client@$new_version to npm"
     log_info "Would push to GitHub and create release"
+    log_info "GitHub release would trigger CI workflow to publish @livetemplate/client@$new_version to npm"
 
     echo ""
     log_info "Dry run completed successfully"
@@ -561,8 +546,8 @@ main() {
     echo "  • Generate/update CHANGELOG.md"
     echo "  • Run all tests and builds"
     echo "  • Commit and tag v$new_version"
-    echo "  • Publish @livetemplate/client@$new_version to npm"
     echo "  • Create GitHub release with release notes"
+    echo "  • Trigger CI workflow to publish @livetemplate/client@$new_version to npm"
     echo ""
 
     if [ "$dry_run_mode" = true ]; then
@@ -580,29 +565,33 @@ main() {
     log_info "Starting release process..."
     echo ""
 
-    # Execute release steps
+    # Execute release steps. Note: npm publish runs in CI (publish.yml),
+    # triggered by the GitHub release created in publish_github below.
     update_versions "$new_version"
     generate_changelog "$new_version"
     build_and_test
     verify_build "$new_version"
     verify_package_contents
     commit_and_tag "$new_version"
-    publish_npm "$new_version"
     publish_github "$new_version"
 
     echo ""
     echo "================================================"
-    log_info "✨ Release v$new_version completed successfully!"
+    log_info "✨ Release v$new_version tagged and pushed!"
     echo "================================================"
     echo ""
-    echo "📦 Published artifacts:"
-    echo "  • npm:    https://www.npmjs.com/package/@livetemplate/client/v/$new_version"
-    echo "  • GitHub: https://github.com/livetemplate/client/releases/tag/v$new_version"
-    echo "  • CDN:    https://cdn.jsdelivr.net/npm/@livetemplate/client@$new_version/dist/livetemplate-client.browser.js"
+    echo "📦 GitHub release: https://github.com/livetemplate/client/releases/tag/v$new_version"
+    echo ""
+    echo "🤖 npm publish runs on CI (triggered by the GitHub release):"
+    echo "   https://github.com/livetemplate/client/actions/workflows/publish.yml"
+    echo ""
+    echo "Once the workflow finishes, the package will be available at:"
+    echo "   • npm: https://www.npmjs.com/package/@livetemplate/client/v/$new_version"
+    echo "   • CDN: https://cdn.jsdelivr.net/npm/@livetemplate/client@$new_version/dist/livetemplate-client.browser.js"
     echo ""
     echo "📝 Next steps:"
-    echo "  • Verify the npm package"
-    echo "  • Test the CDN link"
+    echo "  • Watch the Actions tab and confirm the Publish workflow succeeds"
+    echo "  • Verify the npm package once published"
     echo "  • Update examples to use new version"
 }
 


### PR DESCRIPTION
## Summary

- Make CI the sole publisher of `@livetemplate/client`, triggered only by the explicit `release: published` event — no more pasting an npm token (or `npm login`) when running `release.sh`.
- `publish.yml` now uses **npm OIDC trusted publishing** (`id-token: write`) plus `npm publish --provenance`, so the repo holds **zero npm secrets** and the package gets a verified provenance badge on npmjs.com. Checkout is pinned to `github.event.release.tag_name` and a version-match guard rejects releases that point at a mismatched `package.json`.
- `release.sh` keeps its local pre-flight (test, build, verify, package contents) and still tags + pushes + creates the GitHub release — but no longer runs `npm publish` locally. The `publish_npm()` function and `npm whoami` check are gone. Dry-run text and closing summary updated to point at the Actions workflow.

## Trusted publisher (already configured)

The npmjs.com Trusted Publisher for `@livetemplate/client` has been pointed at this repo + `publish.yml`, so the new workflow can authenticate via OIDC without `NPM_TOKEN`.

## Test plan

- [x] `bash -n scripts/release.sh` — syntax check passes
- [x] `dry_run` output inspected — no longer mentions a local npm publish step
- [x] `npm test` — 340 passed across 20 suites
- [x] Workflow YAML parses cleanly
- [ ] After merge: cut a small patch release (e.g. `v0.8.24`) via `./scripts/release.sh` and watch the `Publish` workflow on the Actions tab
- [ ] Confirm `npm view @livetemplate/client@<new>` shows `dist.attestations` (provenance uploaded)
- [ ] Confirm the package page on npmjs.com shows a green "Provenance" badge linking to the workflow run

## Rollback

- If CI fails **before** `npm publish`: nothing on npm. Re-run the failed workflow from the Actions UI; no need to recreate the tag/release.
- If CI fails **after** `npm publish` but in the verify step: the package is published and fine — npm read-after-write can lag 10–60s. Re-running the verify step (or just running `npm view` manually) will succeed.
- If a bad version ships: `npm deprecate @livetemplate/client@X.Y.Z "reason"`. Don't unpublish — npm forbids it after 72h and breaks downstream installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)