### PR TITLE
fix: popstate navigation broken by samePath check

### DIFF
--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -34,6 +34,8 @@ export interface LinkInterceptorContext {
 export class LinkInterceptor {
   private popstateListener: (() => void) | null = null;
   private abortController: AbortController | null = null;
+  private lastNavigatedPath: string = window.location.pathname;
+  private lastNavigatedSearch: string = window.location.search;
 
   constructor(
     private readonly context: LinkInterceptorContext,
@@ -69,6 +71,9 @@ export class LinkInterceptor {
   }
 
   setup(wrapper: Element): void {
+    this.lastNavigatedPath = window.location.pathname;
+    this.lastNavigatedSearch = window.location.search;
+
     const wrapperId = wrapper.getAttribute("data-lvt-id");
     const listenerKey = `__lvt_link_intercept_${wrapperId}`;
     const existing = (document as any)[listenerKey];
@@ -121,12 +126,20 @@ export class LinkInterceptor {
 
   private async navigate(href: string, pushState: boolean = true): Promise<void> {
     const targetURL = new URL(href, window.location.origin);
+
+    // For click-based nav (pushState=true), window.location still reflects
+    // the OLD page. For popstate (pushState=false), the browser has already
+    // updated window.location to the destination — compare against tracked
+    // values so we can detect that the URL actually changed.
+    const referencePath = pushState ? window.location.pathname : this.lastNavigatedPath;
+    const referenceSearch = pushState ? window.location.search : this.lastNavigatedSearch;
+
     const samePath =
       targetURL.origin === window.location.origin &&
-      targetURL.pathname === window.location.pathname;
+      targetURL.pathname === referencePath;
 
     if (samePath) {
-      const sameSearch = targetURL.search === window.location.search;
+      const sameSearch = targetURL.search === referenceSearch;
       if (sameSearch) {
         // Hash-only change or exact same URL — the browser handles scroll
         // to the anchor; no server round-trip is needed. This guard also
@@ -168,6 +181,8 @@ export class LinkInterceptor {
           if (pushState) {
             window.history.pushState(null, "", href);
           }
+          this.lastNavigatedPath = targetURL.pathname;
+          this.lastNavigatedSearch = targetURL.search;
           return;
         }
         // sendNavigate returned false — fall through to fetch as recovery.
@@ -201,6 +216,9 @@ export class LinkInterceptor {
       if (pushState) {
         window.history.pushState(null, "", href);
       }
+
+      this.lastNavigatedPath = targetURL.pathname;
+      this.lastNavigatedSearch = targetURL.search;
 
       this.context.handleNavigationResponse(html);
     } catch (e: unknown) {

--- a/tests/navigate.test.ts
+++ b/tests/navigate.test.ts
@@ -66,19 +66,24 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
       sendNavigate: sendNavigateSpy,
       canSendNavigate: () => true,
     };
+    // Pin the current location BEFORE setup() so lastNavigatedPath
+    // is initialized correctly. jsdom defaults to about:blank.
+    history.replaceState(null, "", "/claude?s=initial");
+
     interceptor = new LinkInterceptor(ctx, silentLogger);
     interceptor.setup(wrapper);
-
-    // Pin the current location so test navigations have something to
-    // compare their pathname against. jsdom defaults to about:blank,
-    // which has no useful pathname.
-    history.replaceState(null, "", "/claude?s=initial");
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
-    // Tear down any listeners the interceptor added to document.
+    // Tear down click listener keyed to the wrapper.
     interceptor.teardownForWrapper(wrapper.getAttribute("data-lvt-id"));
+    // Remove the popstate listener (not covered by teardownForWrapper).
+    const popListener = (interceptor as any).popstateListener;
+    if (popListener) {
+      window.removeEventListener("popstate", popListener);
+      (interceptor as any).popstateListener = null;
+    }
   });
 
   it("same-pathname link click sends navigate message, no fetch", async () => {
@@ -223,6 +228,46 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     httpInterceptor.teardownForWrapper(wrapper.getAttribute("data-lvt-id"));
+  });
+
+  it("cross-path popstate (back button) triggers fetch, not early return", async () => {
+    // Simulate having navigated to /other-page. We use pushState + setup()
+    // rather than a link click because jsdom's Response.text() is unreliable
+    // and the try/catch fallback (window.location.href =) throws in jsdom.
+    history.pushState(null, "", "/other-page");
+    interceptor.setup(wrapper); // re-syncs lastNavigatedPath to /other-page
+
+    // Simulate browser back: browser updates URL, then popstate fires.
+    history.replaceState(null, "", "/claude?s=initial");
+    window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    await Promise.resolve();
+
+    // Must fetch the old page content, not short-circuit.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sendNavigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("same-path different-search popstate sends navigate message", async () => {
+    // Simulate: user clicked /claude?s=second (same-path, different search),
+    // then presses back to /claude?s=initial.
+    const link = document.createElement("a");
+    link.href = "/claude?s=second";
+    wrapper.appendChild(link);
+    link.click();
+    await Promise.resolve();
+
+    expect(sendNavigateSpy).toHaveBeenCalledTimes(1);
+    sendNavigateSpy.mockClear();
+
+    // Browser back: URL reverts to /claude?s=initial, popstate fires.
+    history.replaceState(null, "", "/claude?s=initial");
+    window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    await Promise.resolve();
+
+    // Should use sendNavigate for same-path query-string change.
+    expect(sendNavigateSpy).toHaveBeenCalledTimes(1);
+    expect(sendNavigateSpy.mock.calls[0][0]).toContain("s=initial");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("hash-only popstate (same pathname + same search) does not trigger sendNavigate or fetch", async () => {


### PR DESCRIPTION
## Summary

- The `samePath` check added in v0.8.26 (`__navigate__` SPA nav) compares `targetURL` against `window.location` inside `navigate()`. During `popstate` (browser back/forward), the browser updates `window.location` **before** the event fires — so `targetURL === window.location` always, and `navigate()` short-circuits without fetching content or reconnecting the WebSocket.
- Fix: track the last-navigated `pathname`/`search` in `LinkInterceptor`. For click-based nav (`pushState=true`), compare against `window.location` as before. For popstate (`pushState=false`), compare against the tracked values to detect actual URL changes.
- Adds 2 new unit tests: cross-path popstate triggers fetch; same-path different-search popstate sends navigate message.

## Test plan

- [x] All 361 client unit tests pass (including 2 new popstate tests)
- [x] `TestCrossHandlerNavigation` E2E passes locally with the built client bundle (`LVT_LOCAL_CLIENT=...`)
- [ ] CI passes on this PR
- [ ] After merge + publish, examples CI `TestCrossHandlerNavigation` passes with `@latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)