### PR TITLE
fix(morphdom): allow child updates inside open dialogs

### DIFF
--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1185,31 +1185,28 @@ export class LiveTemplateClient {
           }
         }
 
-        // Preserve open <dialog> elements entirely. showModal() adds
-        // the dialog to the browser's top layer — a rendering state
-        // with no DOM representation. Morphdom's attribute sync and
-        // child reconciliation can disrupt this top-layer state.
-        // Skip the entire subtree while the live element has open;
-        // use data-lvt-force-update to bypass.
+        // Preserve open <dialog> top-layer state while allowing child
+        // updates. showModal() puts the dialog in the browser's top
+        // layer. Copying `open` onto toEl ensures morphdom's attribute
+        // sync won't remove it. Children reconcile normally so
+        // server-sent changes (e.g. validation errors) reach the DOM.
         if (
           fromEl instanceof HTMLDialogElement &&
           fromEl.hasAttribute('open') &&
           !(toEl as Element).hasAttribute('data-lvt-force-update')
         ) {
-          return false;
+          (toEl as Element).setAttribute('open', '');
         }
 
-        // Preserve open <dialog> and open [popover] elements entirely.
-        // showModal()/showPopover() add the element to the browser's
-        // top layer — a rendering state with no DOM representation.
-        // Morphdom's attribute sync and child reconciliation can
-        // disrupt this top-layer state. Skip the entire subtree while
-        // the live element is open; use data-lvt-force-update to bypass.
+        // Preserve open [popover] elements entirely. showPopover()
+        // adds the element to the browser's top layer — skip the
+        // entire subtree while open; use data-lvt-force-update to
+        // bypass.
         if (
-          !(toEl as Element).hasAttribute("data-lvt-force-update") && (
-            (fromEl instanceof HTMLDialogElement && fromEl.hasAttribute("open")) ||
-            (fromEl instanceof HTMLElement && fromEl.hasAttribute("popover") && safeMatchesPopoverOpen(fromEl))
-          )
+          !(toEl as Element).hasAttribute("data-lvt-force-update") &&
+          fromEl instanceof HTMLElement &&
+          fromEl.hasAttribute("popover") &&
+          safeMatchesPopoverOpen(fromEl)
         ) {
           return false;
         }

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1185,11 +1185,7 @@ export class LiveTemplateClient {
           }
         }
 
-        // Preserve open <dialog> top-layer state while allowing child
-        // updates. showModal() puts the dialog in the browser's top
-        // layer. Copying `open` onto toEl ensures morphdom's attribute
-        // sync won't remove it. Children reconcile normally so
-        // server-sent changes (e.g. validation errors) reach the DOM.
+        // Copy `open` onto toEl so morphdom's attr sync won't strip it (preserves top-layer state).
         if (
           fromEl instanceof HTMLDialogElement &&
           fromEl.hasAttribute('open') &&
@@ -1198,10 +1194,7 @@ export class LiveTemplateClient {
           (toEl as Element).setAttribute('open', '');
         }
 
-        // Preserve open [popover] elements entirely. showPopover()
-        // adds the element to the browser's top layer — skip the
-        // entire subtree while open; use data-lvt-force-update to
-        // bypass.
+        // Skip open popovers entirely (top-layer state has no DOM representation).
         if (
           !(toEl as Element).hasAttribute("data-lvt-force-update") &&
           fromEl instanceof HTMLElement &&

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -556,7 +556,7 @@ describe("lvt-ignore and lvt-ignore-attrs", () => {
     expect(tsAfter.textContent).toBe("12:00:02");
   });
 
-  it("skips entire open dialog subtree when dialog was opened client-side", () => {
+  it("updates children of open dialog while preserving open state", () => {
     const tree = {
       s: [`<div>`, `</div>`],
       0: `<dialog id="my-dialog" data-key="my-dialog"><p>content</p></dialog>`,
@@ -573,11 +573,7 @@ describe("lvt-ignore and lvt-ignore-attrs", () => {
     client.updateDOM(wrapper, updateTree);
 
     expect(dialog.hasAttribute('open')).toBe(true);
-    expect(dialog.querySelector('p')!.textContent).toBe("content");
-
-    dialog.removeAttribute('open');
-    client.updateDOM(wrapper, updateTree);
-    expect(wrapper.querySelector('#my-dialog p')!.textContent).toBe("changed");
+    expect(dialog.querySelector('p')!.textContent).toBe("changed");
   });
 
   it("server closes dialog via data-lvt-force-update", () => {
@@ -602,7 +598,7 @@ describe("lvt-ignore and lvt-ignore-attrs", () => {
     expect(dialogAfter.hasAttribute('data-lvt-force-update')).toBe(false);
   });
 
-  it("preserves entire dialog subtree including non-datalist children when open", () => {
+  it("updates dialog children while preserving open state", () => {
     const tree = {
       s: [`<div>`, `</div>`],
       0: `<span data-key="ts">12:00:00</span>` +
@@ -634,17 +630,11 @@ describe("lvt-ignore and lvt-ignore-attrs", () => {
     };
     client.updateDOM(wrapper, updateTree);
 
-    // Siblings OUTSIDE the dialog are updated normally.
+    // Siblings outside the dialog update normally.
     expect(wrapper.querySelector('[data-key="ts"]')!.textContent).toBe("12:00:02");
-    // Dialog children are frozen while open.
-    expect(wrapper.querySelector('[data-key="lbl"]')!.textContent).toBe("Folder");
-    expect(wrapper.querySelector('[data-key="btn"]')!.textContent).toBe("Submit");
-    expect(wrapper.querySelectorAll('#dl-opts option').length).toBe(2);
-
-    dialog.removeAttribute('open');
-    client.updateDOM(wrapper, updateTree);
-
-    // After close, dialog children sync.
+    // Dialog stays open.
+    expect(dialog.hasAttribute('open')).toBe(true);
+    // Dialog children update while open.
     expect(wrapper.querySelector('[data-key="lbl"]')!.textContent).toBe("Directory");
     expect(wrapper.querySelector('[data-key="btn"]')!.textContent).toBe("Save");
     expect(wrapper.querySelectorAll('#dl-opts option').length).toBe(3);
@@ -686,6 +676,42 @@ describe("lvt-ignore and lvt-ignore-attrs", () => {
     expect(dialogAfter.hasAttribute('open')).toBe(true);
     expect(dialogAfter.querySelector('p')!.textContent).toBe("updated");
     expect(dialogAfter.hasAttribute('data-lvt-force-update')).toBe(false);
+  });
+
+  it("applies server-sent validation errors inside open dialog", () => {
+    const tree = {
+      s: [`<div>`, `</div>`],
+      0: `<dialog id="val-dlg" data-key="val-dlg">` +
+           `<form data-key="val-frm">` +
+             `<input name="title" data-key="val-inp">` +
+             `<button data-key="val-btn">Add</button>` +
+           `</form>` +
+         `</dialog>`,
+    };
+    client.updateDOM(wrapper, tree);
+
+    const dialog = wrapper.querySelector('#val-dlg') as HTMLDialogElement;
+    dialog.setAttribute('open', '');
+    expect(wrapper.querySelectorAll('small').length).toBe(0);
+
+    const updateTree = {
+      s: [`<div>`, `</div>`],
+      0: `<dialog id="val-dlg" data-key="val-dlg">` +
+           `<form data-key="val-frm">` +
+             `<input name="title" aria-invalid="true" data-key="val-inp">` +
+             `<small>Title is required</small>` +
+             `<button data-key="val-btn">Add</button>` +
+           `</form>` +
+         `</dialog>`,
+    };
+    client.updateDOM(wrapper, updateTree);
+
+    expect(dialog.hasAttribute('open')).toBe(true);
+    const smalls = wrapper.querySelectorAll('small');
+    expect(smalls.length).toBe(1);
+    expect(smalls[0].textContent).toBe("Title is required");
+    const input = wrapper.querySelector('input[name="title"]') as HTMLInputElement;
+    expect(input.getAttribute('aria-invalid')).toBe("true");
   });
 
   it("preserves the element's children as well", () => {


### PR DESCRIPTION
## Summary
- morphdom's `onBeforeElUpdated` was returning `false` for open `<dialog>` elements, which skipped the element **and its entire subtree**. This prevented server-sent updates (e.g. validation errors via `<small>` tags) from reaching the DOM while a dialog was open via `showModal()`.
- Instead of skipping, copy the `open` attribute onto `toEl` so morphdom's attribute sync preserves it, then let children reconcile normally. Popover elements still skip entirely (separate concern).
- Removed duplicate dialog check block (PR #85 introduced it, PR #86 duplicated it when adding popover support).

## Test plan
- [x] Updated 2 existing preserve tests to verify children update while dialog stays open
- [x] Added new test: "applies server-sent validation errors inside open dialog"
- [x] All 428 unit tests pass
- [x] Verified with dialog-patterns E2E example (validation errors render inside open dialog)
- [x] lvt `Validation_Errors` E2E test passes with patched client

🤖 Generated with [Claude Code](https://claude.com/claude-code)