### PR TITLE
feat: data-lvt-target for scroll effects + lvt-scroll-away visibility toggle

### DIFF
--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -92,7 +92,7 @@ export function setupFxDOMEventTriggers(scanRoot: Element, registryRoot?: Elemen
       const listener = () => {
         if (!el.hasAttribute(attrNameCapture)) return; // attr removed by morphdom
         const currentValue = el.getAttribute(attrNameCapture) || "";
-        const targetEl = resolveTarget(el) as HTMLElement;
+        const targetEl = (resolveTarget(el) || el) as HTMLElement;
         applyFxEffect(targetEl, effect, currentValue);
       };
       el.addEventListener(parsed.trigger, listener);

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -92,7 +92,7 @@ export function setupFxDOMEventTriggers(scanRoot: Element, registryRoot?: Elemen
       const listener = () => {
         if (!el.hasAttribute(attrNameCapture)) return; // attr removed by morphdom
         const currentValue = el.getAttribute(attrNameCapture) || "";
-        const targetEl = (resolveTarget(el) || el) as HTMLElement;
+        const targetEl = resolveTarget(el) as HTMLElement;
         applyFxEffect(targetEl, effect, currentValue);
       };
       el.addEventListener(parsed.trigger, listener);

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1,4 +1,4 @@
-import { isDOMEventTrigger, SYNTHETIC_TRIGGERS } from "./reactive-attributes";
+import { isDOMEventTrigger, SYNTHETIC_TRIGGERS, resolveTarget } from "./reactive-attributes";
 
 // ─── Trigger parsing for lvt-fx: attributes ─────────────────────────────────
 
@@ -92,7 +92,8 @@ export function setupFxDOMEventTriggers(scanRoot: Element, registryRoot?: Elemen
       const listener = () => {
         if (!el.hasAttribute(attrNameCapture)) return; // attr removed by morphdom
         const currentValue = el.getAttribute(attrNameCapture) || "";
-        applyFxEffect(el as HTMLElement, effect, currentValue);
+        const targetEl = resolveTarget(el) as HTMLElement;
+        applyFxEffect(targetEl, effect, currentValue);
       };
       el.addEventListener(parsed.trigger, listener);
       (el as any)[listenerKey] = listener;
@@ -246,8 +247,14 @@ function applyFxEffect(htmlElement: HTMLElement, effect: string, config: string)
           htmlElement.scrollTo({ top: htmlElement.scrollHeight, behavior });
           break;
         case "bottom-sticky": {
-          const isNearBottom = htmlElement.scrollHeight - htmlElement.scrollTop - htmlElement.clientHeight <= threshold;
-          if (isNearBottom) htmlElement.scrollTo({ top: htmlElement.scrollHeight, behavior });
+          const initialized = htmlElement.dataset.lvtScrollSticky === "1";
+          if (!initialized) {
+            htmlElement.dataset.lvtScrollSticky = "1";
+            htmlElement.scrollTo({ top: htmlElement.scrollHeight, behavior: "instant" });
+          } else {
+            const isNearBottom = htmlElement.scrollHeight - htmlElement.scrollTop - htmlElement.clientHeight <= threshold;
+            if (isNearBottom) htmlElement.scrollTo({ top: htmlElement.scrollHeight, behavior });
+          }
           break;
         }
         case "top":

--- a/dom/scroll-away.ts
+++ b/dom/scroll-away.ts
@@ -1,0 +1,77 @@
+import { resolveTarget } from "./reactive-attributes";
+
+interface ScrollAwayBinding {
+  trigger: Element;
+  target: Element;
+  handler: () => void;
+}
+
+const GUARD_KEY = "__lvt_scroll_away";
+
+const activeBindings: ScrollAwayBinding[] = [];
+
+export function setupScrollAway(scanRoot: Element): void {
+  const processEl = (el: Element) => {
+    const edge = el.getAttribute("lvt-scroll-away");
+    if (!edge) return;
+    if (edge !== "bottom") {
+      console.warn(`Unknown lvt-scroll-away edge: ${edge}`);
+      return;
+    }
+
+    const target = resolveTarget(el) as HTMLElement;
+    if (!target || target === el) return;
+
+    const existing = (el as any)[GUARD_KEY] as ScrollAwayBinding | undefined;
+    if (existing) {
+      if (existing.target === target) return;
+      existing.target.removeEventListener("scroll", existing.handler);
+      removeBinding(existing);
+    }
+
+    const threshold = parseInt(
+      getComputedStyle(el).getPropertyValue("--lvt-scroll-threshold").trim() || "200",
+      10
+    );
+
+    let ticking = false;
+    const handler = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        ticking = false;
+        const distance = target.scrollHeight - target.scrollTop - target.clientHeight;
+        if (distance > threshold) {
+          el.classList.add("visible");
+        } else {
+          el.classList.remove("visible");
+        }
+      });
+    };
+
+    target.addEventListener("scroll", handler, { passive: true });
+    handler();
+
+    const binding: ScrollAwayBinding = { trigger: el, target, handler };
+    (el as any)[GUARD_KEY] = binding;
+    activeBindings.push(binding);
+  };
+
+  processEl(scanRoot);
+  scanRoot.querySelectorAll("[lvt-scroll-away]").forEach(processEl);
+}
+
+function removeBinding(binding: ScrollAwayBinding): void {
+  const idx = activeBindings.indexOf(binding);
+  if (idx !== -1) activeBindings.splice(idx, 1);
+}
+
+export function teardownScrollAway(wrapper?: Element): void {
+  for (let i = activeBindings.length - 1; i >= 0; i--) {
+    const binding = activeBindings[i];
+    if (wrapper && !wrapper.contains(binding.trigger)) continue;
+    binding.target.removeEventListener("scroll", binding.handler);
+    delete (binding.trigger as any)[GUARD_KEY];
+    activeBindings.splice(i, 1);
+  }
+}

--- a/dom/scroll-away.ts
+++ b/dom/scroll-away.ts
@@ -20,7 +20,10 @@ export function setupScrollAway(scanRoot: Element): void {
     }
 
     const target = resolveTarget(el) as HTMLElement;
-    if (!target || target === el) return;
+    if (!target || target === el) {
+      console.warn("lvt-scroll-away requires data-lvt-target pointing to a scrollable container");
+      return;
+    }
 
     const existing = (el as any)[GUARD_KEY] as ScrollAwayBinding | undefined;
     if (existing) {

--- a/dom/scroll-away.ts
+++ b/dom/scroll-away.ts
@@ -10,7 +10,19 @@ const GUARD_KEY = "__lvt_scroll_away";
 
 const activeBindings: ScrollAwayBinding[] = [];
 
+function pruneDisconnectedBindings(): void {
+  for (let i = activeBindings.length - 1; i >= 0; i--) {
+    const binding = activeBindings[i];
+    if (binding.trigger.isConnected) continue;
+    binding.target.removeEventListener("scroll", binding.handler);
+    delete (binding.trigger as any)[GUARD_KEY];
+    activeBindings.splice(i, 1);
+  }
+}
+
 export function setupScrollAway(scanRoot: Element): void {
+  pruneDisconnectedBindings();
+
   const processEl = (el: Element) => {
     const edge = el.getAttribute("lvt-scroll-away");
     if (!edge) return;
@@ -21,6 +33,12 @@ export function setupScrollAway(scanRoot: Element): void {
 
     const target = resolveTarget(el) as HTMLElement;
     if (!target || target === el) {
+      const existing = (el as any)[GUARD_KEY] as ScrollAwayBinding | undefined;
+      if (existing) {
+        existing.target.removeEventListener("scroll", existing.handler);
+        removeBinding(existing);
+        delete (el as any)[GUARD_KEY];
+      }
       console.warn("lvt-scroll-away requires data-lvt-target pointing to a scrollable container");
       return;
     }
@@ -72,7 +90,7 @@ function removeBinding(binding: ScrollAwayBinding): void {
 export function teardownScrollAway(wrapper?: Element): void {
   for (let i = activeBindings.length - 1; i >= 0; i--) {
     const binding = activeBindings[i];
-    if (wrapper && !wrapper.contains(binding.trigger)) continue;
+    if (wrapper && binding.trigger.isConnected && !wrapper.contains(binding.trigger)) continue;
     binding.target.removeEventListener("scroll", binding.handler);
     delete (binding.trigger as any)[GUARD_KEY];
     activeBindings.splice(i, 1);

--- a/dom/scroll-away.ts
+++ b/dom/scroll-away.ts
@@ -50,10 +50,10 @@ export function setupScrollAway(scanRoot: Element): void {
       removeBinding(existing);
     }
 
-    const threshold = parseInt(
-      getComputedStyle(el).getPropertyValue("--lvt-scroll-threshold").trim() || "200",
-      10
+    const raw = parseInt(
+      getComputedStyle(el).getPropertyValue("--lvt-scroll-threshold").trim(), 10
     );
+    const threshold = isNaN(raw) ? 200 : raw;
 
     let ticking = false;
     const handler = () => {

--- a/dom/scroll-away.ts
+++ b/dom/scroll-away.ts
@@ -92,6 +92,7 @@ export function teardownScrollAway(wrapper?: Element): void {
     const binding = activeBindings[i];
     if (wrapper && binding.trigger.isConnected && !wrapper.contains(binding.trigger)) continue;
     binding.target.removeEventListener("scroll", binding.handler);
+    binding.trigger.classList.remove("visible");
     delete (binding.trigger as any)[GUARD_KEY];
     activeBindings.splice(i, 1);
   }

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -26,6 +26,7 @@ import { FormDisabler } from "./dom/form-disabler";
 import { setupReactiveAttributeListeners } from "./dom/reactive-attributes";
 import { setupInvokerPolyfill } from "./dom/invoker-polyfill";
 import { setupHashLink, teardownHashLink, openFromHash, safeMatchesPopoverOpen } from "./dom/hash-link";
+import { setupScrollAway, teardownScrollAway } from "./dom/scroll-away";
 import { TreeRenderer } from "./state/tree-renderer";
 import { FormLifecycleManager } from "./state/form-lifecycle-manager";
 import { ChangeAutoWirer } from "./state/change-auto-wirer";
@@ -458,6 +459,7 @@ export class LiveTemplateClient {
     if (this.wrapperElement) {
       teardownFxDOMEventTriggers(this.wrapperElement);
       teardownFxLifecycleListeners(this.wrapperElement);
+      teardownScrollAway(this.wrapperElement);
     }
     this.resetSessionState();
   }
@@ -1329,6 +1331,9 @@ export class LiveTemplateClient {
 
     // Re-scan updated subtree for lvt-el:*:on:{event} DOM triggers
     this.eventDelegator.setupDOMEventTriggerDelegation(element);
+
+    // Set up scroll-away visibility toggles
+    setupScrollAway(element);
 
     // Handle toast trigger directives (ephemeral client-side toasts)
     handleToastDirectives(element);

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -63,25 +63,13 @@ describe("handleScrollDirectives", () => {
     });
   });
 
-  it("sticky bottom only scrolls when near bottom", () => {
-    document.body.innerHTML = `<div id="container" lvt-fx:scroll="bottom-sticky" style="--lvt-scroll-threshold: 50;"></div>`;
-    const container = document.getElementById("container")!;
-    Object.defineProperty(container, "scrollHeight", { value: 500, configurable: true });
-    Object.defineProperty(container, "scrollTop", { value: 400, configurable: true });
-    Object.defineProperty(container, "clientHeight", { value: 100, configurable: true });
-
-    const scrollToSpy = jest.fn();
-    container.scrollTo = scrollToSpy;
-
-    handleScrollDirectives(document.body);
-
-    // scrollHeight (500) - scrollTop (400) - clientHeight (100) = 0, which is <= threshold (50)
-    expect(scrollToSpy).toHaveBeenCalled();
-  });
-
-  it("sticky bottom does not scroll when far from bottom", () => {
-    document.body.innerHTML = `<div id="container" lvt-fx:scroll="bottom-sticky" style="--lvt-scroll-threshold: 50;"></div>`;
-    const container = document.getElementById("container")!;
+  it("bottom-sticky scrolls unconditionally on first encounter", () => {
+    document.body.replaceChildren();
+    const container = document.createElement("div");
+    container.id = "container";
+    container.setAttribute("lvt-fx:scroll", "bottom-sticky");
+    container.style.setProperty("--lvt-scroll-threshold", "50");
+    document.body.appendChild(container);
     Object.defineProperty(container, "scrollHeight", { value: 500, configurable: true });
     Object.defineProperty(container, "scrollTop", { value: 0, configurable: true });
     Object.defineProperty(container, "clientHeight", { value: 100, configurable: true });
@@ -91,7 +79,47 @@ describe("handleScrollDirectives", () => {
 
     handleScrollDirectives(document.body);
 
-    // scrollHeight (500) - scrollTop (0) - clientHeight (100) = 400, which is > threshold (50)
+    expect(scrollToSpy).toHaveBeenCalledWith({ top: 500, behavior: "instant" });
+    expect(container.dataset.lvtScrollSticky).toBe("1");
+  });
+
+  it("bottom-sticky scrolls when near bottom after initialization", () => {
+    document.body.replaceChildren();
+    const container = document.createElement("div");
+    container.id = "container";
+    container.setAttribute("lvt-fx:scroll", "bottom-sticky");
+    container.style.setProperty("--lvt-scroll-threshold", "50");
+    container.dataset.lvtScrollSticky = "1";
+    document.body.appendChild(container);
+    Object.defineProperty(container, "scrollHeight", { value: 500, configurable: true });
+    Object.defineProperty(container, "scrollTop", { value: 400, configurable: true });
+    Object.defineProperty(container, "clientHeight", { value: 100, configurable: true });
+
+    const scrollToSpy = jest.fn();
+    container.scrollTo = scrollToSpy;
+
+    handleScrollDirectives(document.body);
+
+    expect(scrollToSpy).toHaveBeenCalled();
+  });
+
+  it("bottom-sticky does not scroll when far from bottom after initialization", () => {
+    document.body.replaceChildren();
+    const container = document.createElement("div");
+    container.id = "container";
+    container.setAttribute("lvt-fx:scroll", "bottom-sticky");
+    container.style.setProperty("--lvt-scroll-threshold", "50");
+    container.dataset.lvtScrollSticky = "1";
+    document.body.appendChild(container);
+    Object.defineProperty(container, "scrollHeight", { value: 500, configurable: true });
+    Object.defineProperty(container, "scrollTop", { value: 0, configurable: true });
+    Object.defineProperty(container, "clientHeight", { value: 100, configurable: true });
+
+    const scrollToSpy = jest.fn();
+    container.scrollTo = scrollToSpy;
+
+    handleScrollDirectives(document.body);
+
     expect(scrollToSpy).not.toHaveBeenCalled();
   });
 
@@ -356,5 +384,44 @@ describe("setupFxDOMEventTriggers", () => {
     target.dispatchEvent(new MouseEvent("mouseenter"));
 
     expect(target.style.backgroundColor).not.toBe("");
+  });
+
+  it("resolves data-lvt-target for scroll effect on click", () => {
+    const container = document.createElement("div");
+    container.id = "chat-log";
+    Object.defineProperty(container, "scrollHeight", { value: 500, configurable: true });
+    const scrollToSpy = jest.fn();
+    container.scrollTo = scrollToSpy;
+    document.body.appendChild(container);
+
+    const button = document.createElement("button");
+    button.setAttribute("lvt-fx:scroll:on:click", "bottom");
+    button.setAttribute("data-lvt-target", "#chat-log");
+    document.body.appendChild(button);
+
+    setupFxDOMEventTriggers(document.body);
+    button.click();
+
+    expect(scrollToSpy).toHaveBeenCalledWith({
+      top: 500,
+      behavior: "auto",
+    });
+  });
+
+  it("resolves data-lvt-target for highlight effect on click", () => {
+    const target = document.createElement("div");
+    target.id = "my-target";
+    document.body.appendChild(target);
+
+    const trigger = document.createElement("button");
+    trigger.setAttribute("lvt-fx:highlight:on:click", "flash");
+    trigger.setAttribute("data-lvt-target", "#my-target");
+    document.body.appendChild(trigger);
+
+    setupFxDOMEventTriggers(document.body);
+    trigger.click();
+
+    expect(target.style.backgroundColor).not.toBe("");
+    expect(trigger.style.backgroundColor).toBe("");
   });
 });

--- a/tests/scroll-away.test.ts
+++ b/tests/scroll-away.test.ts
@@ -1,0 +1,234 @@
+import { setupScrollAway, teardownScrollAway } from "../dom/scroll-away";
+
+function mockScrollableElement(
+  id: string,
+  props: { scrollHeight: number; scrollTop: number; clientHeight: number }
+): HTMLDivElement {
+  const el = document.createElement("div");
+  el.id = id;
+  Object.defineProperty(el, "scrollHeight", { value: props.scrollHeight, configurable: true });
+  Object.defineProperty(el, "scrollTop", { value: props.scrollTop, configurable: true, writable: true });
+  Object.defineProperty(el, "clientHeight", { value: props.clientHeight, configurable: true });
+  return el;
+}
+
+describe("setupScrollAway", () => {
+  let rafCallbacks: FrameRequestCallback[];
+
+  beforeEach(() => {
+    document.body.replaceChildren();
+    rafCallbacks = [];
+    jest.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    });
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    teardownScrollAway();
+    jest.restoreAllMocks();
+  });
+
+  function flushRAF() {
+    const cbs = rafCallbacks.splice(0);
+    cbs.forEach((cb) => cb(performance.now()));
+  }
+
+  it("adds 'visible' class when scrolled away from bottom", () => {
+    const container = mockScrollableElement("chat-log", {
+      scrollHeight: 1000,
+      scrollTop: 0,
+      clientHeight: 400,
+    });
+    document.body.appendChild(container);
+
+    const button = document.createElement("button");
+    button.setAttribute("lvt-scroll-away", "bottom");
+    button.setAttribute("data-lvt-target", "#chat-log");
+    document.body.appendChild(button);
+
+    setupScrollAway(document.body);
+    flushRAF();
+
+    expect(button.classList.contains("visible")).toBe(true);
+  });
+
+  it("removes 'visible' class when at bottom", () => {
+    const container = mockScrollableElement("chat-log", {
+      scrollHeight: 1000,
+      scrollTop: 600,
+      clientHeight: 400,
+    });
+    document.body.appendChild(container);
+
+    const button = document.createElement("button");
+    button.setAttribute("lvt-scroll-away", "bottom");
+    button.setAttribute("data-lvt-target", "#chat-log");
+    document.body.appendChild(button);
+
+    setupScrollAway(document.body);
+    flushRAF();
+
+    expect(button.classList.contains("visible")).toBe(false);
+  });
+
+  it("toggles on scroll events", () => {
+    const container = mockScrollableElement("chat-log", {
+      scrollHeight: 1000,
+      scrollTop: 600,
+      clientHeight: 400,
+    });
+    document.body.appendChild(container);
+
+    const button = document.createElement("button");
+    button.setAttribute("lvt-scroll-away", "bottom");
+    button.setAttribute("data-lvt-target", "#chat-log");
+    document.body.appendChild(button);
+
+    setupScrollAway(document.body);
+    flushRAF();
+    expect(button.classList.contains("visible")).toBe(false);
+
+    Object.defineProperty(container, "scrollTop", { value: 0, configurable: true });
+    container.dispatchEvent(new Event("scroll"));
+    flushRAF();
+    expect(button.classList.contains("visible")).toBe(true);
+
+    Object.defineProperty(container, "scrollTop", { value: 600, configurable: true });
+    container.dispatchEvent(new Event("scroll"));
+    flushRAF();
+    expect(button.classList.contains("visible")).toBe(false);
+  });
+
+  it("uses default threshold of 200 when no CSS property set", () => {
+    const container = mockScrollableElement("chat-log", {
+      scrollHeight: 1000,
+      scrollTop: 700,
+      clientHeight: 100,
+    });
+    document.body.appendChild(container);
+
+    const button = document.createElement("button");
+    button.setAttribute("lvt-scroll-away", "bottom");
+    button.setAttribute("data-lvt-target", "#chat-log");
+    document.body.appendChild(button);
+
+    setupScrollAway(document.body);
+    flushRAF();
+
+    // distance = 1000 - 700 - 100 = 200, which is NOT > 200
+    expect(button.classList.contains("visible")).toBe(false);
+  });
+
+  it("does not attach listener when no target resolves (self-target)", () => {
+    const button = document.createElement("button");
+    button.setAttribute("lvt-scroll-away", "bottom");
+    document.body.appendChild(button);
+
+    setupScrollAway(document.body);
+
+    expect((button as any).__lvt_scroll_away).toBeUndefined();
+  });
+
+  it("warns on unknown edge value", () => {
+    const container = mockScrollableElement("chat-log", {
+      scrollHeight: 1000,
+      scrollTop: 0,
+      clientHeight: 400,
+    });
+    document.body.appendChild(container);
+
+    const button = document.createElement("button");
+    button.setAttribute("lvt-scroll-away", "top");
+    button.setAttribute("data-lvt-target", "#chat-log");
+    document.body.appendChild(button);
+
+    setupScrollAway(document.body);
+
+    expect(console.warn).toHaveBeenCalledWith("Unknown lvt-scroll-away edge: top");
+  });
+
+  it("does not duplicate listeners on re-scan with same target", () => {
+    const container = mockScrollableElement("chat-log", {
+      scrollHeight: 1000,
+      scrollTop: 0,
+      clientHeight: 400,
+    });
+    document.body.appendChild(container);
+
+    const button = document.createElement("button");
+    button.setAttribute("lvt-scroll-away", "bottom");
+    button.setAttribute("data-lvt-target", "#chat-log");
+    document.body.appendChild(button);
+
+    setupScrollAway(document.body);
+    const firstBinding = (button as any).__lvt_scroll_away;
+
+    setupScrollAway(document.body);
+    const secondBinding = (button as any).__lvt_scroll_away;
+
+    expect(firstBinding).toBe(secondBinding);
+  });
+
+  it("re-attaches listener when target element is replaced", () => {
+    const container1 = mockScrollableElement("chat-log", {
+      scrollHeight: 1000,
+      scrollTop: 0,
+      clientHeight: 400,
+    });
+    document.body.appendChild(container1);
+
+    const button = document.createElement("button");
+    button.setAttribute("lvt-scroll-away", "bottom");
+    button.setAttribute("data-lvt-target", "#chat-log");
+    document.body.appendChild(button);
+
+    setupScrollAway(document.body);
+    flushRAF();
+    expect(button.classList.contains("visible")).toBe(true);
+
+    // Replace the container (simulating morphdom replacement)
+    container1.remove();
+    const container2 = mockScrollableElement("chat-log", {
+      scrollHeight: 500,
+      scrollTop: 100,
+      clientHeight: 400,
+    });
+    document.body.appendChild(container2);
+
+    setupScrollAway(document.body);
+    flushRAF();
+
+    // distance = 500 - 100 - 400 = 0, not > 200
+    expect(button.classList.contains("visible")).toBe(false);
+  });
+
+  it("teardown removes all listeners", () => {
+    const container = mockScrollableElement("chat-log", {
+      scrollHeight: 1000,
+      scrollTop: 0,
+      clientHeight: 400,
+    });
+    document.body.appendChild(container);
+
+    const button = document.createElement("button");
+    button.setAttribute("lvt-scroll-away", "bottom");
+    button.setAttribute("data-lvt-target", "#chat-log");
+    document.body.appendChild(button);
+
+    setupScrollAway(document.body);
+    flushRAF();
+    expect(button.classList.contains("visible")).toBe(true);
+
+    teardownScrollAway();
+    expect((button as any).__lvt_scroll_away).toBeUndefined();
+
+    button.classList.remove("visible");
+    container.dispatchEvent(new Event("scroll"));
+    flushRAF();
+
+    // Listener removed: class should stay removed
+    expect(button.classList.contains("visible")).toBe(false);
+  });
+});

--- a/tests/scroll-away.test.ts
+++ b/tests/scroll-away.test.ts
@@ -121,7 +121,7 @@ describe("setupScrollAway", () => {
     expect(button.classList.contains("visible")).toBe(false);
   });
 
-  it("does not attach listener when no target resolves (self-target)", () => {
+  it("warns and skips when no target resolves (self-target)", () => {
     const button = document.createElement("button");
     button.setAttribute("lvt-scroll-away", "bottom");
     document.body.appendChild(button);
@@ -129,6 +129,9 @@ describe("setupScrollAway", () => {
     setupScrollAway(document.body);
 
     expect((button as any).__lvt_scroll_away).toBeUndefined();
+    expect(console.warn).toHaveBeenCalledWith(
+      "lvt-scroll-away requires data-lvt-target pointing to a scrollable container"
+    );
   });
 
   it("warns on unknown edge value", () => {


### PR DESCRIPTION
## Summary

- **`data-lvt-target` resolution for scroll effects**: `setupFxDOMEventTriggers()` now resolves `data-lvt-target` before passing the element to `applyFxEffect`, enabling patterns like `lvt-fx:scroll:on:click="bottom" data-lvt-target="#chat-log"` where a button scrolls a different element.
- **`lvt-scroll-away` attribute**: New scroll-position visibility toggle that adds/removes `.visible` class based on scroll distance from an edge. Supports `data-lvt-target` for watching a different scrollable element and `--lvt-scroll-threshold` CSS custom property.
- **`bottom-sticky` first-run detection**: On first encounter, scrolls unconditionally with `behavior: "instant"` to show latest content, then becomes sticky. Session switches reset via `data-key` change.

## Test plan

- [x] `data-lvt-target` resolution test for scroll + click
- [x] `data-lvt-target` resolution test for highlight + click
- [x] `bottom-sticky` first-run unconditional scroll test
- [x] `bottom-sticky` near-bottom sticky scroll test
- [x] `bottom-sticky` far-from-bottom skip test
- [x] 9 scroll-away tests (visibility toggle, threshold, teardown, duplication guard)
- [x] All 440 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)