### PR TITLE
fix(checkbox): send array of values for multiple same-name checkboxes

### DIFF
--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -242,8 +242,19 @@ export class EventDelegator {
                 ) as HTMLInputElement[];
                 const checkboxNames = new Set(checkboxes.map((cb) => cb.name));
 
-                checkboxNames.forEach((name) => {
-                  message.data[name] = false;
+                const checkboxGroups = new Map<string, HTMLInputElement[]>();
+                checkboxes.forEach((cb) => {
+                  const group = checkboxGroups.get(cb.name) || [];
+                  group.push(cb);
+                  checkboxGroups.set(cb.name, group);
+                });
+
+                checkboxGroups.forEach((cbs, name) => {
+                  if (cbs.length === 1) {
+                    message.data[name] = false;
+                  } else {
+                    message.data[name] = [] as string[];
+                  }
                 });
 
                 // Get password field names to skip parseValue for them
@@ -267,8 +278,13 @@ export class EventDelegator {
                   if (value instanceof File) return; // Skip file entries — handled by sendHTTPMultipart
                   if (actionFieldName && key === actionFieldName) return;
                   if (checkboxNames.has(key)) {
-                    message.data[key] = true;
-                    this.logger.debug("Converted checkbox", key, "to true");
+                    const group = checkboxGroups.get(key)!;
+                    if (group.length === 1) {
+                      message.data[key] = true;
+                    } else {
+                      (message.data[key] as string[]).push(value as string);
+                    }
+                    this.logger.debug("Converted checkbox", key, group.length === 1 ? "to true" : "appended value");
                   } else if (passwordFields.has(key)) {
                     // Never parse password values - always keep as string
                     message.data[key] = value as string;

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -240,7 +240,6 @@ export class EventDelegator {
                 const checkboxes = Array.from(
                   targetElement.querySelectorAll('input[type="checkbox"][name]')
                 ) as HTMLInputElement[];
-                const checkboxNames = new Set(checkboxes.map((cb) => cb.name));
 
                 const checkboxGroups = new Map<string, HTMLInputElement[]>();
                 checkboxes.forEach((cb) => {
@@ -251,9 +250,9 @@ export class EventDelegator {
 
                 checkboxGroups.forEach((cbs, name) => {
                   if (cbs.length === 1) {
-                    message.data[name] = false;
+                    message.data[name] = cbs[0].checked;
                   } else {
-                    message.data[name] = [] as string[];
+                    message.data[name] = cbs.filter(cb => cb.checked).map(cb => cb.value);
                   }
                 });
 
@@ -277,15 +276,8 @@ export class EventDelegator {
                 formData.forEach((value, key) => {
                   if (value instanceof File) return; // Skip file entries — handled by sendHTTPMultipart
                   if (actionFieldName && key === actionFieldName) return;
-                  if (checkboxNames.has(key)) {
-                    const group = checkboxGroups.get(key)!;
-                    if (group.length === 1) {
-                      message.data[key] = true;
-                    } else {
-                      (message.data[key] as string[]).push(value as string);
-                    }
-                    this.logger.debug("Converted checkbox", key, group.length === 1 ? "to true" : "appended value");
-                  } else if (passwordFields.has(key)) {
+                  if (checkboxGroups.has(key)) return;
+                  if (passwordFields.has(key)) {
                     // Never parse password values - always keep as string
                     message.data[key] = value as string;
                   } else {

--- a/tests/event-delegation.test.ts
+++ b/tests/event-delegation.test.ts
@@ -198,6 +198,79 @@ describe("EventDelegator", () => {
     );
   });
 
+  it("sends array of values for multiple same-name checkboxes", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-lvt-id", "wrapper-multi-checkbox");
+    wrapper.innerHTML = `
+      <form id="multi-cb-form" lvt-on:submit="process">
+        <input type="checkbox" name="ids" value="a" checked />
+        <input type="checkbox" name="ids" value="b" />
+        <input type="checkbox" name="ids" value="c" checked />
+        <input type="checkbox" name="solo" checked />
+        <button type="submit" id="multi-cb-submit">Go</button>
+      </form>
+    `;
+    document.body.appendChild(wrapper);
+
+    const form = document.getElementById("multi-cb-form") as HTMLFormElement;
+    const submitButton = document.getElementById("multi-cb-submit") as HTMLButtonElement;
+
+    const context = createContext(wrapper);
+    const delegator = new EventDelegator(
+      context,
+      createLogger({ scope: "EventDelegatorTest", level: "silent" })
+    );
+    delegator.setupEventDelegation();
+
+    const submitEvent = new Event("submit", {
+      bubbles: true,
+      cancelable: true,
+    }) as SubmitEvent & { submitter?: HTMLButtonElement };
+    submitEvent.submitter = submitButton;
+
+    form.dispatchEvent(submitEvent);
+
+    expect(context.send).toHaveBeenCalledTimes(1);
+    const sentData = context.send.mock.calls[0][0].data;
+    expect(sentData.ids).toEqual(["a", "c"]);
+    expect(sentData.solo).toBe(true);
+  });
+
+  it("sends empty array when no checkboxes are checked in multi-group", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-lvt-id", "wrapper-multi-cb-none");
+    wrapper.innerHTML = `
+      <form id="multi-cb-none-form" lvt-on:submit="process">
+        <input type="checkbox" name="ids" value="a" />
+        <input type="checkbox" name="ids" value="b" />
+        <button type="submit" id="multi-cb-none-submit">Go</button>
+      </form>
+    `;
+    document.body.appendChild(wrapper);
+
+    const form = document.getElementById("multi-cb-none-form") as HTMLFormElement;
+    const submitButton = document.getElementById("multi-cb-none-submit") as HTMLButtonElement;
+
+    const context = createContext(wrapper);
+    const delegator = new EventDelegator(
+      context,
+      createLogger({ scope: "EventDelegatorTest", level: "silent" })
+    );
+    delegator.setupEventDelegation();
+
+    const submitEvent = new Event("submit", {
+      bubbles: true,
+      cancelable: true,
+    }) as SubmitEvent & { submitter?: HTMLButtonElement };
+    submitEvent.submitter = submitButton;
+
+    form.dispatchEvent(submitEvent);
+
+    expect(context.send).toHaveBeenCalledTimes(1);
+    const sentData = context.send.mock.calls[0][0].data;
+    expect(sentData.ids).toEqual([]);
+  });
+
   it("lvt-form:action attribute takes priority over button name", () => {
     const wrapper = document.createElement("div");
     wrapper.setAttribute("data-lvt-id", "wrapper-form-action");

--- a/tests/event-delegation.test.ts
+++ b/tests/event-delegation.test.ts
@@ -271,6 +271,79 @@ describe("EventDelegator", () => {
     expect(sentData.ids).toEqual([]);
   });
 
+  it("ignores hidden inputs sharing a checkbox name", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-lvt-id", "wrapper-hidden-cb");
+    const formHtml = [
+      '<form id="hidden-cb-form" lvt-on:submit="save">',
+      '  <input type="hidden" name="agree" value="0" />',
+      '  <input type="checkbox" name="agree" checked />',
+      '  <button type="submit" id="hidden-cb-submit">Go</button>',
+      '</form>',
+    ].join("\n");
+    wrapper.innerHTML = formHtml; // Safe: hardcoded test markup
+    document.body.appendChild(wrapper);
+
+    const form = document.getElementById("hidden-cb-form") as HTMLFormElement;
+    const submitButton = document.getElementById("hidden-cb-submit") as HTMLButtonElement;
+
+    const context = createContext(wrapper);
+    const delegator = new EventDelegator(
+      context,
+      createLogger({ scope: "EventDelegatorTest", level: "silent" })
+    );
+    delegator.setupEventDelegation();
+
+    const submitEvent = new Event("submit", {
+      bubbles: true,
+      cancelable: true,
+    }) as SubmitEvent & { submitter?: HTMLButtonElement };
+    submitEvent.submitter = submitButton;
+
+    form.dispatchEvent(submitEvent);
+
+    expect(context.send).toHaveBeenCalledTimes(1);
+    const sentData = context.send.mock.calls[0][0].data;
+    expect(sentData.agree).toBe(true);
+  });
+
+  it("sends singleton array when one checkbox is checked in multi-group", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-lvt-id", "wrapper-singleton-cb");
+    const formHtml = [
+      '<form id="singleton-cb-form" lvt-on:submit="process">',
+      '  <input type="checkbox" name="ids" value="a" checked />',
+      '  <input type="checkbox" name="ids" value="b" />',
+      '  <input type="checkbox" name="ids" value="c" />',
+      '  <button type="submit" id="singleton-cb-submit">Go</button>',
+      '</form>',
+    ].join("\n");
+    wrapper.innerHTML = formHtml; // Safe: hardcoded test markup
+    document.body.appendChild(wrapper);
+
+    const form = document.getElementById("singleton-cb-form") as HTMLFormElement;
+    const submitButton = document.getElementById("singleton-cb-submit") as HTMLButtonElement;
+
+    const context = createContext(wrapper);
+    const delegator = new EventDelegator(
+      context,
+      createLogger({ scope: "EventDelegatorTest", level: "silent" })
+    );
+    delegator.setupEventDelegation();
+
+    const submitEvent = new Event("submit", {
+      bubbles: true,
+      cancelable: true,
+    }) as SubmitEvent & { submitter?: HTMLButtonElement };
+    submitEvent.submitter = submitButton;
+
+    form.dispatchEvent(submitEvent);
+
+    expect(context.send).toHaveBeenCalledTimes(1);
+    const sentData = context.send.mock.calls[0][0].data;
+    expect(sentData.ids).toEqual(["a"]);
+  });
+
   it("lvt-form:action attribute takes priority over button name", () => {
     const wrapper = document.createElement("div");
     wrapper.setAttribute("data-lvt-id", "wrapper-form-action");


### PR DESCRIPTION
## Summary
- Multiple checkboxes with the same `name` and different `value` attributes were collapsed to a single boolean `true/false`, losing individual values
- Single-checkbox groups keep boolean behavior (backward compatible)
- Multi-checkbox groups now send an array of checked values, matching the server-side HTTP form parsing path
- Checkbox values are now computed directly from DOM nodes instead of FormData, preventing hidden inputs from corrupting checkbox payloads

## ⚠️ Breaking change
Backend handlers that previously received `true`/`false` for a checkbox field will now receive an **array of strings** if the form contains ≥2 checkboxes with that name:
- **Single checkbox** (`<input type="checkbox" name="agree">`): still sends `true`/`false` — no change
- **Multi-checkbox group** (`<input type="checkbox" name="ids" value="a">` + more): sends `["a", "c"]` (checked values) or `[]` (none checked)
- A multi-group with exactly one checked item sends a **singleton array** (e.g., `["a"]`), not a boolean

## Test plan
- [x] Added test: "sends array of values for multiple same-name checkboxes" — 3 checkboxes named `ids`, checks `a` and `c`, expects `["a", "c"]`; also verifies single checkbox `solo` remains boolean `true`
- [x] Added test: "sends empty array when no checkboxes are checked in multi-group" — 2 unchecked checkboxes named `ids`, expects `[]`
- [x] Added test: "ignores hidden inputs sharing a checkbox name" — hidden input with same name doesn't corrupt checkbox value
- [x] Added test: "sends singleton array when one checkbox is checked in multi-group" — single checked in 3-group expects `["a"]`
- [x] Existing single-checkbox test still passes (backward compatible)
- [x] All 363 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)