### PR TITLE
fix(morphdom): preserve checkbox/radio checked state across updates

### DIFF
--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1194,14 +1194,10 @@ export class LiveTemplateClient {
         }
 
         // Preserve checkbox/radio checked state across morphdom updates.
-        // These controls lose focus immediately after click, so the
-        // focusManager never protects them, but their checked state is
-        // user input that must survive scan-loop refreshes. We copy the
-        // DOM's checked value onto the incoming element so morphdom sees
-        // them as equal and won't reset the property.
-        //
-        // data-lvt-force-update reverses this: the server explicitly
-        // wants to reset the checkbox, so we sync toEl to fromEl instead.
+        // User selection wins by default — these controls lose focus on
+        // click so the focusManager never protects them, and their checked
+        // state is user input that must survive scan-loop refreshes. Use
+        // data-lvt-force-update to let the server override the user state.
         if (
           fromEl instanceof HTMLInputElement &&
           toEl instanceof HTMLInputElement &&
@@ -1214,8 +1210,9 @@ export class LiveTemplateClient {
             }
           } else {
             toEl.checked = fromEl.checked;
-            // Sync the checked attribute so morphdom's attribute copy
-            // doesn't trigger radio mutual exclusion side effects.
+            // Align the checked attribute with the property so morphdom's
+            // attribute diff doesn't add a spurious checked attr to fromEl
+            // (which IS in the DOM and would trigger radio mutual exclusion).
             if (fromEl.checked) {
               toEl.setAttribute("checked", "");
             } else {
@@ -1239,12 +1236,13 @@ export class LiveTemplateClient {
         // to process this element or one of its descendants
         // unconditionally (e.g. resetting a checkbox whose checked
         // property differs from the attribute).
-        const hasForcedUpdateInSubtree =
-          toEl instanceof Element &&
-          (toEl.hasAttribute("data-lvt-force-update") ||
-            toEl.querySelector("[data-lvt-force-update]") !== null);
-        if (fromEl.isEqualNode(toEl) && !hasForcedUpdateInSubtree) {
-          return false;
+        if (fromEl.isEqualNode(toEl)) {
+          if (
+            !toEl.hasAttribute("data-lvt-force-update") &&
+            toEl.querySelector("[data-lvt-force-update]") === null
+          ) {
+            return false;
+          }
         }
         // Execute lvt-updated lifecycle hook
         this.executeLifecycleHook(fromEl, "lvt-updated");

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1201,7 +1201,9 @@ export class LiveTemplateClient {
         //
         // Known limitation: force-update on one radio can uncheck a sibling
         // that was already processed earlier in the same morphdom pass, since
-        // browser mutual exclusion fires synchronously mid-loop.
+        // browser mutual exclusion fires synchronously mid-loop. To safely
+        // reset a radio group, send data-lvt-force-update on ALL radios in
+        // the group, not just the one being checked.
         if (
           fromEl instanceof HTMLInputElement &&
           toEl instanceof HTMLInputElement &&

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1261,6 +1261,12 @@ export class LiveTemplateClient {
         if (el instanceof HTMLTextAreaElement) {
           el.value = el.textContent ?? "";
         }
+        // Auto-strip data-lvt-force-update so it acts as a one-shot
+        // directive. The server sets it for one render to override user
+        // state; it self-clears so subsequent renders resume preservation.
+        if (el instanceof HTMLElement && el.hasAttribute("data-lvt-force-update")) {
+          el.removeAttribute("data-lvt-force-update");
+        }
       },
       onNodeAdded: (node) => {
         // Sync textarea value for newly inserted textarea elements

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1248,6 +1248,9 @@ export class LiveTemplateClient {
           ) {
             return false;
           }
+          // Ancestor itself didn't change — only traversing for a
+          // descendant's force-update. Skip the lvt-updated hook.
+          return true;
         }
         // Execute lvt-updated lifecycle hook
         this.executeLifecycleHook(fromEl, "lvt-updated");
@@ -1272,6 +1275,9 @@ export class LiveTemplateClient {
         // Sync textarea value for newly inserted textarea elements
         if (node instanceof HTMLTextAreaElement) {
           node.value = node.textContent ?? "";
+        }
+        if (node instanceof HTMLElement && node.hasAttribute("data-lvt-force-update")) {
+          node.removeAttribute("data-lvt-force-update");
         }
         // Execute lvt-mounted lifecycle hook
         if (node.nodeType === Node.ELEMENT_NODE) {

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1201,7 +1201,7 @@ export class LiveTemplateClient {
         // them as equal and won't reset the property.
         //
         // data-lvt-force-update reverses this: the server explicitly
-        // wants to reset the checkbox, so we sync fromEl to toEl instead.
+        // wants to reset the checkbox, so we sync toEl to fromEl instead.
         if (
           fromEl instanceof HTMLInputElement &&
           toEl instanceof HTMLInputElement &&
@@ -1209,8 +1209,21 @@ export class LiveTemplateClient {
         ) {
           if (toEl.hasAttribute("data-lvt-force-update")) {
             fromEl.checked = toEl.checked;
+            if (fromEl.type === "checkbox") {
+              fromEl.indeterminate = toEl.indeterminate;
+            }
           } else {
             toEl.checked = fromEl.checked;
+            // Sync the checked attribute so morphdom's attribute copy
+            // doesn't trigger radio mutual exclusion side effects.
+            if (fromEl.checked) {
+              toEl.setAttribute("checked", "");
+            } else {
+              toEl.removeAttribute("checked");
+            }
+            if (fromEl.type === "checkbox") {
+              toEl.indeterminate = fromEl.indeterminate;
+            }
           }
         }
 
@@ -1223,15 +1236,14 @@ export class LiveTemplateClient {
 
         // Only update if content actually changed — but honour
         // data-lvt-force-update which means the server wants morphdom
-        // to process this element unconditionally (e.g. resetting a
-        // checkbox whose checked property differs from the attribute).
-        if (
-          fromEl.isEqualNode(toEl) &&
-          !(
-            toEl instanceof Element &&
-            (toEl as Element).hasAttribute("data-lvt-force-update")
-          )
-        ) {
+        // to process this element or one of its descendants
+        // unconditionally (e.g. resetting a checkbox whose checked
+        // property differs from the attribute).
+        const hasForcedUpdateInSubtree =
+          toEl instanceof Element &&
+          (toEl.hasAttribute("data-lvt-force-update") ||
+            toEl.querySelector("[data-lvt-force-update]") !== null);
+        if (fromEl.isEqualNode(toEl) && !hasForcedUpdateInSubtree) {
           return false;
         }
         // Execute lvt-updated lifecycle hook

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1193,6 +1193,27 @@ export class LiveTemplateClient {
           // Fall through to normal diff path so children are still updated.
         }
 
+        // Preserve checkbox/radio checked state across morphdom updates.
+        // These controls lose focus immediately after click, so the
+        // focusManager never protects them, but their checked state is
+        // user input that must survive scan-loop refreshes. We copy the
+        // DOM's checked value onto the incoming element so morphdom sees
+        // them as equal and won't reset the property.
+        //
+        // data-lvt-force-update reverses this: the server explicitly
+        // wants to reset the checkbox, so we sync fromEl to toEl instead.
+        if (
+          fromEl instanceof HTMLInputElement &&
+          toEl instanceof HTMLInputElement &&
+          (fromEl.type === "checkbox" || fromEl.type === "radio")
+        ) {
+          if (toEl.hasAttribute("data-lvt-force-update")) {
+            fromEl.checked = toEl.checked;
+          } else {
+            toEl.checked = fromEl.checked;
+          }
+        }
+
         // Skip update entirely for focused form elements to preserve user
         // input. This also skips attribute updates (class, disabled, aria-*)
         // and the lvt-updated hook — use data-lvt-force-update to override.
@@ -1200,8 +1221,17 @@ export class LiveTemplateClient {
           return false;
         }
 
-        // Only update if content actually changed
-        if (fromEl.isEqualNode(toEl)) {
+        // Only update if content actually changed — but honour
+        // data-lvt-force-update which means the server wants morphdom
+        // to process this element unconditionally (e.g. resetting a
+        // checkbox whose checked property differs from the attribute).
+        if (
+          fromEl.isEqualNode(toEl) &&
+          !(
+            toEl instanceof Element &&
+            (toEl as Element).hasAttribute("data-lvt-force-update")
+          )
+        ) {
           return false;
         }
         // Execute lvt-updated lifecycle hook

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1240,6 +1240,9 @@ export class LiveTemplateClient {
         // to process this element or one of its descendants
         // unconditionally (e.g. resetting a checkbox whose checked
         // property differs from the attribute).
+        // Note: querySelector is O(subtree) per equal node — acceptable
+        // since isEqualNode-true is rare for dynamic content, but worth
+        // revisiting if large static subtrees cause perf issues.
         if (fromEl.isEqualNode(toEl)) {
           if (
             !toEl.hasAttribute("data-lvt-force-update") &&
@@ -1264,9 +1267,9 @@ export class LiveTemplateClient {
         if (el instanceof HTMLTextAreaElement) {
           el.value = el.textContent ?? "";
         }
-        // Auto-strip data-lvt-force-update so it acts as a one-shot
-        // directive. The server sets it for one render to override user
-        // state; it self-clears so subsequent renders resume preservation.
+        // Strip data-lvt-force-update from the live DOM after each
+        // render. If the server stops sending it, preservation resumes;
+        // if the server keeps including it, each render force-resets.
         if (el instanceof HTMLElement && el.hasAttribute("data-lvt-force-update")) {
           el.removeAttribute("data-lvt-force-update");
         }

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1214,6 +1214,7 @@ export class LiveTemplateClient {
             if (fromEl.type === "checkbox") {
               fromEl.indeterminate = toEl.indeterminate;
             }
+            fromEl.removeAttribute("data-lvt-force-update");
           } else {
             toEl.checked = fromEl.checked;
             // Align the checked attribute with the property so morphdom's
@@ -1242,9 +1243,10 @@ export class LiveTemplateClient {
         // to process this element or one of its descendants
         // unconditionally (e.g. resetting a checkbox whose checked
         // property differs from the attribute).
-        // Note: querySelector is O(subtree) per equal node — acceptable
-        // since isEqualNode-true is rare for dynamic content, but worth
-        // revisiting if large static subtrees cause perf issues.
+        // Note: querySelector is a defensive fallback — in steady state
+        // the attr is stripped after each render, so isEqualNode returns
+        // false and normal diffing reaches the descendant. The scan only
+        // matters on the first render of a newly inserted subtree.
         if (fromEl.isEqualNode(toEl)) {
           if (
             !toEl.hasAttribute("data-lvt-force-update") &&

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1198,6 +1198,10 @@ export class LiveTemplateClient {
         // click so the focusManager never protects them, and their checked
         // state is user input that must survive scan-loop refreshes. Use
         // data-lvt-force-update to let the server override the user state.
+        //
+        // Known limitation: force-update on one radio can uncheck a sibling
+        // that was already processed earlier in the same morphdom pass, since
+        // browser mutual exclusion fires synchronously mid-loop.
         if (
           fromEl instanceof HTMLInputElement &&
           toEl instanceof HTMLInputElement &&
@@ -1239,7 +1243,8 @@ export class LiveTemplateClient {
         if (fromEl.isEqualNode(toEl)) {
           if (
             !toEl.hasAttribute("data-lvt-force-update") &&
-            toEl.querySelector("[data-lvt-force-update]") === null
+            (toEl.children.length === 0 ||
+              toEl.querySelector("[data-lvt-force-update]") === null)
           ) {
             return false;
           }

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -194,6 +194,78 @@ describe("lvt-preserve attribute", () => {
     expect(detailsAfter.hasAttribute("lvt-preserve-attrs")).toBe(false);
   });
 
+  it("preserves checkbox checked state across morphdom updates", () => {
+    const initialTree = {
+      s: [
+        `<form>`,
+        `</form>`,
+      ],
+      0: `<label><input type="checkbox" class="cb" data-key="a" value="a"></label>` +
+         `<label><input type="checkbox" class="cb" data-key="b" value="b"></label>`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const checkboxes = wrapper.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+    expect(checkboxes.length).toBe(2);
+    expect(checkboxes[0].checked).toBe(false);
+    expect(checkboxes[1].checked).toBe(false);
+
+    // User checks the first checkbox.
+    checkboxes[0].checked = true;
+
+    // Server pushes a refresh (same HTML, no checked attribute).
+    client.updateDOM(wrapper, initialTree);
+
+    const afterUpdate = wrapper.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+    expect(afterUpdate[0].checked).toBe(true);
+    expect(afterUpdate[1].checked).toBe(false);
+  });
+
+  it("preserves radio button checked state across morphdom updates", () => {
+    const initialTree = {
+      s: [
+        `<form>`,
+        `</form>`,
+      ],
+      0: `<input type="radio" name="choice" data-key="x" value="x">` +
+         `<input type="radio" name="choice" data-key="y" value="y">`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const radios = wrapper.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    radios[1].checked = true;
+
+    client.updateDOM(wrapper, initialTree);
+
+    const afterUpdate = wrapper.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    expect(afterUpdate[0].checked).toBe(false);
+    expect(afterUpdate[1].checked).toBe(true);
+  });
+
+  it("data-lvt-force-update overrides checkbox preservation", () => {
+    // Parent content must differ between renders so isEqualNode returns
+    // false on the parent, causing morphdom to actually reach the
+    // checkbox element. In real apps, dynamic text like "5m ago" ensures
+    // this — we simulate it with changing span text.
+    const initialTree = {
+      s: [`<form>`, `</form>`],
+      0: `<div data-key="w"><span>v1</span><input type="checkbox" data-lvt-force-update value="f"></div>`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const cb = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    cb.checked = true;
+
+    const updateTree = {
+      s: [`<form>`, `</form>`],
+      0: `<div data-key="w"><span>v2</span><input type="checkbox" data-lvt-force-update value="f"></div>`,
+    };
+    client.updateDOM(wrapper, updateTree);
+
+    const cbAfter = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    expect(cbAfter.checked).toBe(false);
+  });
+
   it("preserves the element's children as well", () => {
     // lvt-preserve is a full-element bail-out: attributes, children,
     // everything stays as-is. Useful for third-party widgets that

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -289,10 +289,9 @@ describe("lvt-preserve attribute", () => {
   });
 
   it("data-lvt-force-update overrides checkbox preservation", () => {
-    // Parent content must differ between renders so isEqualNode returns
-    // false on the parent, causing morphdom to actually reach the
-    // checkbox element. In real apps, dynamic text like "5m ago" ensures
-    // this — we simulate it with changing span text.
+    // Parent content differs between renders (v1 → v2) so morphdom
+    // reaches the checkbox via normal diffing, not via the isEqualNode
+    // subtree bypass (which the next test covers separately).
     const initialTree = {
       s: [`<form>`, `</form>`],
       0: `<div data-key="w"><span>v1</span><input type="checkbox" data-lvt-force-update value="f"></div>`,
@@ -310,6 +309,31 @@ describe("lvt-preserve attribute", () => {
 
     const cbAfter = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
     expect(cbAfter.checked).toBe(false);
+  });
+
+  it("data-lvt-force-update overrides radio preservation", () => {
+    const initialTree = {
+      s: [`<form>`, `</form>`],
+      0: `<div data-key="r"><span>v1</span>` +
+         `<input type="radio" name="fg" data-lvt-force-update value="a">` +
+         `<input type="radio" name="fg" value="b"></div>`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const radios = wrapper.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    radios[1].checked = true;
+
+    const updateTree = {
+      s: [`<form>`, `</form>`],
+      0: `<div data-key="r"><span>v2</span>` +
+         `<input type="radio" name="fg" data-lvt-force-update value="a" checked>` +
+         `<input type="radio" name="fg" value="b"></div>`,
+    };
+    client.updateDOM(wrapper, updateTree);
+
+    const afterUpdate = wrapper.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    expect(afterUpdate[0].checked).toBe(true);
+    expect(afterUpdate[1].checked).toBe(false);
   });
 
   it("data-lvt-force-update on descendant bypasses ancestor isEqualNode short-circuit", () => {

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -375,8 +375,8 @@ describe("lvt-preserve attribute", () => {
 
   it("data-lvt-force-update on newly added node is stripped after first render", () => {
     // When a node with data-lvt-force-update is first inserted via
-    // onNodeAdded, the attribute is stripped. Subsequent renders treat
-    // the checkbox normally (user selection wins).
+    // onNodeAdded, the attribute is stripped from the live DOM. If the
+    // server keeps sending it, each render still force-resets the state.
     const tree = {
       s: [`<form>`, `</form>`],
       0: `<div class="stable"><input type="checkbox" data-lvt-force-update value="x"></div>`,

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -242,6 +242,52 @@ describe("lvt-preserve attribute", () => {
     expect(afterUpdate[1].checked).toBe(true);
   });
 
+  it("preserves radio selection when server sends a different default", () => {
+    const initialTree = {
+      s: [
+        `<form>`,
+        `</form>`,
+      ],
+      0: `<input type="radio" name="opt" data-key="a" value="a">` +
+         `<input type="radio" name="opt" data-key="b" value="b">`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const radios = wrapper.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    radios[1].checked = true;
+
+    // Server sends update with radio A pre-checked via the checked attribute.
+    const updateTree = {
+      s: [
+        `<form>`,
+        `</form>`,
+      ],
+      0: `<input type="radio" name="opt" data-key="a" value="a" checked>` +
+         `<input type="radio" name="opt" data-key="b" value="b">`,
+    };
+    client.updateDOM(wrapper, updateTree);
+
+    const afterUpdate = wrapper.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    expect(afterUpdate[0].checked).toBe(false);
+    expect(afterUpdate[1].checked).toBe(true);
+  });
+
+  it("preserves checkbox indeterminate state across morphdom updates", () => {
+    const initialTree = {
+      s: [`<form>`, `</form>`],
+      0: `<input type="checkbox" class="select-all" value="all">`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const cb = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    cb.indeterminate = true;
+
+    client.updateDOM(wrapper, initialTree);
+
+    const cbAfter = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    expect(cbAfter.indeterminate).toBe(true);
+  });
+
   it("data-lvt-force-update overrides checkbox preservation", () => {
     // Parent content must differ between renders so isEqualNode returns
     // false on the parent, causing morphdom to actually reach the
@@ -261,6 +307,28 @@ describe("lvt-preserve attribute", () => {
       0: `<div data-key="w"><span>v2</span><input type="checkbox" data-lvt-force-update value="f"></div>`,
     };
     client.updateDOM(wrapper, updateTree);
+
+    const cbAfter = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    expect(cbAfter.checked).toBe(false);
+  });
+
+  it("data-lvt-force-update on descendant bypasses ancestor isEqualNode short-circuit", () => {
+    // When the parent container is structurally equal across renders,
+    // isEqualNode would return true and skip the subtree. The subtree
+    // check ensures a descendant with data-lvt-force-update still
+    // gets processed.
+    const tree = {
+      s: [`<form>`, `</form>`],
+      0: `<div class="stable"><input type="checkbox" data-lvt-force-update value="x"></div>`,
+    };
+    client.updateDOM(wrapper, tree);
+
+    const cb = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    cb.checked = true;
+
+    // Same tree — parent div is structurally equal, but descendant
+    // input has data-lvt-force-update so morphdom must still traverse.
+    client.updateDOM(wrapper, tree);
 
     const cbAfter = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
     expect(cbAfter.checked).toBe(false);

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -398,6 +398,30 @@ describe("lvt-preserve attribute", () => {
     expect(cbAfter.checked).toBe(false);
   });
 
+  it("data-lvt-force-update resets checked state even when checkbox is focused", () => {
+    // The checkbox preservation block runs BEFORE the focus guard, so
+    // force-update resets the checked property even on a focused element.
+    // The focus guard then skips the rest of the update (attributes, etc).
+    const initialTree = {
+      s: [`<form>`, `</form>`],
+      0: `<div data-key="fc"><span>v1</span><input type="checkbox" data-lvt-force-update class="fc" value="fc"></div>`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const cb = wrapper.querySelector<HTMLInputElement>('input.fc')!;
+    cb.checked = true;
+    cb.focus();
+
+    const updateTree = {
+      s: [`<form>`, `</form>`],
+      0: `<div data-key="fc"><span>v2</span><input type="checkbox" data-lvt-force-update class="fc" value="fc"></div>`,
+    };
+    client.updateDOM(wrapper, updateTree);
+
+    const cbAfter = wrapper.querySelector<HTMLInputElement>('input.fc')!;
+    expect(cbAfter.checked).toBe(false);
+  });
+
   it("preserves the element's children as well", () => {
     // lvt-preserve is a full-element bail-out: attributes, children,
     // everything stays as-is. Useful for third-party widgets that

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -420,6 +420,10 @@ describe("lvt-preserve attribute", () => {
 
     const cbAfter = wrapper.querySelector<HTMLInputElement>('input.fc')!;
     expect(cbAfter.checked).toBe(false);
+    // Attribute must be stripped even though onElUpdated didn't fire
+    // (focus guard returned false). Eager strip in onBeforeElUpdated
+    // prevents the attribute from getting stuck on focused elements.
+    expect(cbAfter.hasAttribute("data-lvt-force-update")).toBe(false);
   });
 
   it("preserves the element's children as well", () => {

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -373,11 +373,10 @@ describe("lvt-preserve attribute", () => {
     expect(afterNormal.checked).toBe(true);
   });
 
-  it("data-lvt-force-update on descendant bypasses ancestor isEqualNode short-circuit", () => {
-    // When the parent container is structurally equal across renders,
-    // isEqualNode would return true and skip the subtree. The subtree
-    // check ensures a descendant with data-lvt-force-update still
-    // gets processed.
+  it("data-lvt-force-update on newly added node is stripped after first render", () => {
+    // When a node with data-lvt-force-update is first inserted via
+    // onNodeAdded, the attribute is stripped. Subsequent renders treat
+    // the checkbox normally (user selection wins).
     const tree = {
       s: [`<form>`, `</form>`],
       0: `<div class="stable"><input type="checkbox" data-lvt-force-update value="x"></div>`,
@@ -385,10 +384,14 @@ describe("lvt-preserve attribute", () => {
     client.updateDOM(wrapper, tree);
 
     const cb = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    // Attribute should be stripped after the initial render.
+    expect(cb.hasAttribute("data-lvt-force-update")).toBe(false);
+
     cb.checked = true;
 
-    // Same tree — parent div is structurally equal, but descendant
-    // input has data-lvt-force-update so morphdom must still traverse.
+    // Server sends same tree again — since the attr was stripped from
+    // fromEl, morphdom sees a diff and processes normally. The checkbox
+    // block sees data-lvt-force-update on toEl and force-resets.
     client.updateDOM(wrapper, tree);
 
     const cbAfter = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -336,6 +336,43 @@ describe("lvt-preserve attribute", () => {
     expect(afterUpdate[1].checked).toBe(false);
   });
 
+  it("data-lvt-force-update is one-shot and self-clears after the render", () => {
+    const forceTree = {
+      s: [`<form>`, `</form>`],
+      0: `<div data-key="lc"><span>v1</span><input type="checkbox" data-lvt-force-update value="lc"></div>`,
+    };
+    client.updateDOM(wrapper, forceTree);
+
+    const cb = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    cb.checked = true;
+
+    // Server sends force-update to reset the checkbox.
+    const resetTree = {
+      s: [`<form>`, `</form>`],
+      0: `<div data-key="lc"><span>v2</span><input type="checkbox" data-lvt-force-update value="lc"></div>`,
+    };
+    client.updateDOM(wrapper, resetTree);
+
+    const afterReset = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    expect(afterReset.checked).toBe(false);
+    // Attribute should be auto-stripped after processing.
+    expect(afterReset.hasAttribute("data-lvt-force-update")).toBe(false);
+
+    // User checks again.
+    afterReset.checked = true;
+
+    // Server sends a normal update (no data-lvt-force-update) — user
+    // state should now be preserved since the attribute self-cleared.
+    const normalTree = {
+      s: [`<form>`, `</form>`],
+      0: `<div data-key="lc"><span>v3</span><input type="checkbox" value="lc"></div>`,
+    };
+    client.updateDOM(wrapper, normalTree);
+
+    const afterNormal = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    expect(afterNormal.checked).toBe(true);
+  });
+
   it("data-lvt-force-update on descendant bypasses ancestor isEqualNode short-circuit", () => {
     // When the parent container is structurally equal across renders,
     // isEqualNode would return true and skip the subtree. The subtree


### PR DESCRIPTION
## Summary

- Preserves checkbox and radio `checked` state in morphdom's `onBeforeElUpdated` hook so that user-toggled checkboxes survive server-driven re-renders (e.g. 2-second scan loops)
- Adds `data-lvt-force-update` escape hatch so the server can override preserved state when needed
- Fixes `isEqualNode` optimization to not short-circuit when `data-lvt-force-update` is present

## Context

Without this fix, any morphdom diff cycle that touches a form with checkboxes resets user-checked state because `checked` is a DOM property (not an attribute) and morphdom's attribute-diffing replaces the element. This is the framework-level fix — consumers no longer need `lvt-preserve-attrs` workarounds on individual checkboxes.

## Test plan

- [x] Unit test: checkbox checked state preserved across morphdom updates
- [x] Unit test: radio button checked state preserved across morphdom updates  
- [x] Unit test: `data-lvt-force-update` overrides checkbox preservation
- [x] All 366 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)