### PR TITLE
fix(release): use explicit refspec to update tracking ref before sync check

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -468,10 +468,12 @@ main() {
         branch="main"
         log_info "Switched to main"
     fi
-    # Fetch origin/$branch so we can compare local vs remote state.
-    # Note: fetch updates remote-tracking refs in .git — a minor side effect required to check sync state.
+    # Fetch origin/$branch and force-update the tracking ref so the
+    # rev-list ahead/behind comparison below uses current remote state.
+    # Plain `git fetch origin $branch` only updates FETCH_HEAD in some
+    # git versions/configs, leaving refs/remotes/origin/$branch stale.
     log_step "Fetching origin/$branch to check sync state"
-    if ! git fetch origin "$branch" --quiet; then
+    if ! git fetch origin "+refs/heads/$branch:refs/remotes/origin/$branch" --quiet; then
         log_error "Could not fetch origin/$branch. Check your network connection."
         exit 1
     fi


### PR DESCRIPTION
## Summary

- `git fetch origin $branch` only updates `FETCH_HEAD` in some git versions/configs, leaving `refs/remotes/origin/$branch` stale
- The `git rev-list --count HEAD..origin/$branch` ahead/behind comparison then operates on outdated state
- This caused the v0.8.33 release to misdetect "1 ahead" when remote was actually 1 ahead (PR #94 had landed), leading to a push rejection instead of a pull
- Fix: use explicit refspec `+refs/heads/$branch:refs/remotes/origin/$branch` to force-update the tracking ref

## Test plan

- [x] `bash -n scripts/release.sh` — syntax check passes
- [x] All 440 tests pass
- [ ] Run `./scripts/release.sh --dry-run` to verify fetch + sync detection works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)