### PR TITLE
feat: lvt-preserve attributes, __navigate__ SPA nav, DOMParser script fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to @livetemplate/client will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `lvt-preserve` attribute: morphdom escape hatch that skips an element and its subtree entirely during diff (equivalent to Phoenix LiveView's `phx-update="ignore"`). Checked on `toEl` so the server retains authority to remove it.
+- `lvt-preserve-attrs` attribute: morphdom escape hatch that preserves user-managed attributes (e.g. `open` on `<details>`) while still diffing children. Protects attributes the server template does **not** set. Checked on `toEl` for consistent server authority.
+- In-band `__navigate__` SPA navigation: same-pathname link clicks send `{action:"__navigate__", data:<params>}` over the existing WebSocket instead of fetching new HTML. Requires server-side support (livetemplate/livetemplate#344).
+- DOMParser fallback in `updateDOM`: HTML containing `<script>` tags is now parsed via `DOMParser` to avoid a Chrome `innerHTML` bug that creates phantom duplicate DOM nodes after script tags.
+
+### Breaking Changes
+
+- **Cross-pathname same-handler navigation now always reconnects.** Previously, if two routes shared the same `data-lvt-id`, navigating between them would do an in-place DOM swap without reconnecting. This fast path has been removed; all cross-pathname navigations (regardless of handler ID) now trigger a full WebSocket reconnect. This is the correct behavior — same-ID across paths means two distinct routes, and `sendNavigate` cannot express a path change. **If your app shares a `data-lvt-id` across routes, expect a reconnect flash where there was none before.**
+
+### Deployment note
+
+The `__navigate__` in-band action is a no-op on server versions before livetemplate/livetemplate#344. Deploy the server update before or simultaneously with this client version to avoid same-pathname link clicks sending an unrecognized WebSocket action.
+
 ## [v0.8.25] - 2026-04-15
 
 ### Changes

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -4,15 +4,16 @@ export interface LinkInterceptorContext {
   getWrapperElement(): Element | null;
   handleNavigationResponse(html: string): void;
   // Send an in-band navigate message over the existing WebSocket.
-  // Used by the same-pathname fast path below: rather than fetching
-  // new HTML and replacing DOM, the client asks the server to re-run
-  // Mount with the new query params. Path-level navigation (different
-  // pathnames) still goes through handleNavigationResponse.
-  sendNavigate(href: string): void;
+  // Returns true if the message was sent, false if it was dropped
+  // (e.g. WS not open). The caller uses this to decide whether to push
+  // browser history state — only advancing the URL when the server will
+  // actually receive the navigate eliminates the TOCTOU window where
+  // the WS could close between canSendNavigate() and the actual send.
+  sendNavigate(href: string): boolean;
   // Returns true when an in-band navigate message can be sent (i.e.
-  // WebSocket mode is active). In HTTP mode this is always false, and
-  // the same-pathname fast path must fall through to a normal fetch so
-  // the URL and server state stay in sync.
+  // WebSocket mode is active and the socket is OPEN). In HTTP mode or
+  // when the WS is not yet open, this is false and the same-pathname
+  // fast path must fall through to a normal fetch.
   canSendNavigate(): boolean;
 }
 
@@ -156,15 +157,19 @@ export class LinkInterceptor {
         // in-band __navigate__ update.
         this.abortController?.abort();
         this.abortController = null;
-        if (pushState) {
+        // sendNavigate returns true if the WS message was actually sent.
+        // Push history state ONLY on success to prevent a TOCTOU window
+        // where the WS closes between canSendNavigate() and the actual
+        // send — which would advance the URL with no server-side effect.
+        const sent = this.context.sendNavigate(href);
+        if (sent && pushState) {
           window.history.pushState(null, "", href);
         }
-        this.context.sendNavigate(href);
         return;
       }
-      // HTTP mode (canSendNavigate=false): fall through to normal fetch even
-      // though pathname matches — skipping pushState until after fetch is not
-      // easy here, so we fall through and let handleNavigationResponse run.
+      // HTTP mode or WS not OPEN: fall through to normal fetch. pushState
+      // is handled downstream by the navigate() fetch path (after fetch
+      // resolves and handleNavigationResponse is called).
     }
 
     // Cancel any in-flight navigation fetch

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -158,18 +158,23 @@ export class LinkInterceptor {
         this.abortController?.abort();
         this.abortController = null;
         // sendNavigate returns true if the WS message was actually sent.
-        // Push history state ONLY on success to prevent a TOCTOU window
-        // where the WS closes between canSendNavigate() and the actual
-        // send — which would advance the URL with no server-side effect.
+        // Push history state ONLY on success to keep window.location
+        // consistent with what the server received.
+        // If sent === false (defensive path — normally unreachable since
+        // canSendNavigate() already checked readyState), fall through to
+        // the normal fetch so the navigation isn't silently dropped.
         const sent = this.context.sendNavigate(href);
-        if (sent && pushState) {
-          window.history.pushState(null, "", href);
+        if (sent) {
+          if (pushState) {
+            window.history.pushState(null, "", href);
+          }
+          return;
         }
-        return;
+        // sendNavigate returned false — fall through to fetch as recovery.
       }
-      // HTTP mode or WS not OPEN: fall through to normal fetch. pushState
-      // is handled downstream by the navigate() fetch path (after fetch
-      // resolves and handleNavigationResponse is called).
+      // HTTP mode, WS not OPEN, or sendNavigate returned false:
+      // fall through to normal fetch. pushState is handled downstream by
+      // the fetch path (after the response resolves).
     }
 
     // Cancel any in-flight navigation fetch

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -133,6 +133,12 @@ export class LinkInterceptor {
         // the user navigates between same-pathname hash anchors (shouldSkip
         // catches direct <a> clicks, but popstate calls navigate() directly
         // and bypasses shouldSkip).
+        //
+        // Still abort any in-flight cross-path fetch: if a fetch was in
+        // progress when the user clicked a hash anchor, we don't want it
+        // to resolve and call handleNavigationResponse unexpectedly.
+        this.abortController?.abort();
+        this.abortController = null;
         return;
       }
 

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -2,11 +2,7 @@ import type { Logger } from "../utils/logger";
 
 export interface LinkInterceptorContext {
   getWrapperElement(): Element | null;
-  // prePushPathname: the pathname at the moment the link was clicked,
-  // BEFORE history.pushState was called. Used by handleNavigationResponse
-  // to detect whether the pathname actually changed so it can decide between
-  // in-band sendNavigate (same path, query-param only) and a full reconnect.
-  handleNavigationResponse(html: string, href: string, prePushPathname: string): void;
+  handleNavigationResponse(html: string, href: string): void;
   // Send an in-band navigate message over the existing WebSocket.
   // Used by the same-pathname fast path below: rather than fetching
   // new HTML and replacing DOM, the client asks the server to re-run
@@ -167,11 +163,6 @@ export class LinkInterceptor {
 
       const html = await response.text();
 
-      // Capture the pathname BEFORE pushState so handleNavigationResponse
-      // can tell whether the path actually changed. After pushState,
-      // window.location.pathname is the new path and the old value is lost.
-      const prePushPathname = window.location.pathname;
-
       // Push state BEFORE handling response so that cross-handler
       // navigation reconnects the WebSocket to the correct URL.
       // connect() derives the WebSocket path from window.location.
@@ -179,7 +170,7 @@ export class LinkInterceptor {
         window.history.pushState(null, "", href);
       }
 
-      this.context.handleNavigationResponse(html, href, prePushPathname);
+      this.context.handleNavigationResponse(html, href);
     } catch (e: unknown) {
       // AbortError means a new navigation superseded this one — ignore
       if (e instanceof DOMException && e.name === "AbortError") return;

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -2,7 +2,7 @@ import type { Logger } from "../utils/logger";
 
 export interface LinkInterceptorContext {
   getWrapperElement(): Element | null;
-  handleNavigationResponse(html: string): void;
+  handleNavigationResponse(html: string, href: string): void;
   // Send an in-band navigate message over the existing WebSocket.
   // Used by the same-pathname fast path below: rather than fetching
   // new HTML and replacing DOM, the client asks the server to re-run
@@ -131,6 +131,13 @@ export class LinkInterceptor {
       targetURL.origin === window.location.origin &&
       targetURL.pathname === window.location.pathname
     ) {
+      // Abort any in-flight fetch even on the fast path: a user could
+      // click a cross-path link (starting a fetch) and quickly click a
+      // same-pathname link. Without aborting, the earlier fetch can
+      // still resolve and call handleNavigationResponse, racing with the
+      // in-band __navigate__ update.
+      this.abortController?.abort();
+      this.abortController = null;
       if (pushState) {
         window.history.pushState(null, "", href);
       }
@@ -163,7 +170,7 @@ export class LinkInterceptor {
         window.history.pushState(null, "", href);
       }
 
-      this.context.handleNavigationResponse(html);
+      this.context.handleNavigationResponse(html, href);
     } catch (e: unknown) {
       // AbortError means a new navigation superseded this one — ignore
       if (e instanceof DOMException && e.name === "AbortError") return;

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -119,41 +119,46 @@ export class LinkInterceptor {
   }
 
   private async navigate(href: string, pushState: boolean = true): Promise<void> {
-    // Same-pathname fast path: query-string changed on the same route.
-    // This is definitionally same-handler (the server's mux routes by
-    // path), so we can skip the fetch entirely and just send an in-band
-    // navigate message over the existing WebSocket. The server re-runs
-    // Mount with the new query params, sends back a tree update, and
-    // the normal message handler applies it via morphdom.
-    //
-    // Before this fast path existed, same-pathname clicks went through
-    // fetch + replaceChildren, which swapped DOM but left the server's
-    // connSt.state pinned to the OLD query params — producing the
-    // "clicking any session always shows the first one" bug in
-    // devbox-dash.
     const targetURL = new URL(href, window.location.origin);
-    if (
+    const samePath =
       targetURL.origin === window.location.origin &&
-      targetURL.pathname === window.location.pathname &&
-      this.context.canSendNavigate()
-    ) {
-      // Same-pathname + WebSocket mode: use the in-band fast path.
-      // canSendNavigate() returns false in HTTP mode, which would cause
-      // pushState to fire without a corresponding server message and leave
-      // the URL permanently ahead of server state.
-      //
-      // Abort any in-flight fetch even on the fast path: a user could
-      // click a cross-path link (starting a fetch) and quickly click a
-      // same-pathname link. Without aborting, the earlier fetch can
-      // still resolve and call handleNavigationResponse, racing with the
-      // in-band __navigate__ update.
-      this.abortController?.abort();
-      this.abortController = null;
-      if (pushState) {
-        window.history.pushState(null, "", href);
+      targetURL.pathname === window.location.pathname;
+
+    if (samePath) {
+      const sameSearch = targetURL.search === window.location.search;
+      if (sameSearch) {
+        // Hash-only change or exact same URL — the browser handles scroll
+        // to the anchor; no server round-trip is needed. This guard also
+        // prevents a spurious __navigate__ from the popstate listener when
+        // the user navigates between same-pathname hash anchors (shouldSkip
+        // catches direct <a> clicks, but popstate calls navigate() directly
+        // and bypasses shouldSkip).
+        return;
       }
-      this.context.sendNavigate(href);
-      return;
+
+      if (this.context.canSendNavigate()) {
+        // Same-pathname, different search, WebSocket mode: use the in-band
+        // fast path. Before this existed, same-pathname clicks went through
+        // fetch + replaceChildren, which swapped DOM but left server state
+        // pinned to the OLD query params ("clicking any session always shows
+        // the first one" bug in devbox-dash).
+        //
+        // Abort any in-flight fetch even on the fast path: a user could
+        // click a cross-path link (starting a fetch) and quickly click a
+        // same-pathname link. Without aborting, the earlier fetch can
+        // still resolve and call handleNavigationResponse, racing with the
+        // in-band __navigate__ update.
+        this.abortController?.abort();
+        this.abortController = null;
+        if (pushState) {
+          window.history.pushState(null, "", href);
+        }
+        this.context.sendNavigate(href);
+        return;
+      }
+      // HTTP mode (canSendNavigate=false): fall through to normal fetch even
+      // though pathname matches — skipping pushState until after fetch is not
+      // easy here, so we fall through and let handleNavigationResponse run.
     }
 
     // Cancel any in-flight navigation fetch

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -2,7 +2,11 @@ import type { Logger } from "../utils/logger";
 
 export interface LinkInterceptorContext {
   getWrapperElement(): Element | null;
-  handleNavigationResponse(html: string, href: string): void;
+  // prePushPathname: the pathname at the moment the link was clicked,
+  // BEFORE history.pushState was called. Used by handleNavigationResponse
+  // to detect whether the pathname actually changed so it can decide between
+  // in-band sendNavigate (same path, query-param only) and a full reconnect.
+  handleNavigationResponse(html: string, href: string, prePushPathname: string): void;
   // Send an in-band navigate message over the existing WebSocket.
   // Used by the same-pathname fast path below: rather than fetching
   // new HTML and replacing DOM, the client asks the server to re-run
@@ -163,6 +167,11 @@ export class LinkInterceptor {
 
       const html = await response.text();
 
+      // Capture the pathname BEFORE pushState so handleNavigationResponse
+      // can tell whether the path actually changed. After pushState,
+      // window.location.pathname is the new path and the old value is lost.
+      const prePushPathname = window.location.pathname;
+
       // Push state BEFORE handling response so that cross-handler
       // navigation reconnects the WebSocket to the correct URL.
       // connect() derives the WebSocket path from window.location.
@@ -170,7 +179,7 @@ export class LinkInterceptor {
         window.history.pushState(null, "", href);
       }
 
-      this.context.handleNavigationResponse(html, href);
+      this.context.handleNavigationResponse(html, href, prePushPathname);
     } catch (e: unknown) {
       // AbortError means a new navigation superseded this one — ignore
       if (e instanceof DOMException && e.name === "AbortError") return;

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -3,12 +3,24 @@ import type { Logger } from "../utils/logger";
 export interface LinkInterceptorContext {
   getWrapperElement(): Element | null;
   handleNavigationResponse(html: string): void;
+  // Send an in-band navigate message over the existing WebSocket.
+  // Used by the same-pathname fast path below: rather than fetching
+  // new HTML and replacing DOM, the client asks the server to re-run
+  // Mount with the new query params. Path-level navigation (different
+  // pathnames) still goes through handleNavigationResponse.
+  sendNavigate(href: string): void;
 }
 
 /**
  * Intercepts <a> clicks within the LiveTemplate wrapper for SPA navigation.
- * Same-origin links are fetched via fetch() and the wrapper content is replaced.
- * External links, target="_blank", download, and lvt-nav:no-intercept are skipped.
+ *
+ * - Same pathname (query-string change only) -> sends __navigate__ over WS;
+ *   no fetch, no DOM replace, no reconnect.
+ * - Different pathname (cross-handler or just different route) -> fetches
+ *   new HTML and hands it to handleNavigationResponse, which decides
+ *   between same-handler DOM replace and cross-handler reconnect.
+ * - External links, target="_blank", download, and lvt-nav:no-intercept
+ *   are skipped.
  *
  * Uses AbortController to cancel in-flight fetches when a new navigation
  * starts (rapid clicks, back/forward during fetch).
@@ -102,6 +114,30 @@ export class LinkInterceptor {
   }
 
   private async navigate(href: string, pushState: boolean = true): Promise<void> {
+    // Same-pathname fast path: query-string changed on the same route.
+    // This is definitionally same-handler (the server's mux routes by
+    // path), so we can skip the fetch entirely and just send an in-band
+    // navigate message over the existing WebSocket. The server re-runs
+    // Mount with the new query params, sends back a tree update, and
+    // the normal message handler applies it via morphdom.
+    //
+    // Before this fast path existed, same-pathname clicks went through
+    // fetch + replaceChildren, which swapped DOM but left the server's
+    // connSt.state pinned to the OLD query params — producing the
+    // "clicking any session always shows the first one" bug in
+    // devbox-dash.
+    const targetURL = new URL(href, window.location.origin);
+    if (
+      targetURL.origin === window.location.origin &&
+      targetURL.pathname === window.location.pathname
+    ) {
+      if (pushState) {
+        window.history.pushState(null, "", href);
+      }
+      this.context.sendNavigate(href);
+      return;
+    }
+
     // Cancel any in-flight navigation fetch
     this.abortController?.abort();
     this.abortController = new AbortController();

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -9,6 +9,11 @@ export interface LinkInterceptorContext {
   // Mount with the new query params. Path-level navigation (different
   // pathnames) still goes through handleNavigationResponse.
   sendNavigate(href: string): void;
+  // Returns true when an in-band navigate message can be sent (i.e.
+  // WebSocket mode is active). In HTTP mode this is always false, and
+  // the same-pathname fast path must fall through to a normal fetch so
+  // the URL and server state stay in sync.
+  canSendNavigate(): boolean;
 }
 
 /**
@@ -129,8 +134,14 @@ export class LinkInterceptor {
     const targetURL = new URL(href, window.location.origin);
     if (
       targetURL.origin === window.location.origin &&
-      targetURL.pathname === window.location.pathname
+      targetURL.pathname === window.location.pathname &&
+      this.context.canSendNavigate()
     ) {
+      // Same-pathname + WebSocket mode: use the in-band fast path.
+      // canSendNavigate() returns false in HTTP mode, which would cause
+      // pushState to fire without a corresponding server message and leave
+      // the URL permanently ahead of server state.
+      //
       // Abort any in-flight fetch even on the fast path: a user could
       // click a cross-path link (starting a fetch) and quickly click a
       // same-pathname link. Without aborting, the earlier fetch can

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -2,7 +2,7 @@ import type { Logger } from "../utils/logger";
 
 export interface LinkInterceptorContext {
   getWrapperElement(): Element | null;
-  handleNavigationResponse(html: string, href: string): void;
+  handleNavigationResponse(html: string): void;
   // Send an in-band navigate message over the existing WebSocket.
   // Used by the same-pathname fast path below: rather than fetching
   // new HTML and replacing DOM, the client asks the server to re-run
@@ -170,7 +170,7 @@ export class LinkInterceptor {
         window.history.pushState(null, "", href);
       }
 
-      this.context.handleNavigationResponse(html, href);
+      this.context.handleNavigationResponse(html);
     } catch (e: unknown) {
       // AbortError means a new navigation superseded this one — ignore
       if (e instanceof DOMException && e.name === "AbortError") return;

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -203,6 +203,7 @@ export class LiveTemplateClient {
         getWrapperElement: () => this.wrapperElement,
         handleNavigationResponse: (html: string) => this.handleNavigationResponse(html),
         sendNavigate: (href: string) => this.sendNavigate(href),
+        canSendNavigate: () => !this.useHTTP,
       },
       this.logger.child("LinkInterceptor")
     );

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -203,7 +203,13 @@ export class LiveTemplateClient {
         getWrapperElement: () => this.wrapperElement,
         handleNavigationResponse: (html: string) => this.handleNavigationResponse(html),
         sendNavigate: (href: string) => this.sendNavigate(href),
-        canSendNavigate: () => !this.useHTTP,
+        // Only take the in-band fast path when the WS is actually OPEN.
+        // If WS is CONNECTING or CLOSED, falling through to the normal fetch
+        // path is safer: pushState fires after the fetch resolves (not before),
+        // so the browser URL never gets ahead of server state.
+        canSendNavigate: () =>
+          !this.useHTTP &&
+          this.webSocketManager.getReadyState() === 1 /* WebSocket.OPEN */,
       },
       this.logger.child("LinkInterceptor")
     );

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -579,6 +579,9 @@ export class LiveTemplateClient {
   private sendNavigate(href: string): void {
     const url = new URL(href, window.location.origin);
     const data: Record<string, string> = {};
+    // Note: duplicate keys (e.g. ?tag=a&tag=b) are last-write-wins here.
+    // LiveTemplate routes use scalar string params by convention. Routes
+    // that need repeated params should not use sendNavigate directly.
     url.searchParams.forEach((v, k) => {
       data[k] = v;
     });
@@ -1057,12 +1060,18 @@ export class LiveTemplateClient {
         // mutate their own DOM, and for scroll containers with
         // JS-managed scrollTop.
         //
+        // We check toEl (the incoming server version) rather than fromEl
+        // (the current DOM). This gives the server authority: if a later
+        // render omits lvt-preserve, morphdom resumes updating the element.
+        // Checking fromEl would make the attribute sticky in the DOM
+        // forever once applied, preventing the server from ever removing it.
+        //
         // For the subtler case of "preserve my *attributes* but still
         // let children update" (e.g. <details open>, <select> with
         // user-selected options), use lvt-preserve-attrs below.
         if (
-          fromEl.nodeType === Node.ELEMENT_NODE &&
-          (fromEl as Element).hasAttribute("lvt-preserve")
+          toEl.nodeType === Node.ELEMENT_NODE &&
+          (toEl as Element).hasAttribute("lvt-preserve")
         ) {
           return false;
         }

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1125,6 +1125,11 @@ export class LiveTemplateClient {
         // For the subtler case of "preserve my *attributes* but still
         // let children update" (e.g. <details open>, <select> with
         // user-selected options), use lvt-preserve-attrs below.
+        //
+        // Priority: lvt-preserve is checked first and returns early; if
+        // toEl has lvt-preserve, lvt-preserve-attrs on the same element
+        // is never reached. lvt-preserve wins (full freeze > partial
+        // attribute-only freeze).
         if (
           toEl.nodeType === Node.ELEMENT_NODE &&
           (toEl as Element).hasAttribute("lvt-preserve")

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -201,7 +201,7 @@ export class LiveTemplateClient {
     this.linkInterceptor = new LinkInterceptor(
       {
         getWrapperElement: () => this.wrapperElement,
-        handleNavigationResponse: (html: string, href: string, prePushPathname: string) => this.handleNavigationResponse(html, href, prePushPathname),
+        handleNavigationResponse: (html: string, href: string) => this.handleNavigationResponse(html, href),
         sendNavigate: (href: string) => this.sendNavigate(href),
       },
       this.logger.child("LinkInterceptor")
@@ -582,6 +582,28 @@ export class LiveTemplateClient {
     url.searchParams.forEach((v, k) => {
       data[k] = v;
     });
+
+    // Keep liveUrl in sync so that any subsequent WebSocket reconnect uses
+    // the new URL's query params rather than the initial-connect URL. This
+    // matters if the socket is mid-reconnect when sendNavigate is called —
+    // the message would not be sent, but the reconnect that follows will
+    // use the updated liveUrl and arrive at the correct state.
+    const newLiveUrl = url.pathname + url.search;
+    this.liveUrlOverride = newLiveUrl;
+    this.webSocketManager.setLiveUrl(newLiveUrl);
+
+    // If the WebSocket is not open and we are not in HTTP mode, the
+    // __navigate__ message cannot be delivered reliably. The liveUrl update
+    // above ensures the pending reconnect will use the new URL, so the
+    // user will land in the correct state once the connection recovers.
+    // Sending via the HTTP fallback is skipped here because __navigate__
+    // is a WebSocket-only in-band action; the server HTTP endpoint does
+    // not process it.
+    if (this.webSocketManager.getReadyState() !== 1 /* WebSocket.OPEN */ && !this.useHTTP) {
+      this.logger.warn("sendNavigate: WebSocket not open; liveUrl updated, awaiting reconnect", { href });
+      return;
+    }
+
     this.logger.debug("sendNavigate", { href, data });
     this.send({ action: "__navigate__", data });
   }
@@ -685,7 +707,7 @@ export class LiveTemplateClient {
    * (done in LinkInterceptor.navigate) so the WebSocket connects to
    * the correct handler.
    */
-  private handleNavigationResponse(html: string, href: string, prePushPathname: string): void {
+  private handleNavigationResponse(html: string, href: string): void {
     if (!this.wrapperElement) return;
 
     const parser = new DOMParser();
@@ -700,45 +722,20 @@ export class LiveTemplateClient {
       document.title = newTitleText;
     }
 
-    // Try same-handler wrapper first (same data-lvt-id)
-    const sameWrapper = oldId
-      ? doc.querySelector(`[data-lvt-id="${oldId}"]`)
-      : null;
+    // sameWrapper: the fetched page has the same data-lvt-id as the current
+    // wrapper. This means two different paths share the same handler ID.
+    // handleNavigationResponse is only reached via LinkInterceptor for
+    // cross-pathname navigations (same-pathname links are caught by the fast
+    // path before a fetch is issued and handled via sendNavigate directly).
+    // For cross-pathname same-ID, a full reconnect is correct: the server
+    // must receive the new URL to re-run Mount on the right route. We fall
+    // through to the newWrapper block below, which handles both same-ID and
+    // different-ID handler switches identically.
+    //
+    // Same-pathname same-ID navigation (query-param change on the same route)
+    // is covered exclusively by LinkInterceptor's fast path and navigate.test.ts.
 
-    if (sameWrapper) {
-      // In-band navigate is only correct when the PATHNAME is unchanged.
-      // sendNavigate ships only query-param data to the server, which
-      // re-runs Mount on the existing route. If two different paths share
-      // the same handler ID, calling sendNavigate for a path change would
-      // silently discard the new path and re-run Mount on the wrong route.
-      //
-      // prePushPathname is the pathname captured BEFORE history.pushState
-      // was called, so it reliably reflects the original route even though
-      // window.location has already been updated by the time we arrive here.
-      //
-      // When the pathname IS the same (query-string-only change), the
-      // in-band navigate avoids a full WebSocket reconnect — no DOM churn,
-      // no stale-state risk from reconnect races.
-      //
-      // When the pathname changed, fall through to the cross-handler
-      // reconnect path below, which handles same-ID same-handler
-      // (different path) the same as a genuine handler switch.
-      // Note: through the normal LinkInterceptor callsite, same-pathname
-      // navigations are intercepted by the fast path before a fetch is
-      // issued, so handleNavigationResponse is only reachable when the
-      // pathname changed and targetPathname !== prePushPathname. The
-      // equality branch below is therefore structurally unreachable via
-      // LinkInterceptor; it exists as a correct fallback for any direct
-      // caller that passes a same-path href (e.g. navigation.test.ts).
-      const targetPathname = new URL(href, window.location.origin).pathname;
-      if (targetPathname === prePushPathname) {
-        this.sendNavigate(href);
-        return;
-      }
-      // Pathname changed — fall through to reconnect.
-    }
-
-    // Check for a different handler's wrapper (cross-handler navigation)
+    // Check for any handler wrapper (same-ID cross-path or different handler)
     const newWrapper = doc.querySelector("[data-lvt-id]");
     if (newWrapper) {
       const newId = newWrapper.getAttribute("data-lvt-id");
@@ -990,7 +987,13 @@ export class LiveTemplateClient {
     // Wrapping <tr>/<td>/<option> content in a <div> can trigger
     // browser re-parenting; using the real container tag avoids that.
     if (/<script[\s>]/i.test(result.html)) {
-      const wrapTag = element.tagName.toLowerCase();
+      // Guard: <body> and <html> cannot be used as wrapper tags for
+      // parseFromString — doc.body.firstElementChild would return the
+      // first child of body, not the body itself, discarding the wrap.
+      // Fall back to <div> for these edge cases; updateDOM is called on
+      // the lvt wrapper div in practice, so this branch is defensive.
+      const rawTag = element.tagName.toLowerCase();
+      const wrapTag = (rawTag === "body" || rawTag === "html") ? "div" : rawTag;
       const parser = new DOMParser();
       const doc = parser.parseFromString(
         `<${wrapTag}>${result.html}</${wrapTag}>`,

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -201,7 +201,7 @@ export class LiveTemplateClient {
     this.linkInterceptor = new LinkInterceptor(
       {
         getWrapperElement: () => this.wrapperElement,
-        handleNavigationResponse: (html: string, href: string) => this.handleNavigationResponse(html, href),
+        handleNavigationResponse: (html: string) => this.handleNavigationResponse(html),
         sendNavigate: (href: string) => this.sendNavigate(href),
       },
       this.logger.child("LinkInterceptor")
@@ -592,15 +592,14 @@ export class LiveTemplateClient {
     this.liveUrlOverride = newLiveUrl;
     this.webSocketManager.setLiveUrl(newLiveUrl);
 
-    // If the WebSocket is not open and we are not in HTTP mode, the
-    // __navigate__ message cannot be delivered reliably. The liveUrl update
-    // above ensures the pending reconnect will use the new URL, so the
-    // user will land in the correct state once the connection recovers.
-    // Sending via the HTTP fallback is skipped here because __navigate__
-    // is a WebSocket-only in-band action; the server HTTP endpoint does
-    // not process it.
-    if (this.webSocketManager.getReadyState() !== 1 /* WebSocket.OPEN */ && !this.useHTTP) {
-      this.logger.warn("sendNavigate: WebSocket not open; liveUrl updated, awaiting reconnect", { href });
+    // __navigate__ is a WebSocket-only in-band action. Skip send() if:
+    //   - WebSocket is not OPEN (mid-reconnect, closed): message would be lost
+    //   - HTTP mode: send() would POST to the HTTP endpoint, which does not
+    //     process __navigate__
+    // In both cases the liveUrl update above ensures the pending/next
+    // reconnect will arrive at the correct state.
+    if (this.webSocketManager.getReadyState() !== 1 /* WebSocket.OPEN */ || this.useHTTP) {
+      this.logger.warn("sendNavigate: not sent (WS not open or HTTP mode); liveUrl updated", { href });
       return;
     }
 
@@ -707,7 +706,7 @@ export class LiveTemplateClient {
    * (done in LinkInterceptor.navigate) so the WebSocket connects to
    * the correct handler.
    */
-  private handleNavigationResponse(html: string, href: string): void {
+  private handleNavigationResponse(html: string): void {
     if (!this.wrapperElement) return;
 
     const parser = new DOMParser();

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -111,7 +111,20 @@ export class LiveTemplateClient {
     this.options = {
       autoReconnect: false, // Disable autoReconnect by default to avoid connection loops
       reconnectDelay: 1000,
-      liveUrl: window.location.pathname + window.location.search, // Connect to current page (including query params)
+      // liveUrl captures the current page URL (path + search) so the
+      // initial WebSocket handshake reaches the server with the same
+      // query params Mount saw on the HTTP GET. This is intentional —
+      // without the search, the WS-side Mount re-runs with empty data
+      // and drifts state from the HTTP render.
+      //
+      // For *same-handler* SPA navigation (changing query params on
+      // the same path), the client does NOT reconnect — instead it
+      // sends an in-band {action:"__navigate__", data:<params>} message
+      // over the existing WebSocket, and the server re-runs Mount with
+      // the new data. See sendNavigate() and handleNavigationResponse()
+      // for the SPA path. Cross-handler SPA navigation still does the
+      // fetch-and-replaceChildren+reconnect dance.
+      liveUrl: window.location.pathname + window.location.search,
       ...restOptions,
     };
 
@@ -189,6 +202,7 @@ export class LiveTemplateClient {
       {
         getWrapperElement: () => this.wrapperElement,
         handleNavigationResponse: (html: string) => this.handleNavigationResponse(html),
+        sendNavigate: (href: string) => this.sendNavigate(href),
       },
       this.logger.child("LinkInterceptor")
     );
@@ -543,6 +557,36 @@ export class LiveTemplateClient {
   }
 
   /**
+   * Send an in-band navigate message over the existing WebSocket.
+   *
+   * This is the client side of the same-handler SPA navigation flow.
+   * Rather than disconnect + reconnect to land a URL change (which is
+   * what cross-handler nav does and what the old same-handler path
+   * silently skipped), we parse the target URL's query params into a
+   * data map and send {action: "__navigate__", data: params}. The
+   * server special-cases this action name in its event loop (see
+   * livetemplate/mount.go) and re-runs Mount with the new data without
+   * tearing down the connection.
+   *
+   * Equivalent to Phoenix LiveView's live_patch / handle_params:
+   * path-level identity for the socket, Mount-level re-projection for
+   * query-string changes.
+   *
+   * @param href - The target URL to navigate to. Only the search params
+   *               are consumed; the pathname is assumed to match the
+   *               current page (caller checks same-handler first).
+   */
+  private sendNavigate(href: string): void {
+    const url = new URL(href, window.location.origin);
+    const data: Record<string, string> = {};
+    url.searchParams.forEach((v, k) => {
+      data[k] = v;
+    });
+    this.logger.debug("sendNavigate", { href, data });
+    this.send({ action: "__navigate__", data });
+  }
+
+  /**
    * Send action via HTTP POST
    */
   private async sendHTTP(message: any): Promise<void> {
@@ -662,11 +706,23 @@ export class LiveTemplateClient {
       : null;
 
     if (sameWrapper) {
-      this.wrapperElement.replaceChildren(
-        ...Array.from(sameWrapper.childNodes).map((n) => n.cloneNode(true))
-      );
-      this.eventDelegator.setupEventDelegation();
-      this.linkInterceptor.setup(this.wrapperElement);
+      // Same-handler navigation = query-param change on the same path.
+      // Instead of replacing the whole DOM (which would require a full
+      // WebSocket reconnect to keep server state in sync — the former
+      // behaviour silently dropped the second part and caused stale
+      // state bugs like devbox-dash's "always shows the second session"
+      // regression), we send an in-band navigate message over the
+      // existing WebSocket. The server's event loop intercepts the
+      // reserved __navigate__ action, re-runs Mount with the new query
+      // params, and pushes a tree update back — which the normal
+      // WebSocket message handler applies via morphdom. No reconnect,
+      // no DOM churn, no stale state.
+      //
+      // We've already parsed the fetched HTML above, but for
+      // same-handler nav we throw it away — the server-authored tree
+      // update is the source of truth and will overwrite any local DOM
+      // differences via morphdom.
+      this.sendNavigate(window.location.href);
       return;
     }
 
@@ -942,6 +998,56 @@ export class LiveTemplateClient {
         }
       },
       onBeforeElUpdated: (fromEl, toEl) => {
+        // Honour lvt-preserve: the client owns this element's entire
+        // subtree and morphdom should never touch any of it.
+        // Attributes, content, descendants all stay exactly as the DOM
+        // currently has them. Equivalent to Phoenix LiveView's
+        // phx-update="ignore" and Turbo's data-turbo-permanent. Useful
+        // for third-party widgets (maps, date pickers, charts) that
+        // mutate their own DOM, and for scroll containers with
+        // JS-managed scrollTop.
+        //
+        // For the subtler case of "preserve my *attributes* but still
+        // let children update" (e.g. <details open>, <select> with
+        // user-selected options), use lvt-preserve-attrs below.
+        if (
+          fromEl.nodeType === Node.ELEMENT_NODE &&
+          (fromEl as Element).hasAttribute("lvt-preserve")
+        ) {
+          return false;
+        }
+
+        // Honour lvt-preserve-attrs: the client owns this element's own
+        // attributes (e.g. the <details open> state the user toggled),
+        // but its children should still be diffed against the new tree.
+        // This is the right fit for collapsible pickers where the
+        // *container* state is user-managed but the *items* inside are
+        // server-authored and must reflect the latest data.
+        //
+        // Implementation: copy fromEl's attributes that are missing from
+        // toEl onto toEl before morphdom runs its attribute diff. This
+        // makes morphdom see the user-owned attrs as "already present"
+        // in the new version, so it doesn't remove them. Attributes that
+        // exist in both fromEl and toEl take toEl's value (server wins
+        // over client for attributes the template does control), which
+        // preserves the ability to update className etc. on the same
+        // element from the server.
+        if (
+          fromEl.nodeType === Node.ELEMENT_NODE &&
+          (fromEl as Element).hasAttribute("lvt-preserve-attrs") &&
+          toEl.nodeType === Node.ELEMENT_NODE
+        ) {
+          const fromAttrs = (fromEl as Element).attributes;
+          const toElement = toEl as Element;
+          for (let i = 0; i < fromAttrs.length; i++) {
+            const attr = fromAttrs[i];
+            if (!toElement.hasAttribute(attr.name)) {
+              toElement.setAttribute(attr.name, attr.value);
+            }
+          }
+          // Fall through to normal diff path so children are still updated.
+        }
+
         // Skip update entirely for focused form elements to preserve user
         // input. This also skips attribute updates (class, disabled, aria-*)
         // and the lvt-updated hook — use data-lvt-force-update to override.

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -583,7 +583,7 @@ export class LiveTemplateClient {
    *               are consumed; the pathname is assumed to match the
    *               current page (caller checks same-handler first).
    */
-  private sendNavigate(href: string): void {
+  private sendNavigate(href: string): boolean {
     const url = new URL(href, window.location.origin);
     const data: Record<string, string> = {};
     // Note: duplicate keys (e.g. ?tag=a&tag=b) are last-write-wins here.
@@ -648,11 +648,12 @@ export class LiveTemplateClient {
           );
         }
       }
-      return;
+      return false;
     }
 
     this.logger.debug("sendNavigate", { href, data });
     this.send({ action: "__navigate__", data });
+    return true;
   }
 
   /**

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -599,10 +599,21 @@ export class LiveTemplateClient {
     //   - WebSocket is not OPEN (mid-reconnect, closed): message would be lost
     //   - HTTP mode: send() would POST to the HTTP endpoint, which does not
     //     process __navigate__
-    // In both cases the liveUrl update above ensures the pending/next
-    // reconnect will arrive at the correct state.
+    // liveUrl was updated above, so a pending or future reconnect will land
+    // on the correct URL. If autoReconnect is disabled and the socket is
+    // CLOSED (readyState 3), the navigate is lost until the user reloads —
+    // emit an error so this is visible in logs.
     if (this.webSocketManager.getReadyState() !== 1 /* WebSocket.OPEN */ || this.useHTTP) {
-      this.logger.warn("sendNavigate: not sent (WS not open or HTTP mode); liveUrl updated", { href });
+      const readyState = this.webSocketManager.getReadyState();
+      if (readyState === 3 /* CLOSED */ && !this.useHTTP) {
+        this.logger.error(
+          "sendNavigate: WebSocket is CLOSED and autoReconnect may be disabled; " +
+          "navigate message dropped. Reload or re-enable autoReconnect.",
+          { href }
+        );
+      } else {
+        this.logger.warn("sendNavigate: not sent (WS not open or HTTP mode); liveUrl updated", { href });
+      }
       return;
     }
 
@@ -1012,7 +1023,13 @@ export class LiveTemplateClient {
         // an edge case; a follow-up can add a full-table wrapper for those.
         tempWrapper.replaceChildren(...Array.from(root.childNodes));
       } else {
-        tempWrapper.innerHTML = result.html;
+        // root is null when the HTML parser produced no element child for
+        // our wrapper tag (e.g. the wrapper was itself re-parented or the
+        // fragment is text-only). Fall back to doc.body children — the
+        // content is still present there, already parsed by DOMParser
+        // without the script-duplication quirk that innerHTML triggers.
+        this.logger.warn("[updateDOM] DOMParser: no wrapper root element; using doc.body children");
+        tempWrapper.replaceChildren(...Array.from(doc.body.childNodes));
       }
     } else {
       tempWrapper.innerHTML = result.html;
@@ -1091,6 +1108,12 @@ export class LiveTemplateClient {
         // over client for attributes the template does control), which
         // preserves the ability to update className etc. on the same
         // element from the server.
+        //
+        // Limitation: only *missing* attributes from fromEl are copied.
+        // If the server's toEl already has e.g. class="card", that value
+        // is used — JS-added classes (el.classList.add('open')) are
+        // silently overwritten on the next diff. Use lvt-preserve-attrs
+        // for attributes the server template does NOT set at all.
         if (
           fromEl.nodeType === Node.ELEMENT_NODE &&
           (fromEl as Element).hasAttribute("lvt-preserve-attrs") &&

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -582,7 +582,12 @@ export class LiveTemplateClient {
     // Note: duplicate keys (e.g. ?tag=a&tag=b) are last-write-wins here.
     // LiveTemplate routes use scalar string params by convention. Routes
     // that need repeated params should not use sendNavigate directly.
+    const seenKeys = new Set<string>();
     url.searchParams.forEach((v, k) => {
+      if (seenKeys.has(k)) {
+        this.logger.warn("sendNavigate: duplicate query param key — last value wins; server may receive incomplete data", { key: k, href });
+      }
+      seenKeys.add(k);
       data[k] = v;
     });
 
@@ -990,10 +995,13 @@ export class LiveTemplateClient {
     // duplicate DOM nodes after the closing tag. DOMParser doesn't have
     // this quirk because it returns a standalone document.
     //
-    // Regex /<script[\s>]/i is more precise than a plain string search:
-    // it avoids false positives from "<script" appearing inside attribute
-    // values (e.g. data-content="<script") or HTML comments, while still
-    // matching <script>, <script type="..."> and <SCRIPT> case-insensitively.
+    // Regex /<script[\s>]/i is more precise than a bare "<script" string
+    // match: it avoids false positives from words ending in "script" that
+    // aren't a tag (e.g. "noscript"), while still matching <script>,
+    // <script type="..."> and <SCRIPT> case-insensitively.
+    // Note: it can still match <script inside attribute values or HTML
+    // comments — a false positive is harmless (DOMParser is always safe;
+    // we just pay a small allocation cost for the parse).
     //
     // Wrap with the same tagName as the target element (not a hard-coded
     // <div>) so that DOMParser applies the correct HTML parsing rules.
@@ -1114,10 +1122,15 @@ export class LiveTemplateClient {
         // is used — JS-added classes (el.classList.add('open')) are
         // silently overwritten on the next diff. Use lvt-preserve-attrs
         // for attributes the server template does NOT set at all.
+        //
+        // We check toEl (the incoming server tree), not fromEl (the live
+        // DOM), so the server has authority: removing lvt-preserve-attrs
+        // from the template takes effect immediately on the next render,
+        // consistent with how lvt-preserve works.
         if (
-          fromEl.nodeType === Node.ELEMENT_NODE &&
-          (fromEl as Element).hasAttribute("lvt-preserve-attrs") &&
-          toEl.nodeType === Node.ELEMENT_NODE
+          toEl.nodeType === Node.ELEMENT_NODE &&
+          (toEl as Element).hasAttribute("lvt-preserve-attrs") &&
+          fromEl.nodeType === Node.ELEMENT_NODE
         ) {
           const fromAttrs = (fromEl as Element).attributes;
           const toElement = toEl as Element;

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -610,20 +610,29 @@ export class LiveTemplateClient {
     // emit an error so this is visible in logs.
     if (this.webSocketManager.getReadyState() !== 1 /* WebSocket.OPEN */ || this.useHTTP) {
       const readyState = this.webSocketManager.getReadyState();
-      if (readyState === 3 /* CLOSED */ && !this.useHTTP) {
+      if (this.useHTTP) {
+        // HTTP mode has no persistent connection to reconnect on — there is
+        // no self-healing path. The browser URL already changed (pushState
+        // fired before sendNavigate was called) and server state is now
+        // permanently out of sync unless the user reloads.
+        this.logger.error(
+          "sendNavigate: HTTP mode does not support in-band navigation; browser URL may be permanently out of sync. " +
+          "Use a full page navigation instead.",
+          { href }
+        );
+      } else if (readyState === 3 /* CLOSED */) {
         this.logger.error(
           "sendNavigate: WebSocket is CLOSED and autoReconnect may be disabled; " +
           "navigate message dropped. Reload or re-enable autoReconnect.",
           { href }
         );
       } else {
-        // The caller (link-interceptor) already pushed history state, so the
-        // browser URL reflects the new href. The navigate message could not
-        // be sent, but liveUrl was updated above, so the next WebSocket
-        // reconnect will arrive at the correct state — the URL/state desync
-        // is temporary and self-healing when autoReconnect is enabled.
+        // WS is mid-reconnect (CONNECTING or CLOSING). The caller (link-interceptor)
+        // already pushed history state, so the browser URL reflects the new href.
+        // liveUrl was updated above, so the next WebSocket reconnect will arrive
+        // at the correct state — URL/state desync is temporary and self-healing.
         this.logger.warn(
-          "sendNavigate: not sent (WS not open or HTTP mode); browser URL may be ahead of server state until reconnect",
+          "sendNavigate: WS not open; browser URL is ahead of server state until reconnect",
           { href }
         );
       }
@@ -811,6 +820,12 @@ export class LiveTemplateClient {
       // page path and the WebSocket path are always the same. Apps that
       // need a different WebSocket endpoint should set `wsUrl`, which
       // takes precedence over `liveUrl` in WebSocketManager.
+      //
+      // Invariant: link-interceptor.ts calls pushState BEFORE invoking
+      // handleNavigationResponse, so window.location here always
+      // reflects the final target URL (not the previous one). This is
+      // why liveUrlOverride is never stale for cross-pathname navigations
+      // even if sendNavigate had previously set it to a same-pathname URL.
       const newLiveUrl =
         window.location.pathname + window.location.search;
       this.liveUrlOverride = newLiveUrl;
@@ -1154,8 +1169,12 @@ export class LiveTemplateClient {
             ) {
               continue;
             }
-            if (!toElement.hasAttribute(attr.name)) {
-              toElement.setAttribute(attr.name, attr.value);
+            // Use hasAttributeNS / setAttributeNS to preserve namespace
+            // info (e.g. xlink:href on SVG elements). For plain HTML
+            // attributes namespaceURI is null, so this degrades to the
+            // same behaviour as setAttribute.
+            if (!toElement.hasAttributeNS(attr.namespaceURI, attr.localName)) {
+              toElement.setAttributeNS(attr.namespaceURI, attr.name, attr.value);
             }
           }
           // Fall through to normal diff path so children are still updated.

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -628,13 +628,18 @@ export class LiveTemplateClient {
           { href }
         );
       } else {
-        // WS is mid-reconnect (CONNECTING or CLOSING). The caller (link-interceptor)
-        // already pushed history state, so the browser URL reflects the new href.
-        // liveUrl was updated above, so the next WebSocket reconnect will arrive
-        // at the correct state — URL/state desync is temporary and self-healing.
+        // WS is CONNECTING (0) or CLOSING (2). liveUrl was updated above, so
+        // the next reconnect will use the new URL. However, for CONNECTING:
+        // if the in-progress handshake succeeds and the server lands on the
+        // OLD URL before reconnect fires, the navigate is silently lost until
+        // the socket later drops and reconnects. This is an edge case only when
+        // autoReconnect is enabled and the CONNECTING handshake completes at
+        // the old URL before being superseded. With autoReconnect enabled, the
+        // next drop+reconnect recovers correctly; with autoReconnect off, there
+        // may be no recovery until the user reloads.
         this.logger.warn(
           "sendNavigate: WS not open; browser URL is ahead of server state until reconnect",
-          { href }
+          { href, readyState }
         );
       }
       return;

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -598,11 +598,11 @@ export class LiveTemplateClient {
       data[k] = v;
     });
 
-    // Keep liveUrl in sync so that any subsequent WebSocket reconnect uses
-    // the new URL's query params rather than the initial-connect URL. This
-    // matters if the socket is mid-reconnect when sendNavigate is called —
-    // the message would not be sent, but the reconnect that follows will
-    // use the updated liveUrl and arrive at the correct state.
+    // Tentatively update liveUrl — if the send succeeds this stays; if it
+    // fails we revert so liveUrlOverride stays consistent with window.location
+    // (no pushState fired on failure). An inconsistent liveUrlOverride would
+    // cause a future reconnect to land on a URL the browser doesn't show.
+    const previousLiveUrl = this.liveUrlOverride;
     const newLiveUrl = url.pathname + url.search;
     this.liveUrlOverride = newLiveUrl;
     this.webSocketManager.setLiveUrl(newLiveUrl);
@@ -613,11 +613,6 @@ export class LiveTemplateClient {
     // Note: this.useHTTP is not checked here because sendNavigate() is only
     // reachable when canSendNavigate() returns true (i.e. !this.useHTTP),
     // enforced by LinkInterceptor. Checking useHTTP here would be dead code.
-    //
-    // liveUrl was updated above, so a pending or future reconnect will land
-    // on the correct URL. If autoReconnect is disabled and the socket is
-    // CLOSED (readyState 3), the navigate is lost until the user reloads —
-    // emit an error so this is visible in logs.
     if (this.webSocketManager.getReadyState() !== 1 /* WebSocket.OPEN */) {
       const readyState = this.webSocketManager.getReadyState();
       if (readyState === 3 /* CLOSED */) {
@@ -648,6 +643,12 @@ export class LiveTemplateClient {
           );
         }
       }
+      // Revert: browser URL won't change (no pushState on failure), so keep
+      // liveUrlOverride consistent with window.location to avoid a future
+      // reconnect landing on a URL the browser does not display.
+      this.liveUrlOverride = previousLiveUrl;
+      const revertUrl = previousLiveUrl ?? this.options.liveUrl ?? "/live";
+      this.webSocketManager.setLiveUrl(revertUrl);
       return false;
     }
 

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -723,6 +723,13 @@ export class LiveTemplateClient {
       // When the pathname changed, fall through to the cross-handler
       // reconnect path below, which handles same-ID same-handler
       // (different path) the same as a genuine handler switch.
+      // Note: through the normal LinkInterceptor callsite, same-pathname
+      // navigations are intercepted by the fast path before a fetch is
+      // issued, so handleNavigationResponse is only reachable when the
+      // pathname changed and targetPathname !== prePushPathname. The
+      // equality branch below is therefore structurally unreachable via
+      // LinkInterceptor; it exists as a correct fallback for any direct
+      // caller that passes a same-path href (e.g. navigation.test.ts).
       const targetPathname = new URL(href, window.location.origin).pathname;
       if (targetPathname === prePushPathname) {
         this.sendNavigate(href);
@@ -973,14 +980,16 @@ export class LiveTemplateClient {
     // duplicate DOM nodes after the closing tag. DOMParser doesn't have
     // this quirk because it returns a standalone document.
     //
-    // Case-insensitive check: HTML tag names are case-insensitive, so
-    // <SCRIPT> or <Script> must also route through DOMParser.
+    // Regex /<script[\s>]/i is more precise than a plain string search:
+    // it avoids false positives from "<script" appearing inside attribute
+    // values (e.g. data-content="<script") or HTML comments, while still
+    // matching <script>, <script type="..."> and <SCRIPT> case-insensitively.
     //
     // Wrap with the same tagName as the target element (not a hard-coded
     // <div>) so that DOMParser applies the correct HTML parsing rules.
     // Wrapping <tr>/<td>/<option> content in a <div> can trigger
     // browser re-parenting; using the real container tag avoids that.
-    if (result.html.toLowerCase().includes("<script")) {
+    if (/<script[\s>]/i.test(result.html)) {
       const wrapTag = element.tagName.toLowerCase();
       const parser = new DOMParser();
       const doc = parser.parseFromString(

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -621,19 +621,26 @@ export class LiveTemplateClient {
           { href }
         );
       } else {
-        // WS is CONNECTING (0) or CLOSING (2). liveUrl was updated above, so
-        // the next reconnect will use the new URL. However, for CONNECTING:
-        // if the in-progress handshake succeeds and the server lands on the
-        // OLD URL before reconnect fires, the navigate is silently lost until
-        // the socket later drops and reconnects. This is an edge case only when
-        // autoReconnect is enabled and the CONNECTING handshake completes at
-        // the old URL before being superseded. With autoReconnect enabled, the
-        // next drop+reconnect recovers correctly; with autoReconnect off, there
-        // may be no recovery until the user reloads.
-        this.logger.warn(
-          "sendNavigate: WS not open; browser URL is ahead of server state until reconnect",
-          { href, readyState }
-        );
+        // WS is CONNECTING (0) or CLOSING (2). liveUrl was updated above.
+        //
+        // autoReconnect defaults to false. If it's disabled and the in-progress
+        // CONNECTING handshake succeeds at the OLD URL, the navigate is
+        // permanently lost (no future reconnect will fire). Treat this as an
+        // error since there may be no recovery path.
+        //
+        // With autoReconnect enabled the next reconnect recovers correctly, so
+        // warn is appropriate in that case.
+        if (!this.options.autoReconnect) {
+          this.logger.error(
+            "sendNavigate: WS not open and autoReconnect is disabled; navigate may be permanently lost if handshake completes at old URL",
+            { href, readyState }
+          );
+        } else {
+          this.logger.warn(
+            "sendNavigate: WS not open; browser URL is ahead of server state until reconnect",
+            { href, readyState }
+          );
+        }
       }
       return;
     }
@@ -830,41 +837,47 @@ export class LiveTemplateClient {
       this.liveUrlOverride = newLiveUrl;
       this.webSocketManager.setLiveUrl(newLiveUrl);
 
-      // Reconnect to the new handler. The server sends an initial tree
-      // that produces the same DOM as the fetched HTML.
-      //
-      // Escape the wrapper ID to defend against (pathological) server
-      // responses with special characters that would break the
-      // attribute selector. Only `"` and `\` need escaping inside a
-      // double-quoted attribute value selector (`[attr="..."]`), and
-      // we prefer a manual escape over CSS.escape() which is not
-      // available in jsdom test environments.
-      //
-      // Epoch semantics: the failure branch is guarded by the epoch
-      // check to avoid stale reloads. The success branch has no work
-      // to do — there's nothing for handleNavigationResponse to undo
-      // on success.
-      //
-      // Known limitation: if two cross-handler navigations run in rapid
-      // succession (A then B), A's connect() might still be executing
-      // its post-await setup (useHTTP assignment, initial state
-      // rendering, event delegation) when B starts. Because there's
-      // only one WebSocketManager transport at a time, B's disconnect()
-      // kills A's in-flight transport, and B's setup happens on the
-      // wrapper with B's ID. If A's post-await code runs AFTER B sets
-      // the wrapper ID, A's querySelector lookup would already be
-      // stale (it captured the wrapper synchronously before the await).
-      // A true fix requires making connect() itself cancellable with
-      // an AbortSignal, which is out of scope for this PR. In practice,
-      // two successive SPA navigations within a single event loop tick
-      // are rare, and the idempotent setup methods minimize fallout.
-      const escapedId = newId.replace(/[\\"]/g, "\\$&");
-      const selector = `[data-lvt-id="${escapedId}"]`;
-      this.connect(selector).catch((err) => {
-        if (myEpoch !== this.navigationEpoch) return;
-        this.logger.error("Cross-handler reconnect failed:", err);
-        window.location.reload();
-      });
+      // In HTTP mode there is no persistent WebSocket connection — skip
+      // connect() so we don't unexpectedly create a WebSocket. The DOM swap
+      // and event re-setup above are sufficient for HTTP-mode apps; the next
+      // user action will POST via the normal HTTP send path.
+      if (!this.useHTTP) {
+        // Reconnect to the new handler. The server sends an initial tree
+        // that produces the same DOM as the fetched HTML.
+        //
+        // Escape the wrapper ID to defend against (pathological) server
+        // responses with special characters that would break the
+        // attribute selector. Only `"` and `\` need escaping inside a
+        // double-quoted attribute value selector (`[attr="..."]`), and
+        // we prefer a manual escape over CSS.escape() which is not
+        // available in jsdom test environments.
+        //
+        // Epoch semantics: the failure branch is guarded by the epoch
+        // check to avoid stale reloads. The success branch has no work
+        // to do — there's nothing for handleNavigationResponse to undo
+        // on success.
+        //
+        // Known limitation: if two cross-handler navigations run in rapid
+        // succession (A then B), A's connect() might still be executing
+        // its post-await setup (useHTTP assignment, initial state
+        // rendering, event delegation) when B starts. Because there's
+        // only one WebSocketManager transport at a time, B's disconnect()
+        // kills A's in-flight transport, and B's setup happens on the
+        // wrapper with B's ID. If A's post-await code runs AFTER B sets
+        // the wrapper ID, A's querySelector lookup would already be
+        // stale (it captured the wrapper synchronously before the await).
+        // A true fix requires making connect() itself cancellable with
+        // an AbortSignal, which is out of scope for this PR. In practice,
+        // two successive SPA navigations within a single event loop tick
+        // are rare, and the idempotent setup methods minimize fallout.
+        const escapedId = newId.replace(/[\\"]/g, "\\$&");
+        const selector = `[data-lvt-id="${escapedId}"]`;
+        this.connect(selector).catch((err) => {
+          if (myEpoch !== this.navigationEpoch) return;
+          this.logger.error("Cross-handler reconnect failed:", err);
+          window.location.reload();
+        });
+      }
       return;
     }
 

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -601,27 +601,20 @@ export class LiveTemplateClient {
     this.liveUrlOverride = newLiveUrl;
     this.webSocketManager.setLiveUrl(newLiveUrl);
 
-    // __navigate__ is a WebSocket-only in-band action. Skip send() if:
-    //   - WebSocket is not OPEN (mid-reconnect, closed): message would be lost
-    //   - HTTP mode: send() would POST to the HTTP endpoint, which does not
-    //     process __navigate__
+    // __navigate__ is a WebSocket-only in-band action — only call send()
+    // when the socket is actually OPEN.
+    //
+    // Note: this.useHTTP is not checked here because sendNavigate() is only
+    // reachable when canSendNavigate() returns true (i.e. !this.useHTTP),
+    // enforced by LinkInterceptor. Checking useHTTP here would be dead code.
+    //
     // liveUrl was updated above, so a pending or future reconnect will land
     // on the correct URL. If autoReconnect is disabled and the socket is
     // CLOSED (readyState 3), the navigate is lost until the user reloads —
     // emit an error so this is visible in logs.
-    if (this.webSocketManager.getReadyState() !== 1 /* WebSocket.OPEN */ || this.useHTTP) {
+    if (this.webSocketManager.getReadyState() !== 1 /* WebSocket.OPEN */) {
       const readyState = this.webSocketManager.getReadyState();
-      if (this.useHTTP) {
-        // HTTP mode has no persistent connection to reconnect on — there is
-        // no self-healing path. The browser URL already changed (pushState
-        // fired before sendNavigate was called) and server state is now
-        // permanently out of sync unless the user reloads.
-        this.logger.error(
-          "sendNavigate: HTTP mode does not support in-band navigation; browser URL may be permanently out of sync. " +
-          "Use a full page navigation instead.",
-          { href }
-        );
-      } else if (readyState === 3 /* CLOSED */) {
+      if (readyState === 3 /* CLOSED */) {
         this.logger.error(
           "sendNavigate: WebSocket is CLOSED and autoReconnect may be disabled; " +
           "navigate message dropped. Reload or re-enable autoReconnect.",

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -617,7 +617,15 @@ export class LiveTemplateClient {
           { href }
         );
       } else {
-        this.logger.warn("sendNavigate: not sent (WS not open or HTTP mode); liveUrl updated", { href });
+        // The caller (link-interceptor) already pushed history state, so the
+        // browser URL reflects the new href. The navigate message could not
+        // be sent, but liveUrl was updated above, so the next WebSocket
+        // reconnect will arrive at the correct state — the URL/state desync
+        // is temporary and self-healing when autoReconnect is enabled.
+        this.logger.warn(
+          "sendNavigate: not sent (WS not open or HTTP mode); browser URL may be ahead of server state until reconnect",
+          { href }
+        );
       }
       return;
     }

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -963,7 +963,30 @@ export class LiveTemplateClient {
       );
     }
 
-    tempWrapper.innerHTML = result.html;
+    // Use DOMParser when the HTML contains <script> tags. Browsers'
+    // innerHTML parser handles scripts specially and can create phantom
+    // duplicate DOM nodes after the closing tag. DOMParser doesn't have
+    // this quirk because it returns a standalone document.
+    if (result.html.includes("<scr" + "ipt")) {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(
+        "<div>" + result.html + "</div>",
+        "text/html"
+      );
+      const root = doc.body.firstElementChild;
+      if (root) {
+        while (tempWrapper.firstChild) {
+          tempWrapper.removeChild(tempWrapper.firstChild);
+        }
+        while (root.firstChild) {
+          tempWrapper.appendChild(root.firstChild);
+        }
+      } else {
+        tempWrapper.innerHTML = result.html;
+      }
+    } else {
+      tempWrapper.innerHTML = result.html;
+    }
 
     if (this.logger.isDebugEnabled()) {
       this.logger.debug(

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -201,7 +201,7 @@ export class LiveTemplateClient {
     this.linkInterceptor = new LinkInterceptor(
       {
         getWrapperElement: () => this.wrapperElement,
-        handleNavigationResponse: (html: string) => this.handleNavigationResponse(html),
+        handleNavigationResponse: (html: string, href: string) => this.handleNavigationResponse(html, href),
         sendNavigate: (href: string) => this.sendNavigate(href),
       },
       this.logger.child("LinkInterceptor")
@@ -685,7 +685,7 @@ export class LiveTemplateClient {
    * (done in LinkInterceptor.navigate) so the WebSocket connects to
    * the correct handler.
    */
-  private handleNavigationResponse(html: string): void {
+  private handleNavigationResponse(html: string, href: string): void {
     if (!this.wrapperElement) return;
 
     const parser = new DOMParser();
@@ -722,7 +722,10 @@ export class LiveTemplateClient {
       // same-handler nav we throw it away — the server-authored tree
       // update is the source of truth and will overwrite any local DOM
       // differences via morphdom.
-      this.sendNavigate(window.location.href);
+      // Use the original navigation target href rather than re-reading
+      // window.location.href — avoids a subtle race where another
+      // navigation could change the location between pushState and here.
+      this.sendNavigate(href);
       return;
     }
 
@@ -967,10 +970,19 @@ export class LiveTemplateClient {
     // innerHTML parser handles scripts specially and can create phantom
     // duplicate DOM nodes after the closing tag. DOMParser doesn't have
     // this quirk because it returns a standalone document.
-    if (result.html.includes("<scr" + "ipt")) {
+    //
+    // Case-insensitive check: HTML tag names are case-insensitive, so
+    // <SCRIPT> or <Script> must also route through DOMParser.
+    //
+    // Wrap with the same tagName as the target element (not a hard-coded
+    // <div>) so that DOMParser applies the correct HTML parsing rules.
+    // Wrapping <tr>/<td>/<option> content in a <div> can trigger
+    // browser re-parenting; using the real container tag avoids that.
+    if (result.html.toLowerCase().includes("<script")) {
+      const wrapTag = element.tagName.toLowerCase();
       const parser = new DOMParser();
       const doc = parser.parseFromString(
-        "<div>" + result.html + "</div>",
+        `<${wrapTag}>${result.html}</${wrapTag}>`,
         "text/html"
       );
       const root = doc.body.firstElementChild;
@@ -1064,6 +1076,16 @@ export class LiveTemplateClient {
           const toElement = toEl as Element;
           for (let i = 0; i < fromAttrs.length; i++) {
             const attr = fromAttrs[i];
+            // Skip the preserve control attributes themselves so the
+            // server can opt elements in/out across renders. If we
+            // copied lvt-preserve-attrs back onto toEl, the server
+            // could never remove the attribute in a future update.
+            if (
+              attr.name === "lvt-preserve" ||
+              attr.name === "lvt-preserve-attrs"
+            ) {
+              continue;
+            }
             if (!toElement.hasAttribute(attr.name)) {
               toElement.setAttribute(attr.name, attr.value);
             }

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -201,7 +201,7 @@ export class LiveTemplateClient {
     this.linkInterceptor = new LinkInterceptor(
       {
         getWrapperElement: () => this.wrapperElement,
-        handleNavigationResponse: (html: string, href: string) => this.handleNavigationResponse(html, href),
+        handleNavigationResponse: (html: string, href: string, prePushPathname: string) => this.handleNavigationResponse(html, href, prePushPathname),
         sendNavigate: (href: string) => this.sendNavigate(href),
       },
       this.logger.child("LinkInterceptor")
@@ -685,7 +685,7 @@ export class LiveTemplateClient {
    * (done in LinkInterceptor.navigate) so the WebSocket connects to
    * the correct handler.
    */
-  private handleNavigationResponse(html: string, href: string): void {
+  private handleNavigationResponse(html: string, href: string, prePushPathname: string): void {
     if (!this.wrapperElement) return;
 
     const parser = new DOMParser();
@@ -706,27 +706,29 @@ export class LiveTemplateClient {
       : null;
 
     if (sameWrapper) {
-      // Same-handler navigation = query-param change on the same path.
-      // Instead of replacing the whole DOM (which would require a full
-      // WebSocket reconnect to keep server state in sync — the former
-      // behaviour silently dropped the second part and caused stale
-      // state bugs like devbox-dash's "always shows the second session"
-      // regression), we send an in-band navigate message over the
-      // existing WebSocket. The server's event loop intercepts the
-      // reserved __navigate__ action, re-runs Mount with the new query
-      // params, and pushes a tree update back — which the normal
-      // WebSocket message handler applies via morphdom. No reconnect,
-      // no DOM churn, no stale state.
+      // In-band navigate is only correct when the PATHNAME is unchanged.
+      // sendNavigate ships only query-param data to the server, which
+      // re-runs Mount on the existing route. If two different paths share
+      // the same handler ID, calling sendNavigate for a path change would
+      // silently discard the new path and re-run Mount on the wrong route.
       //
-      // We've already parsed the fetched HTML above, but for
-      // same-handler nav we throw it away — the server-authored tree
-      // update is the source of truth and will overwrite any local DOM
-      // differences via morphdom.
-      // Use the original navigation target href rather than re-reading
-      // window.location.href — avoids a subtle race where another
-      // navigation could change the location between pushState and here.
-      this.sendNavigate(href);
-      return;
+      // prePushPathname is the pathname captured BEFORE history.pushState
+      // was called, so it reliably reflects the original route even though
+      // window.location has already been updated by the time we arrive here.
+      //
+      // When the pathname IS the same (query-string-only change), the
+      // in-band navigate avoids a full WebSocket reconnect — no DOM churn,
+      // no stale-state risk from reconnect races.
+      //
+      // When the pathname changed, fall through to the cross-handler
+      // reconnect path below, which handles same-ID same-handler
+      // (different path) the same as a genuine handler switch.
+      const targetPathname = new URL(href, window.location.origin).pathname;
+      if (targetPathname === prePushPathname) {
+        this.sendNavigate(href);
+        return;
+      }
+      // Pathname changed — fall through to reconnect.
     }
 
     // Check for a different handler's wrapper (cross-handler navigation)
@@ -987,12 +989,14 @@ export class LiveTemplateClient {
       );
       const root = doc.body.firstElementChild;
       if (root) {
-        while (tempWrapper.firstChild) {
-          tempWrapper.removeChild(tempWrapper.firstChild);
-        }
-        while (root.firstChild) {
-          tempWrapper.appendChild(root.firstChild);
-        }
+        // Array.from snapshots the live NodeList before replaceChildren
+        // starts moving nodes, keeping iteration stable.
+        //
+        // Note: DOMParser still re-parents bare table-cell content (tr/td
+        // without surrounding table+tbody) even when wrapTag matches.
+        // Slots rendered into table-cell elements with <script> tags are
+        // an edge case; a follow-up can add a full-table wrapper for those.
+        tempWrapper.replaceChildren(...Array.from(root.childNodes));
       } else {
         tempWrapper.innerHTML = result.html;
       }

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -598,21 +598,17 @@ export class LiveTemplateClient {
       data[k] = v;
     });
 
-    // Tentatively update liveUrl — if the send succeeds this stays; if it
-    // fails we revert so liveUrlOverride stays consistent with window.location
-    // (no pushState fired on failure). An inconsistent liveUrlOverride would
-    // cause a future reconnect to land on a URL the browser doesn't show.
-    const previousLiveUrl = this.liveUrlOverride;
     const newLiveUrl = url.pathname + url.search;
-    this.liveUrlOverride = newLiveUrl;
-    this.webSocketManager.setLiveUrl(newLiveUrl);
 
     // __navigate__ is a WebSocket-only in-band action — only call send()
     // when the socket is actually OPEN.
     //
     // Note: this.useHTTP is not checked here because sendNavigate() is only
-    // reachable when canSendNavigate() returns true (i.e. !this.useHTTP),
-    // enforced by LinkInterceptor. Checking useHTTP here would be dead code.
+    // reachable when canSendNavigate() returns true (i.e. !this.useHTTP and
+    // readyState === 1), enforced by LinkInterceptor. Checking useHTTP or
+    // re-checking readyState here would be dead code in the normal call path.
+    // The guard below is a defensive fallback for direct callers that bypass
+    // canSendNavigate().
     if (this.webSocketManager.getReadyState() !== 1 /* WebSocket.OPEN */) {
       const readyState = this.webSocketManager.getReadyState();
       if (readyState === 3 /* CLOSED */) {
@@ -622,18 +618,10 @@ export class LiveTemplateClient {
           { href }
         );
       } else {
-        // WS is CONNECTING (0) or CLOSING (2). liveUrl was updated above.
-        //
-        // autoReconnect defaults to false. If it's disabled and the in-progress
-        // CONNECTING handshake succeeds at the OLD URL, the navigate is
-        // permanently lost (no future reconnect will fire). Treat this as an
-        // error since there may be no recovery path.
-        //
-        // With autoReconnect enabled the next reconnect recovers correctly, so
-        // warn is appropriate in that case.
+        // CONNECTING (0) or CLOSING (2). autoReconnect defaults to false.
         if (!this.options.autoReconnect) {
           this.logger.error(
-            "sendNavigate: WS not open and autoReconnect is disabled; navigate may be permanently lost if handshake completes at old URL",
+            "sendNavigate: WS not open and autoReconnect is disabled; navigate may be permanently lost",
             { href, readyState }
           );
         } else {
@@ -643,15 +631,15 @@ export class LiveTemplateClient {
           );
         }
       }
-      // Revert: browser URL won't change (no pushState on failure), so keep
-      // liveUrlOverride consistent with window.location to avoid a future
-      // reconnect landing on a URL the browser does not display.
-      this.liveUrlOverride = previousLiveUrl;
-      const revertUrl = previousLiveUrl ?? this.options.liveUrl ?? "/live";
-      this.webSocketManager.setLiveUrl(revertUrl);
       return false;
     }
 
+    // Socket is OPEN: commit the URL update and send the navigate message.
+    // liveUrlOverride is updated here (not before the guard) so it only
+    // advances when the message is actually sent — keeping it consistent
+    // with window.location throughout.
+    this.liveUrlOverride = newLiveUrl;
+    this.webSocketManager.setLiveUrl(newLiveUrl);
     this.logger.debug("sendNavigate", { href, data });
     this.send({ action: "__navigate__", data });
     return true;

--- a/tests/conditional-slot-transition.test.ts
+++ b/tests/conditional-slot-transition.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression test for the conditional-slot structural transition bug.
+ *
+ * When a template slot transitions from an empty string ("") to a
+ * sub-tree with its own statics ({"0":"text","s":["<mark>","</mark>"]}),
+ * the rendered HTML must include the statics. Before the fix, the
+ * client's tree renderer silently dropped the transition and the DOM
+ * never showed the <mark> tag.
+ *
+ * This test operates at the TreeRenderer level (no morphdom, no
+ * WebSocket) to isolate the reconstruction bug from the DOM-patching
+ * layer.
+ */
+
+import { LiveTemplateClient } from "../livetemplate-client";
+
+describe("conditional slot structural transition", () => {
+  let client: LiveTemplateClient;
+
+  beforeEach(() => {
+    client = new LiveTemplateClient();
+  });
+
+  it("slot transitioning from empty string to sub-tree with statics renders the statics", () => {
+    // Initial tree: slot 1 is a simple empty string (the {{if .Error}}
+    // block evaluated to false on the first render).
+    const initialTree = {
+      s: ["<p>status: ", " error: ", "</p>"],
+      0: "ok",
+      1: "",
+    };
+    const r1 = client.applyUpdate(initialTree);
+    expect(r1.html).toContain("status: ok");
+    expect(r1.html).not.toContain("<mark>");
+
+    // Update: slot 1 transitions from "" to a sub-tree with statics
+    // (the {{if .Error}} block now evaluates to true, emitting a
+    // <mark> wrapper around the error text).
+    const update = {
+      1: {
+        s: [" — <mark>", "</mark>"],
+        0: "something broke",
+      },
+    };
+    const r2 = client.applyUpdate(update);
+
+    // The rendered HTML MUST include the <mark> tag from the sub-tree's
+    // statics. Before the fix, r2.html was "<p>status: ok error: </p>"
+    // — the sub-tree was silently dropped.
+    expect(r2.html).toContain("<mark>");
+    expect(r2.html).toContain("something broke");
+    expect(r2.html).toContain("</mark>");
+    // Full expected: "<p>status: ok error:  — <mark>something broke</mark></p>"
+    expect(r2.html).toContain(" — <mark>something broke</mark>");
+  });
+
+  it("slot transitioning from sub-tree back to empty string removes the statics", () => {
+    // Start with the sub-tree present.
+    const initialTree = {
+      s: ["<p>status: ", " error: ", "</p>"],
+      0: "ok",
+      1: {
+        s: [" — <mark>", "</mark>"],
+        0: "something broke",
+      },
+    };
+    const r1 = client.applyUpdate(initialTree);
+    expect(r1.html).toContain("<mark>something broke</mark>");
+
+    // Update: error clears, slot 1 goes back to empty string.
+    const update = { 1: "" };
+    const r2 = client.applyUpdate(update);
+
+    expect(r2.html).not.toContain("<mark>");
+    expect(r2.html).not.toContain("something broke");
+  });
+
+  it("multiple transitions back and forth work correctly", () => {
+    const initialTree = {
+      s: ["<div>", "</div>"],
+      0: "",
+    };
+    client.applyUpdate(initialTree);
+
+    // Empty → sub-tree
+    const r1 = client.applyUpdate({
+      0: { s: ["<b>", "</b>"], 0: "bold" },
+    });
+    expect(r1.html).toContain("<b>bold</b>");
+
+    // Sub-tree → different sub-tree
+    const r2 = client.applyUpdate({
+      0: { s: ["<em>", "</em>"], 0: "italic" },
+    });
+    expect(r2.html).toContain("<em>italic</em>");
+    expect(r2.html).not.toContain("<b>");
+
+    // Sub-tree → empty
+    const r3 = client.applyUpdate({ 0: "" });
+    expect(r3.html).not.toContain("<em>");
+    expect(r3.html).not.toContain("<b>");
+
+    // Empty → sub-tree again
+    const r4 = client.applyUpdate({
+      0: { s: ["<b>", "</b>"], 0: "back" },
+    });
+    expect(r4.html).toContain("<b>back</b>");
+  });
+});

--- a/tests/navigate.test.ts
+++ b/tests/navigate.test.ts
@@ -224,4 +224,27 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
 
     httpInterceptor.teardownForWrapper(wrapper.getAttribute("data-lvt-id"));
   });
+
+  it("hash-only popstate (same pathname + same search) does not trigger sendNavigate or fetch", async () => {
+    // Regression: the popstate listener calls navigate() directly, bypassing
+    // shouldSkip(). Without an explicit sameSearch guard in navigate(), a
+    // popstate to the same pathname+search with a different hash (e.g.
+    // /claude?s=initial → /claude?s=initial#section) would fire sendNavigate
+    // with data={} — a spurious server-side Mount re-run with no query change.
+    //
+    // Push a hash anchor so window.location changes to the hash URL.
+    history.pushState(null, "", "/claude?s=initial#section");
+    expect(window.location.search).toBe("?s=initial"); // search unchanged
+
+    // Dispatch popstate as the browser would on back/forward navigation.
+    window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    await Promise.resolve();
+
+    // No sendNavigate (hash-only, no search change) and no fetch.
+    expect(sendNavigateSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Restore location for other tests.
+    history.replaceState(null, "", "/claude?s=initial");
+  });
 });

--- a/tests/navigate.test.ts
+++ b/tests/navigate.test.ts
@@ -36,7 +36,7 @@ const silentLogger: Logger = {
 describe("LinkInterceptor same-pathname navigate bypass", () => {
   let wrapper: HTMLElement;
   let sendNavigateSpy: jest.Mock<void, [string]>;
-  let handleNavigationResponseSpy: jest.Mock<void, [string, string]>;
+  let handleNavigationResponseSpy: jest.Mock<void, [string]>;
   let fetchMock: jest.SpyInstance;
   let interceptor: LinkInterceptor;
 

--- a/tests/navigate.test.ts
+++ b/tests/navigate.test.ts
@@ -36,7 +36,7 @@ const silentLogger: Logger = {
 describe("LinkInterceptor same-pathname navigate bypass", () => {
   let wrapper: HTMLElement;
   let sendNavigateSpy: jest.Mock<void, [string]>;
-  let handleNavigationResponseSpy: jest.Mock<void, [string, string]>;
+  let handleNavigationResponseSpy: jest.Mock<void, [string, string, string]>;
   let fetchMock: jest.SpyInstance;
   let interceptor: LinkInterceptor;
 

--- a/tests/navigate.test.ts
+++ b/tests/navigate.test.ts
@@ -36,9 +36,8 @@ const silentLogger: Logger = {
 describe("LinkInterceptor same-pathname navigate bypass", () => {
   let wrapper: HTMLElement;
   let sendNavigateSpy: jest.Mock<void, [string]>;
-  let handleNavigationResponseSpy: jest.Mock<void, [string]>;
-  let fetchMock: jest.Mock;
-  let originalFetch: typeof fetch | undefined;
+  let handleNavigationResponseSpy: jest.Mock<void, [string, string]>;
+  let fetchMock: jest.SpyInstance;
   let interceptor: LinkInterceptor;
 
   beforeEach(() => {
@@ -49,13 +48,17 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
 
     sendNavigateSpy = jest.fn();
     handleNavigationResponseSpy = jest.fn();
-    // jsdom doesn't ship a global fetch, so install a mock directly
-    // and restore whatever was there (usually undefined) on teardown.
-    fetchMock = jest.fn(() =>
-      Promise.resolve(new Response("<html></html>", { status: 200 }))
-    );
-    originalFetch = (globalThis as any).fetch;
-    (globalThis as any).fetch = fetchMock;
+    // jsdom doesn't ship a global fetch; define a no-op stub so jest.spyOn
+    // has something to wrap. jest.restoreAllMocks() in afterEach then cleans
+    // up the spy automatically, even if beforeEach throws after this point.
+    if (typeof (globalThis as any).fetch !== "function") {
+      (globalThis as any).fetch = () => {};
+    }
+    fetchMock = jest
+      .spyOn(globalThis as any, "fetch")
+      .mockImplementation(() =>
+        Promise.resolve(new Response("<html></html>", { status: 200 }))
+      );
 
     const ctx: LinkInterceptorContext = {
       getWrapperElement: () => wrapper,
@@ -72,7 +75,7 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
   });
 
   afterEach(() => {
-    (globalThis as any).fetch = originalFetch;
+    jest.restoreAllMocks();
     // Tear down any listeners the interceptor added to document.
     interceptor.teardownForWrapper(wrapper.getAttribute("data-lvt-id"));
   });
@@ -131,6 +134,46 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
     expect(sendNavigateSpy).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
     expect(handleNavigationResponseSpy).not.toHaveBeenCalled();
+  });
+
+  it("same-pathname click aborts any in-flight cross-path fetch", async () => {
+    // Regression: if a cross-path fetch is in flight and the user then
+    // clicks a same-pathname link, the earlier fetch must be aborted so
+    // it cannot later call handleNavigationResponse and race with the
+    // in-band __navigate__ update.
+
+    // First, initiate a cross-path fetch that never resolves until aborted.
+    let capturedSignal: AbortSignal | null = null;
+    fetchMock.mockImplementation((_url: string, opts: RequestInit) => {
+      capturedSignal = opts.signal as AbortSignal;
+      // Never resolve — the test controls when this settles via the signal.
+      return new Promise((_resolve, _reject) => {
+        opts.signal?.addEventListener("abort", () => {
+          _reject(new DOMException("AbortError", "AbortError"));
+        });
+      });
+    });
+
+    const crossPathLink = document.createElement("a");
+    crossPathLink.href = "/other-page?x=1";
+    wrapper.appendChild(crossPathLink);
+    crossPathLink.click();
+    await Promise.resolve();
+
+    // Cross-path click should have started a fetch and captured the signal.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(capturedSignal).not.toBeNull();
+    expect((capturedSignal as unknown as AbortSignal).aborted).toBe(false);
+
+    // Now click a same-pathname link — this must abort the in-flight fetch.
+    const samePathLink = document.createElement("a");
+    samePathLink.href = "/claude?s=fast-nav";
+    wrapper.appendChild(samePathLink);
+    samePathLink.click();
+    await Promise.resolve();
+
+    expect(sendNavigateSpy).toHaveBeenCalledTimes(1);
+    expect((capturedSignal as unknown as AbortSignal).aborted).toBe(true);
   });
 
   it("same-pathname with no query string still sends navigate (empty data)", async () => {

--- a/tests/navigate.test.ts
+++ b/tests/navigate.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for in-band navigate message (same-handler SPA navigation).
+ *
+ * Same-pathname link clicks must bypass fetch() entirely and send a
+ * {action: "__navigate__", data: <query params>} message over the
+ * existing WebSocket. The server's event loop special-cases this
+ * action name to re-run Mount with the new query data without
+ * tearing down the connection — the in-band equivalent of Phoenix
+ * LiveView's live_patch / handle_params.
+ *
+ * The regression these tests guard against is the devbox-dash bug
+ * where clicking between same-handler variants (/claude?s=A vs
+ * /claude?s=B) would swap DOM but leave the server's per-connection
+ * state pinned to the original query params, so the next server-driven
+ * refresh clobbered the DOM with stale content.
+ */
+
+import { LinkInterceptor, LinkInterceptorContext } from "../dom/link-interceptor";
+import type { Logger } from "../utils/logger";
+
+// Minimal logger stub — LinkInterceptor uses it only for debug/error logging.
+const silentLogger: Logger = {
+  isDebugEnabled: () => false,
+  isInfoEnabled: () => false,
+  isWarnEnabled: () => true,
+  isErrorEnabled: () => true,
+  child: () => silentLogger,
+  setLevel: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  trace: () => {},
+} as unknown as Logger;
+
+describe("LinkInterceptor same-pathname navigate bypass", () => {
+  let wrapper: HTMLElement;
+  let sendNavigateSpy: jest.Mock<void, [string]>;
+  let handleNavigationResponseSpy: jest.Mock<void, [string]>;
+  let fetchMock: jest.Mock;
+  let originalFetch: typeof fetch | undefined;
+  let interceptor: LinkInterceptor;
+
+  beforeEach(() => {
+    document.body.replaceChildren();
+    wrapper = document.createElement("div");
+    wrapper.setAttribute("data-lvt-id", "nav-test-wrapper");
+    document.body.appendChild(wrapper);
+
+    sendNavigateSpy = jest.fn();
+    handleNavigationResponseSpy = jest.fn();
+    // jsdom doesn't ship a global fetch, so install a mock directly
+    // and restore whatever was there (usually undefined) on teardown.
+    fetchMock = jest.fn(() =>
+      Promise.resolve(new Response("<html></html>", { status: 200 }))
+    );
+    originalFetch = (globalThis as any).fetch;
+    (globalThis as any).fetch = fetchMock;
+
+    const ctx: LinkInterceptorContext = {
+      getWrapperElement: () => wrapper,
+      handleNavigationResponse: handleNavigationResponseSpy,
+      sendNavigate: sendNavigateSpy,
+    };
+    interceptor = new LinkInterceptor(ctx, silentLogger);
+    interceptor.setup(wrapper);
+
+    // Pin the current location so test navigations have something to
+    // compare their pathname against. jsdom defaults to about:blank,
+    // which has no useful pathname.
+    history.replaceState(null, "", "/claude?s=initial");
+  });
+
+  afterEach(() => {
+    (globalThis as any).fetch = originalFetch;
+    // Tear down any listeners the interceptor added to document.
+    interceptor.teardownForWrapper(wrapper.getAttribute("data-lvt-id"));
+  });
+
+  it("same-pathname link click sends navigate message, no fetch", async () => {
+    // Build a link whose href shares the current pathname but has
+    // a different query string.
+    const link = document.createElement("a");
+    link.href = "/claude?s=new-session";
+    link.textContent = "switch";
+    wrapper.appendChild(link);
+
+    // Simulate a real user click.
+    link.click();
+
+    // Give the async navigate path a microtask to run.
+    await Promise.resolve();
+
+    expect(sendNavigateSpy).toHaveBeenCalledTimes(1);
+    expect(sendNavigateSpy.mock.calls[0][0]).toContain("s=new-session");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(handleNavigationResponseSpy).not.toHaveBeenCalled();
+
+    // History state should have been updated so a subsequent
+    // reload picks up the new URL.
+    expect(window.location.search).toBe("?s=new-session");
+  });
+
+  it("different-pathname link click goes through fetch, not navigate", async () => {
+    const link = document.createElement("a");
+    link.href = "/other-page";
+    link.textContent = "other";
+    wrapper.appendChild(link);
+
+    link.click();
+
+    // Give the sync portion of LinkInterceptor.navigate a microtask.
+    // We're only asserting that fetch() was invoked (the key branch
+    // point) and sendNavigate was NOT — not that the post-fetch chain
+    // completed.
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sendNavigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("external-origin link click is not intercepted at all", async () => {
+    const link = document.createElement("a");
+    link.href = "https://example.com/claude?s=foo";
+    link.textContent = "external";
+    wrapper.appendChild(link);
+
+    link.click();
+    await Promise.resolve();
+
+    expect(sendNavigateSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(handleNavigationResponseSpy).not.toHaveBeenCalled();
+  });
+
+  it("same-pathname with no query string still sends navigate (empty data)", async () => {
+    // User clicks a link that drops all query params ("back to list").
+    const link = document.createElement("a");
+    link.href = "/claude";
+    link.textContent = "all sessions";
+    wrapper.appendChild(link);
+
+    link.click();
+    await Promise.resolve();
+
+    expect(sendNavigateSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    // The sendNavigate URL should be /claude (no query).
+    const arg = sendNavigateSpy.mock.calls[0][0];
+    expect(arg).not.toContain("s=");
+  });
+});

--- a/tests/navigate.test.ts
+++ b/tests/navigate.test.ts
@@ -64,6 +64,7 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
       getWrapperElement: () => wrapper,
       handleNavigationResponse: handleNavigationResponseSpy,
       sendNavigate: sendNavigateSpy,
+      canSendNavigate: () => true,
     };
     interceptor = new LinkInterceptor(ctx, silentLogger);
     interceptor.setup(wrapper);
@@ -191,5 +192,36 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
     // The sendNavigate URL should be /claude (no query).
     const arg = sendNavigateSpy.mock.calls[0][0];
     expect(arg).not.toContain("s=");
+  });
+
+  it("HTTP mode: same-pathname click uses fetch, not navigate (canSendNavigate=false)", async () => {
+    // When canSendNavigate() returns false (HTTP mode), the interceptor
+    // must NOT enter the same-pathname fast path, because pushState would
+    // fire before sendNavigate is called and sendNavigate would bail early
+    // — leaving the URL permanently ahead of server state with no WS
+    // reconnect to recover it. The fix: fall through to a normal fetch.
+    interceptor.teardownForWrapper(wrapper.getAttribute("data-lvt-id"));
+
+    const httpCtx: LinkInterceptorContext = {
+      getWrapperElement: () => wrapper,
+      handleNavigationResponse: handleNavigationResponseSpy,
+      sendNavigate: sendNavigateSpy,
+      canSendNavigate: () => false, // HTTP mode
+    };
+    const httpInterceptor = new LinkInterceptor(httpCtx, silentLogger);
+    httpInterceptor.setup(wrapper);
+
+    const link = document.createElement("a");
+    link.href = "/claude?s=new-session";
+    wrapper.appendChild(link);
+
+    link.click();
+    await Promise.resolve();
+
+    // Must use fetch (not sendNavigate) even though pathname matches.
+    expect(sendNavigateSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    httpInterceptor.teardownForWrapper(wrapper.getAttribute("data-lvt-id"));
   });
 });

--- a/tests/navigate.test.ts
+++ b/tests/navigate.test.ts
@@ -36,7 +36,7 @@ const silentLogger: Logger = {
 describe("LinkInterceptor same-pathname navigate bypass", () => {
   let wrapper: HTMLElement;
   let sendNavigateSpy: jest.Mock<void, [string]>;
-  let handleNavigationResponseSpy: jest.Mock<void, [string, string, string]>;
+  let handleNavigationResponseSpy: jest.Mock<void, [string, string]>;
   let fetchMock: jest.SpyInstance;
   let interceptor: LinkInterceptor;
 

--- a/tests/navigate.test.ts
+++ b/tests/navigate.test.ts
@@ -35,7 +35,7 @@ const silentLogger: Logger = {
 
 describe("LinkInterceptor same-pathname navigate bypass", () => {
   let wrapper: HTMLElement;
-  let sendNavigateSpy: jest.Mock<void, [string]>;
+  let sendNavigateSpy: jest.Mock<boolean, [string]>;
   let handleNavigationResponseSpy: jest.Mock<void, [string]>;
   let fetchMock: jest.SpyInstance;
   let interceptor: LinkInterceptor;
@@ -46,7 +46,7 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
     wrapper.setAttribute("data-lvt-id", "nav-test-wrapper");
     document.body.appendChild(wrapper);
 
-    sendNavigateSpy = jest.fn();
+    sendNavigateSpy = jest.fn().mockReturnValue(true);
     handleNavigationResponseSpy = jest.fn();
     // jsdom doesn't ship a global fetch; define a no-op stub so jest.spyOn
     // has something to wrap. jest.restoreAllMocks() in afterEach then cleans

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -21,8 +21,12 @@ describe("handleNavigationResponse", () => {
     document.body.innerHTML = ""; // safe: test cleanup
   });
 
-  const callHandleNavigationResponse = (html: string, href = window.location.href) => {
-    (client as any).handleNavigationResponse(html, href);
+  const callHandleNavigationResponse = (
+    html: string,
+    href = window.location.href,
+    prePushPathname = window.location.pathname
+  ) => {
+    (client as any).handleNavigationResponse(html, href, prePushPathname);
   };
 
   describe("same-handler navigation", () => {
@@ -70,6 +74,47 @@ describe("handleNavigationResponse", () => {
         data: { s: "new-value" },
       });
 
+      sendSpy.mockRestore();
+    });
+
+    it("falls through to reconnect when pathname changed even if handler ID matches", () => {
+      // Regression: two different routes sharing the same data-lvt-id caused
+      // sendNavigate to be called with the new URL, silently discarding the
+      // path change — the server re-ran Mount on the wrong route.
+      // Fix: the sameWrapper branch guards on prePushPathname equality before
+      // calling sendNavigate; mismatched pathname falls through to reconnect.
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+      const connectSpy = jest
+        .spyOn(client as any, "connect")
+        .mockResolvedValue(undefined);
+      const sendSpy = jest.spyOn(client, "send").mockImplementation(() => {});
+
+      const html = [
+        "<html><body>",
+        // Same data-lvt-id, but delivered from a different path.
+        '<div data-lvt-id="lvt-handler-a">',
+        "<p>Content from /route-b</p>",
+        "</div>",
+        "</body></html>",
+      ].join("");
+
+      // Simulate: user was on /route-a, navigated to /route-b (different
+      // path, same handler ID). prePushPathname is the ORIGINAL path.
+      callHandleNavigationResponse(
+        html,
+        "http://localhost/route-b?s=2",
+        "/route-a"
+      );
+
+      // sendNavigate must NOT have been called — that would drop the path.
+      expect(sendSpy).not.toHaveBeenCalled();
+      // Reconnect path must have fired instead.
+      expect(disconnectSpy).toHaveBeenCalled();
+
+      disconnectSpy.mockRestore();
+      connectSpy.mockRestore();
       sendSpy.mockRestore();
     });
 

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -26,7 +26,25 @@ describe("handleNavigationResponse", () => {
   };
 
   describe("same-handler navigation", () => {
-    it("replaces wrapper children when response has same data-lvt-id", () => {
+    // As of the __navigate__ refactor, same-handler navigation does NOT
+    // replace wrapper children from the fetched HTML. Instead it sends
+    // an in-band __navigate__ message to the existing WebSocket; the
+    // server re-runs Mount with the new query params and pushes a tree
+    // update back, which the normal WS message handler morphs into the
+    // DOM. The fetched HTML is discarded for same-handler nav — the
+    // server-authored tree update is the source of truth.
+    //
+    // This avoids the "clicking any session always shows the first one"
+    // bug where DOM was replaced but the server's connSt.state stayed
+    // pinned to the old query params, and the next refresh tick clobbered
+    // the DOM back to the old content.
+    it("sends in-band __navigate__ instead of replacing children", () => {
+      const sendSpy = jest.spyOn(client, "send").mockImplementation(() => {});
+
+      // Point the window at a same-pathname URL with new query params so
+      // the client's sendNavigate() call picks them up.
+      history.replaceState(null, "", "/handler-a?s=new-value");
+
       const html = [
         "<html><head><title>Same Page</title></head><body>",
         '<div data-lvt-id="lvt-handler-a">',
@@ -37,12 +55,28 @@ describe("handleNavigationResponse", () => {
 
       callHandleNavigationResponse(html);
 
-      expect(wrapper.textContent).toContain("Updated content from same handler");
+      // Wrapper content should NOT have been replaced from the fetched HTML.
+      expect(wrapper.textContent).toContain("Handler A content");
+      expect(wrapper.textContent).not.toContain("Updated content from same handler");
+      // Wrapper identity unchanged.
       expect(wrapper.getAttribute("data-lvt-id")).toBe("lvt-handler-a");
+
+      // The client should have sent a __navigate__ message with the
+      // current URL's query params as data.
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const sent = sendSpy.mock.calls[0][0];
+      expect(sent).toMatchObject({
+        action: "__navigate__",
+        data: { s: "new-value" },
+      });
+
+      sendSpy.mockRestore();
     });
 
     it("preserves wrapper element identity", () => {
       const originalWrapper = wrapper;
+      const sendSpy = jest.spyOn(client, "send").mockImplementation(() => {});
+
       const html = [
         "<html><body>",
         '<div data-lvt-id="lvt-handler-a">',
@@ -54,6 +88,7 @@ describe("handleNavigationResponse", () => {
       callHandleNavigationResponse(html);
 
       expect((client as any).wrapperElement).toBe(originalWrapper);
+      sendSpy.mockRestore();
     });
   });
 

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -21,68 +21,25 @@ describe("handleNavigationResponse", () => {
     document.body.innerHTML = ""; // safe: test cleanup
   });
 
-  const callHandleNavigationResponse = (
-    html: string,
-    href = window.location.href,
-    prePushPathname = window.location.pathname
-  ) => {
-    (client as any).handleNavigationResponse(html, href, prePushPathname);
+  const callHandleNavigationResponse = (html: string, href = window.location.href) => {
+    (client as any).handleNavigationResponse(html, href);
   };
 
   describe("same-handler navigation", () => {
-    // As of the __navigate__ refactor, same-handler navigation does NOT
-    // replace wrapper children from the fetched HTML. Instead it sends
-    // an in-band __navigate__ message to the existing WebSocket; the
-    // server re-runs Mount with the new query params and pushes a tree
-    // update back, which the normal WS message handler morphs into the
-    // DOM. The fetched HTML is discarded for same-handler nav — the
-    // server-authored tree update is the source of truth.
+    // handleNavigationResponse is only reachable via LinkInterceptor for
+    // cross-pathname fetches. Same-pathname navigations (query-param change
+    // on the same route) are caught by the fast path in link-interceptor.ts
+    // and handled via sendNavigate() directly — no fetch, no call here.
     //
-    // This avoids the "clicking any session always shows the first one"
-    // bug where DOM was replaced but the server's connSt.state stayed
-    // pinned to the old query params, and the next refresh tick clobbered
-    // the DOM back to the old content.
-    it("sends in-band __navigate__ instead of replacing children", () => {
-      const sendSpy = jest.spyOn(client, "send").mockImplementation(() => {});
+    // When handleNavigationResponse receives a same-handler-ID response
+    // from a cross-pathname fetch, it falls through to the reconnect path
+    // (same as a genuine handler switch). The in-band __navigate__ path for
+    // same-pathname navigation is covered in navigate.test.ts.
 
-      // Point the window at a same-pathname URL with new query params so
-      // the client's sendNavigate() call picks them up.
-      history.replaceState(null, "", "/handler-a?s=new-value");
-
-      const html = [
-        "<html><head><title>Same Page</title></head><body>",
-        '<div data-lvt-id="lvt-handler-a">',
-        "<p>Updated content from same handler</p>",
-        "</div>",
-        "</body></html>",
-      ].join("");
-
-      callHandleNavigationResponse(html);
-
-      // Wrapper content should NOT have been replaced from the fetched HTML.
-      expect(wrapper.textContent).toContain("Handler A content");
-      expect(wrapper.textContent).not.toContain("Updated content from same handler");
-      // Wrapper identity unchanged.
-      expect(wrapper.getAttribute("data-lvt-id")).toBe("lvt-handler-a");
-
-      // The client should have sent a __navigate__ message with the
-      // current URL's query params as data.
-      expect(sendSpy).toHaveBeenCalledTimes(1);
-      const sent = sendSpy.mock.calls[0][0];
-      expect(sent).toMatchObject({
-        action: "__navigate__",
-        data: { s: "new-value" },
-      });
-
-      sendSpy.mockRestore();
-    });
-
-    it("falls through to reconnect when pathname changed even if handler ID matches", () => {
-      // Regression: two different routes sharing the same data-lvt-id caused
-      // sendNavigate to be called with the new URL, silently discarding the
-      // path change — the server re-ran Mount on the wrong route.
-      // Fix: the sameWrapper branch guards on prePushPathname equality before
-      // calling sendNavigate; mismatched pathname falls through to reconnect.
+    it("same-handler ID match from cross-path fetch triggers reconnect (not sendNavigate)", () => {
+      // Regression guard: two different routes sharing the same data-lvt-id
+      // must NOT call sendNavigate (which only ships query params, silently
+      // dropping the path change). The correct behaviour is a full reconnect.
       const disconnectSpy = jest
         .spyOn(client, "disconnect")
         .mockImplementation(() => {});
@@ -93,20 +50,13 @@ describe("handleNavigationResponse", () => {
 
       const html = [
         "<html><body>",
-        // Same data-lvt-id, but delivered from a different path.
         '<div data-lvt-id="lvt-handler-a">',
         "<p>Content from /route-b</p>",
         "</div>",
         "</body></html>",
       ].join("");
 
-      // Simulate: user was on /route-a, navigated to /route-b (different
-      // path, same handler ID). prePushPathname is the ORIGINAL path.
-      callHandleNavigationResponse(
-        html,
-        "http://localhost/route-b?s=2",
-        "/route-a"
-      );
+      callHandleNavigationResponse(html, "http://localhost/route-b?s=2");
 
       // sendNavigate must NOT have been called — that would drop the path.
       expect(sendSpy).not.toHaveBeenCalled();

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -21,8 +21,8 @@ describe("handleNavigationResponse", () => {
     document.body.innerHTML = ""; // safe: test cleanup
   });
 
-  const callHandleNavigationResponse = (html: string) => {
-    (client as any).handleNavigationResponse(html);
+  const callHandleNavigationResponse = (html: string, href = window.location.href) => {
+    (client as any).handleNavigationResponse(html, href);
   };
 
   describe("same-handler navigation", () => {

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -21,8 +21,8 @@ describe("handleNavigationResponse", () => {
     document.body.innerHTML = ""; // safe: test cleanup
   });
 
-  const callHandleNavigationResponse = (html: string, href = window.location.href) => {
-    (client as any).handleNavigationResponse(html, href);
+  const callHandleNavigationResponse = (html: string) => {
+    (client as any).handleNavigationResponse(html);
   };
 
   describe("same-handler navigation", () => {
@@ -56,7 +56,7 @@ describe("handleNavigationResponse", () => {
         "</body></html>",
       ].join("");
 
-      callHandleNavigationResponse(html, "http://localhost/route-b?s=2");
+      callHandleNavigationResponse(html);
 
       // sendNavigate must NOT have been called — that would drop the path.
       expect(sendSpy).not.toHaveBeenCalled();

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -1,0 +1,163 @@
+/**
+ * lvt-preserve attribute tests.
+ *
+ * lvt-preserve tells the morphdom diff engine "don't touch this element".
+ * It's the generic escape hatch for interactive elements whose state
+ * lives on the client side — <details open>, <dialog open>, checkbox
+ * state, scroll positions, third-party widgets, etc. Without it, any
+ * server-driven update that doesn't include the client-managed state
+ * clobbers it on the next diff cycle.
+ *
+ * Equivalent attributes in other frameworks:
+ *   - Phoenix LiveView: phx-update="ignore"
+ *   - Hotwire Turbo:    data-turbo-permanent
+ *   - HTMX:             hx-preserve="true"
+ */
+
+import { LiveTemplateClient } from "../livetemplate-client";
+
+describe("lvt-preserve attribute", () => {
+  let client: LiveTemplateClient;
+  let wrapper: HTMLElement;
+
+  beforeEach(() => {
+    client = new LiveTemplateClient();
+
+    // Minimal LiveTemplate-style wrapper the updateDOM path expects.
+    // Built via createElement so no innerHTML is needed in the test setup.
+    document.body.replaceChildren();
+    wrapper = document.createElement("div");
+    wrapper.setAttribute("data-lvt-id", "test-preserve");
+    document.body.appendChild(wrapper);
+  });
+
+  it("preserves an element's open attribute across updates", () => {
+    const initialTree = {
+      s: [
+        `<details lvt-preserve class="picker"><summary>Sessions</summary><div class="list">`,
+        `</div></details>`,
+      ],
+      0: "one two",
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const details = wrapper.querySelector("details") as HTMLDetailsElement;
+    expect(details).not.toBeNull();
+    expect(details.open).toBe(false);
+
+    // Simulate the user tapping the summary to expand the details.
+    details.setAttribute("open", "");
+    expect(details.open).toBe(true);
+
+    // Apply an update that does NOT contain the open attribute. Without
+    // lvt-preserve, morphdom would diff the incoming <details> against
+    // the DOM and remove the open attribute to match the server.
+    const updateTree = { 0: "one two three" };
+    client.updateDOM(wrapper, updateTree);
+
+    const detailsAfter = wrapper.querySelector(
+      "details"
+    ) as HTMLDetailsElement;
+    expect(detailsAfter).not.toBeNull();
+    expect(detailsAfter.open).toBe(true);
+  });
+
+  it("does not preserve elements without lvt-preserve (control)", () => {
+    // Same shape, no lvt-preserve. Verify the open state IS clobbered
+    // here — confirming the preservation guarantee in the test above
+    // is actually doing work and not just always passing.
+    const initialTree = {
+      s: [
+        `<details class="picker"><summary>Sessions</summary><div class="list">`,
+        `</div></details>`,
+      ],
+      0: "one two",
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const details = wrapper.querySelector("details") as HTMLDetailsElement;
+    details.setAttribute("open", "");
+    expect(details.open).toBe(true);
+
+    const updateTree = { 0: "one two three" };
+    client.updateDOM(wrapper, updateTree);
+
+    const detailsAfter = wrapper.querySelector(
+      "details"
+    ) as HTMLDetailsElement;
+    // Without lvt-preserve, morphdom diff removes the user's open attr.
+    expect(detailsAfter.open).toBe(false);
+  });
+
+  it("lvt-preserve-attrs keeps own attributes but still diffs children", () => {
+    // This is the subtler "collapsible picker" case: the <details>
+    // element's `open` attribute is user-toggled and must survive
+    // server updates, but the <a> cards inside ARE server-authored
+    // and their state (e.g. the `current` class marker for the
+    // selected item) must reflect the latest tree.
+    const initialTree = {
+      s: [
+        `<details lvt-preserve-attrs class="picker"><summary>Pick</summary>`,
+        `</details>`,
+      ],
+      0: `<a class="card">one</a><a class="card">two</a>`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const details = wrapper.querySelector("details") as HTMLDetailsElement;
+    expect(details).not.toBeNull();
+    expect(details.open).toBe(false);
+
+    // User opens the picker.
+    details.setAttribute("open", "");
+    expect(details.open).toBe(true);
+
+    // Server pushes an update where "two" is now the current card.
+    const updateTree = {
+      0: `<a class="card">one</a><a class="card current">two</a>`,
+    };
+    client.updateDOM(wrapper, updateTree);
+
+    const detailsAfter = wrapper.querySelector(
+      "details"
+    ) as HTMLDetailsElement;
+    // User's open state preserved.
+    expect(detailsAfter.open).toBe(true);
+    // But the children DID update — the second card now has "current".
+    const cards = wrapper.querySelectorAll("a.card");
+    expect(cards.length).toBe(2);
+    expect((cards[0] as HTMLElement).classList.contains("current")).toBe(false);
+    expect((cards[1] as HTMLElement).classList.contains("current")).toBe(true);
+  });
+
+  it("preserves the element's children as well", () => {
+    // lvt-preserve is a full-element bail-out: attributes, children,
+    // everything stays as-is. Useful for third-party widgets that
+    // mutate their own DOM.
+    const initialTree = {
+      s: [`<div lvt-preserve class="widget">`, `</div>`],
+      0: "initial content",
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const widget = wrapper.querySelector(".widget") as HTMLElement;
+    expect(widget.textContent).toBe("initial content");
+
+    // Simulate a third-party widget mutating its own children via
+    // safe DOM methods (the livetemplate contract applies regardless
+    // of how the client-side mutation happened).
+    widget.replaceChildren();
+    const span = document.createElement("span");
+    span.textContent = "widget-modified";
+    widget.appendChild(span);
+
+    // Server sends an update that would otherwise replace the content.
+    const updateTree = { 0: "server-updated content" };
+    client.updateDOM(wrapper, updateTree);
+
+    const widgetAfter = wrapper.querySelector(".widget") as HTMLElement;
+    // The widget's own mutation survives — morphdom never touched it.
+    expect(widgetAfter.textContent).toBe("widget-modified");
+    expect(widgetAfter.querySelector("span")).not.toBeNull();
+  });
+});

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -130,6 +130,36 @@ describe("lvt-preserve attribute", () => {
     expect((cards[1] as HTMLElement).classList.contains("current")).toBe(true);
   });
 
+  it("server can remove lvt-preserve by omitting it in the next full template", () => {
+    // lvt-preserve is checked on toEl (the incoming server version), not
+    // fromEl (the current DOM). This means the server retains authority:
+    // a later render that omits lvt-preserve lets morphdom resume updating
+    // the element. Checking fromEl would make the attribute sticky forever.
+    const initialTree = {
+      s: [`<div lvt-preserve class="widget">`, `</div>`],
+      0: "server-initial",
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const widget = wrapper.querySelector(".widget") as HTMLElement;
+    // Simulate the widget mutating its own DOM.
+    widget.textContent = "client-modified";
+
+    // Server sends a NEW template that removes lvt-preserve.
+    const removedTree = {
+      s: [`<div class="widget">`, `</div>`],
+      0: "server-updated",
+    };
+    client.updateDOM(wrapper, removedTree);
+
+    // Now that lvt-preserve is gone from the template, morphdom should
+    // have applied the server's update, overwriting the client state.
+    const widgetAfter = wrapper.querySelector(".widget") as HTMLElement;
+    expect(widgetAfter).not.toBeNull();
+    expect(widgetAfter.textContent).toBe("server-updated");
+    expect(widgetAfter.hasAttribute("lvt-preserve")).toBe(false);
+  });
+
   it("server can remove lvt-preserve-attrs by omitting it in a later update", () => {
     // The attribute-copy loop must NOT copy the lvt-preserve-attrs control
     // attribute itself back onto toEl. If it did, the server could never

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -130,6 +130,40 @@ describe("lvt-preserve attribute", () => {
     expect((cards[1] as HTMLElement).classList.contains("current")).toBe(true);
   });
 
+  it("server can remove lvt-preserve-attrs by omitting it in a later update", () => {
+    // The attribute-copy loop must NOT copy the lvt-preserve-attrs control
+    // attribute itself back onto toEl. If it did, the server could never
+    // remove the attribute in a future render (it would always be re-added
+    // by the copy loop before morphdom sees the diff).
+    const initialTree = {
+      s: [
+        `<details lvt-preserve-attrs class="picker"><summary>Pick</summary>`,
+        `</details>`,
+      ],
+      0: `<a class="card">item</a>`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const details = wrapper.querySelector("details") as HTMLDetailsElement;
+    expect(details.hasAttribute("lvt-preserve-attrs")).toBe(true);
+
+    // Server pushes an update WITHOUT lvt-preserve-attrs — it is opting
+    // the element back out of attribute preservation.
+    const updateTree = {
+      s: [
+        `<details class="picker"><summary>Pick</summary>`,
+        `</details>`,
+      ],
+      0: `<a class="card">item</a>`,
+    };
+    client.updateDOM(wrapper, updateTree);
+
+    const detailsAfter = wrapper.querySelector("details") as HTMLDetailsElement;
+    expect(detailsAfter).not.toBeNull();
+    // The control attribute must be gone — the server has opted out.
+    expect(detailsAfter.hasAttribute("lvt-preserve-attrs")).toBe(false);
+  });
+
   it("preserves the element's children as well", () => {
     // lvt-preserve is a full-element bail-out: attributes, children,
     // everything stays as-is. Useful for third-party widgets that

--- a/tests/script-duplication.test.ts
+++ b/tests/script-duplication.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression test for the inline <script> content duplication bug.
+ *
+ * When the reconstructed HTML contains an inline <script> tag and
+ * updateDOM sets tempWrapper.innerHTML, browsers parse the script
+ * content specially and can create phantom duplicate DOM nodes after
+ * the script boundary. morphdom then sees doubled elements and
+ * patches them into the live DOM.
+ *
+ * This test operates at the updateDOM level (tree + morphdom) to
+ * reproduce the exact conditions: a template with a <script> block
+ * followed by more HTML elements.
+ */
+
+import { LiveTemplateClient } from "../livetemplate-client";
+
+describe("inline script duplication", () => {
+  let client: LiveTemplateClient;
+  let wrapper: HTMLElement;
+
+  beforeEach(() => {
+    client = new LiveTemplateClient();
+    document.body.replaceChildren();
+    wrapper = document.createElement("div");
+    wrapper.setAttribute("data-lvt-id", "script-dup-test");
+    document.body.appendChild(wrapper);
+  });
+
+  it("elements after an inline script are NOT duplicated", () => {
+    // Initial tree: content + script + more content after.
+    // The tree shape mirrors what devbox-dash's claude.tmpl produces
+    // when chat messages are followed by a scroll-to-bottom script
+    // and then a key-grid div.
+    const tree = {
+      s: [
+        '<div class="chat">messages here</div>',
+        '<script>(function(){ /* scroll */ })();</script>',
+        '<div class="after-script">',
+        "</div>",
+      ],
+      0: "", // between chat and script (slot 0)
+      1: "", // between script and after-script (slot 1)
+      2: "unique-content-that-should-appear-once", // inside after-script
+    };
+
+    client.updateDOM(wrapper, tree);
+
+    // Count: the div.after-script should appear exactly ONCE.
+    const afterScriptDivs = wrapper.querySelectorAll(".after-script");
+    expect(afterScriptDivs.length).toBe(1);
+
+    // The unique content should appear once.
+    const textOccurrences = (wrapper.textContent || "").split(
+      "unique-content-that-should-appear-once"
+    ).length - 1;
+    expect(textOccurrences).toBe(1);
+  });
+
+  it("a second updateDOM does not cause further duplication", () => {
+    const tree = {
+      s: [
+        '<div class="before">',
+        '</div><script>var x = 1;</script><div class="after">',
+        "</div>",
+      ],
+      0: "initial",
+      1: "initial-after",
+    };
+
+    client.updateDOM(wrapper, tree);
+    expect(wrapper.querySelectorAll(".after").length).toBe(1);
+
+    // Apply an update that changes the dynamic slot but keeps the same structure.
+    const update = { 0: "updated", 1: "updated-after" };
+    client.updateDOM(wrapper, update);
+
+    expect(wrapper.querySelectorAll(".after").length).toBe(1);
+    expect(wrapper.textContent).toContain("updated-after");
+  });
+});

--- a/tests/script-duplication.test.ts
+++ b/tests/script-duplication.test.ts
@@ -56,6 +56,26 @@ describe("inline script duplication", () => {
     expect(textOccurrences).toBe(1);
   });
 
+  it("uppercase <SCRIPT> tag also routes through DOMParser (case-insensitive)", () => {
+    // HTML tag names are case-insensitive; <SCRIPT> must be treated the
+    // same as <script> so that the DOMParser path (which prevents phantom
+    // duplication) is used regardless of casing.
+    const tree = {
+      s: [
+        '<div class="before">before</div>',
+        '<SCRIPT>var y = 2;</SCRIPT>',
+        '<div class="after">after</div>',
+      ],
+      0: "",
+      1: "",
+    };
+
+    client.updateDOM(wrapper, tree);
+
+    expect(wrapper.querySelectorAll(".after").length).toBe(1);
+    expect(wrapper.querySelectorAll(".before").length).toBe(1);
+  });
+
   it("a second updateDOM does not cause further duplication", () => {
     const tree = {
       s: [


### PR DESCRIPTION
## Summary

Three related client-side primitives for real-time livetemplate apps:

### lvt-preserve and lvt-preserve-attrs
Two morphdom escape hatches checked in `onBeforeElUpdated`:
- **`lvt-preserve`**: full skip — attributes, content, children untouched. For third-party widgets.
- **`lvt-preserve-attrs`**: preserve own attributes but still diff children. For `<details open>` pickers where the toggle state is user-managed but the items inside are server-authored. Only protects attributes the server template does **not** set — if the server sets `class="card"`, JS-added classes are still overwritten.

Both attributes check `toEl` (the incoming server tree), giving the server authority to remove them on a later render.

### In-band `__navigate__` message
`sendNavigate(href)` parses query params and sends `{action:"__navigate__", data:<params>}` over the existing WebSocket. Same-handler SPA navigation (same pathname, different query string) skips `fetch()` entirely — no HTTP round-trip, no WebSocket reconnect. Server companion: livetemplate/livetemplate#344.

**Rollout order**: `__navigate__` is a no-op on server versions before livetemplate/livetemplate#344. Same-pathname link clicks will send an unrecognized WebSocket action on older server versions. Deploy the server update before or simultaneously with this client release.

### DOMParser for script-containing HTML
`updateDOM` now uses `DOMParser` instead of `innerHTML` when the reconstructed HTML contains `<script>` tags. Chrome's `innerHTML` parser handles scripts specially and can create phantom duplicate DOM nodes after the closing tag.

## Behavioral note: cross-pathname same-handler navigation

The previous `handleNavigationResponse` had a fast path where a same `data-lvt-id` across different pathnames would do an in-place `replaceChildren + re-setup` without a WebSocket reconnect. That path has been removed. Cross-pathname navigation (regardless of whether the handler ID matches) now always triggers a full reconnect. This is correct because same-ID across different paths means two distinct routes share a handler — `sendNavigate` can't express a path change (only query params), so only a reconnect gets the server to the right route. **This is a silent behavioral change**: apps with routes sharing a `data-lvt-id` will now see a reconnect flash on cross-path navigation. See CHANGELOG [Unreleased] for upgrade notes.

## Test plan

- [x] `tests/preserve.test.ts`: 6 tests (open-attr preserve, control, attrs-only children-still-diff, subtree preserve, server-remove lvt-preserve, server-remove lvt-preserve-attrs)
- [x] `tests/navigate.test.ts`: 7 tests (same-pathname bypass, different-pathname fetch, external skip, abort in-flight fetch, empty-query, HTTP mode fallthrough, hash-only popstate no-op)
- [x] `tests/navigation.test.ts`: updated same-handler tests for new behavior; documents cross-path same-ID reconnect trade-off
- [x] `tests/conditional-slot-transition.test.ts`: 3 tree-renderer regression tests
- [x] `tests/script-duplication.test.ts`: 3 DOMParser regression tests (including uppercase SCRIPT)
- [x] All 359 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)