### PR TITLE
feat: reconnect WebSocket on visibility change (iOS background fix)

### DIFF
--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -568,6 +568,14 @@ export class LiveTemplateClient {
     // otherwise a timer queued before disconnect can fire after a
     // subsequent connect on the same instance and trigger an
     // unwanted reconnect.
+    //
+    // Cancel any in-flight timer first so a rapid
+    // visibilitychange+pageshow sequence doesn't leak the earlier
+    // setTimeout (the tracked ref would only point at the last one,
+    // leaving the first orphaned).
+    if (this.visibilityReconnectTimer !== null) {
+      clearTimeout(this.visibilityReconnectTimer);
+    }
     this.visibilityReconnectTimer = setTimeout(() => {
       this.visibilityReconnectTimer = null;
       // Guard: only reconnect if a WebSocket transport exists. After
@@ -601,6 +609,15 @@ export class LiveTemplateClient {
       this.resetSessionState();
 
       const result = await this.webSocketManager.connect();
+
+      // disconnect() may have run during the await above. It clears the
+      // reconnecting flag, so the absence of that flag here is our
+      // "torn down while suspended" signal — abort without mutating
+      // state. Without this, useHTTP / payload application would land
+      // on a client the consumer expects to be inert (or, worse, on a
+      // freshly-reconnected client created by a subsequent connect()).
+      if (!this.reconnecting) return;
+
       this.useHTTP = !result.usingWebSocket;
 
       if (this.useHTTP) {

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -93,6 +93,15 @@ export class LiveTemplateClient {
   // observe side-effects.
   private liveUrlOverride: string | null = null;
 
+  // Visibility-based reconnection: when the browser tab returns from
+  // background (iOS app switch, Android task switch), the WebSocket is
+  // often silently dead. These fields drive a one-shot reconnect on
+  // the visibilitychange event, independent of autoReconnect (which
+  // guards against retry loops on persistent network failures).
+  private visibilityHandlerAttached: boolean = false;
+  private hiddenAt: number = 0;
+  private reconnecting: boolean = false;
+
   constructor(options: LiveTemplateClientOptions = {}) {
     const { logger: providedLogger, logLevel, debug, ...restOptions } = options;
     const resolvedLevel = logLevel ?? (debug ? "debug" : "info");
@@ -445,6 +454,8 @@ export class LiveTemplateClient {
     // Set up infinite scroll observers
     this.observerManager.setupInfiniteScrollObserver();
     this.observerManager.setupInfiniteScrollMutationObserver();
+
+    this.setupVisibilityReconnect();
   }
 
   /**
@@ -454,6 +465,7 @@ export class LiveTemplateClient {
     this.webSocketManager.disconnect();
     this.ws = null;
     this.useHTTP = false;
+    this.hiddenAt = 0;
     this.eventDelegator.teardownDOMEventTriggerDelegation();
     teardownHashLink();
     if (this.wrapperElement) {
@@ -487,6 +499,85 @@ export class LiveTemplateClient {
     this.formDisabler.enable(this.wrapperElement);
     this.lvtId = null;
     this.isInitialized = false;
+  }
+
+  private setupVisibilityReconnect(): void {
+    if (this.visibilityHandlerAttached || typeof document === "undefined") return;
+    this.visibilityHandlerAttached = true;
+
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) {
+        // Only track hidden time if WebSocket is currently open.
+        // Prevents stale handlers from triggering reconnection on
+        // already-disconnected clients (e.g. after cross-handler
+        // navigation or explicit disconnect).
+        if (!this.useHTTP && this.webSocketManager.getReadyState() === 1) {
+          this.hiddenAt = Date.now();
+        }
+        return;
+      }
+      if (this.hiddenAt === 0) return;
+      const elapsed = Date.now() - this.hiddenAt;
+      this.hiddenAt = 0;
+      if (elapsed < 3000) return;
+      this.scheduleVisibilityReconnect();
+    });
+
+    window.addEventListener("pageshow", (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        this.scheduleVisibilityReconnect();
+      }
+    });
+  }
+
+  private scheduleVisibilityReconnect(): void {
+    setTimeout(() => {
+      // Guard: only reconnect if a WebSocket transport exists. After
+      // disconnect(), transport is null (readyState undefined) so we
+      // correctly skip intentionally disconnected clients.
+      // Note: we intentionally do NOT check readyState !== 1 (OPEN)
+      // because iOS 15+ can leave zombie sockets that report OPEN while
+      // the underlying TCP connection is dead. Always reconnecting after
+      // a long background is cheap (morphdom diffs produce no DOM changes
+      // on a healthy connection) and handles the zombie case.
+      if (
+        this.wrapperElement &&
+        !this.useHTTP &&
+        !this.reconnecting &&
+        this.webSocketManager.getReadyState() !== undefined
+      ) {
+        this.performVisibilityReconnect();
+      }
+    }, 500);
+  }
+
+  private async performVisibilityReconnect(): Promise<void> {
+    if (this.reconnecting) return;
+    this.reconnecting = true;
+
+    try {
+      this.logger.info("Reconnecting after visibility change");
+
+      this.webSocketManager.disconnect();
+      this.ws = null;
+      this.resetSessionState();
+
+      const result = await this.webSocketManager.connect();
+      this.useHTTP = !result.usingWebSocket;
+
+      if (this.useHTTP) {
+        this.ws = null;
+        if (result.initialState && this.wrapperElement) {
+          this.handleWebSocketPayload(result.initialState);
+        }
+      }
+
+      this.wrapperElement?.dispatchEvent(new Event("lvt:reconnected"));
+    } catch (err) {
+      this.logger.error("Visibility reconnect failed:", err);
+    } finally {
+      this.reconnecting = false;
+    }
   }
 
   /**

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -106,6 +106,7 @@ export class LiveTemplateClient {
   private reconnecting: boolean = false;
   private visibilityHandler: (() => void) | null = null;
   private pageshowHandler: ((e: PageTransitionEvent) => void) | null = null;
+  private visibilityReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(options: LiveTemplateClientOptions = {}) {
     const { logger: providedLogger, logLevel, debug, ...restOptions } = options;
@@ -544,6 +545,10 @@ export class LiveTemplateClient {
   }
 
   private teardownVisibilityReconnect(): void {
+    if (this.visibilityReconnectTimer !== null) {
+      clearTimeout(this.visibilityReconnectTimer);
+      this.visibilityReconnectTimer = null;
+    }
     if (!this.visibilityHandlerAttached || typeof document === "undefined") return;
     if (this.visibilityHandler) {
       document.removeEventListener("visibilitychange", this.visibilityHandler);
@@ -557,7 +562,14 @@ export class LiveTemplateClient {
   }
 
   private scheduleVisibilityReconnect(): void {
-    setTimeout(() => {
+    // 500ms delay lets onclose deliver before we ask for a new socket.
+    // Tracked on the instance so teardownVisibilityReconnect() can
+    // cancel a pending timer when disconnect() runs mid-window —
+    // otherwise a timer queued before disconnect can fire after a
+    // subsequent connect on the same instance and trigger an
+    // unwanted reconnect.
+    this.visibilityReconnectTimer = setTimeout(() => {
+      this.visibilityReconnectTimer = null;
       // Guard: only reconnect if a WebSocket transport exists. After
       // disconnect(), transport is null (readyState undefined) so we
       // correctly skip intentionally disconnected clients.

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -98,9 +98,14 @@ export class LiveTemplateClient {
   // often silently dead. These fields drive a one-shot reconnect on
   // the visibilitychange event, independent of autoReconnect (which
   // guards against retry loops on persistent network failures).
+  // Handlers are stored as instance properties so disconnect() can
+  // remove them — without that, SPAs that build a new client per route
+  // accumulate listeners that hold closures over destroyed instances.
   private visibilityHandlerAttached: boolean = false;
   private hiddenAt: number = 0;
   private reconnecting: boolean = false;
+  private visibilityHandler: (() => void) | null = null;
+  private pageshowHandler: ((e: PageTransitionEvent) => void) | null = null;
 
   constructor(options: LiveTemplateClientOptions = {}) {
     const { logger: providedLogger, logLevel, debug, ...restOptions } = options;
@@ -466,6 +471,8 @@ export class LiveTemplateClient {
     this.ws = null;
     this.useHTTP = false;
     this.hiddenAt = 0;
+    this.reconnecting = false;
+    this.teardownVisibilityReconnect();
     this.eventDelegator.teardownDOMEventTriggerDelegation();
     teardownHashLink();
     if (this.wrapperElement) {
@@ -505,7 +512,7 @@ export class LiveTemplateClient {
     if (this.visibilityHandlerAttached || typeof document === "undefined") return;
     this.visibilityHandlerAttached = true;
 
-    document.addEventListener("visibilitychange", () => {
+    this.visibilityHandler = () => {
       if (document.hidden) {
         // Only track hidden time if WebSocket is currently open.
         // Prevents stale handlers from triggering reconnection on
@@ -521,13 +528,32 @@ export class LiveTemplateClient {
       this.hiddenAt = 0;
       if (elapsed < 3000) return;
       this.scheduleVisibilityReconnect();
-    });
+    };
 
-    window.addEventListener("pageshow", (event: PageTransitionEvent) => {
+    // pageshow's persisted=true means the page came back from bfcache —
+    // its in-memory connection state is unknown, so reconnect unconditionally
+    // (no 3s threshold). visibilitychange handles ordinary tab-switch cases.
+    this.pageshowHandler = (event: PageTransitionEvent) => {
       if (event.persisted) {
         this.scheduleVisibilityReconnect();
       }
-    });
+    };
+
+    document.addEventListener("visibilitychange", this.visibilityHandler);
+    window.addEventListener("pageshow", this.pageshowHandler);
+  }
+
+  private teardownVisibilityReconnect(): void {
+    if (!this.visibilityHandlerAttached || typeof document === "undefined") return;
+    if (this.visibilityHandler) {
+      document.removeEventListener("visibilitychange", this.visibilityHandler);
+      this.visibilityHandler = null;
+    }
+    if (this.pageshowHandler) {
+      window.removeEventListener("pageshow", this.pageshowHandler);
+      this.pageshowHandler = null;
+    }
+    this.visibilityHandlerAttached = false;
   }
 
   private scheduleVisibilityReconnect(): void {

--- a/tests/visibility-reconnect.test.ts
+++ b/tests/visibility-reconnect.test.ts
@@ -273,25 +273,35 @@ describe("Visibility-based reconnection", () => {
     expect(mockSockets.length).toBe(initialSocketCount);
   });
 
-  it("registers visibility handler only once across multiple connect calls", async () => {
+  it("removes the old visibility handler on disconnect and re-registers on reconnect", async () => {
     await connectClient();
 
     const addEventSpy = jest.spyOn(document, "addEventListener");
+    const removeEventSpy = jest.spyOn(document, "removeEventListener");
 
-    // Reconnect — setupVisibilityReconnect should be a no-op
+    // disconnect must remove the previously registered handler so that
+    // SPAs that build a new client per route don't accumulate listeners
+    // holding closures over destroyed instances.
     client.disconnect();
+    const removed = removeEventSpy.mock.calls.filter(
+      ([event]) => event === "visibilitychange"
+    );
+    expect(removed.length).toBe(1);
+
+    // The next connect re-attaches a fresh handler — exactly one.
     createWrapper();
     const connectPromise = client.connect();
     await jest.advanceTimersByTimeAsync(0);
     mockSockets[mockSockets.length - 1]?.simulateOpen();
     await connectPromise;
 
-    const visibilityCalls = addEventSpy.mock.calls.filter(
+    const added = addEventSpy.mock.calls.filter(
       ([event]) => event === "visibilitychange"
     );
-    expect(visibilityCalls.length).toBe(0);
+    expect(added.length).toBe(1);
 
     addEventSpy.mockRestore();
+    removeEventSpy.mockRestore();
   });
 
   it("dispatches lvt:reconnected event on successful reconnect", async () => {

--- a/tests/visibility-reconnect.test.ts
+++ b/tests/visibility-reconnect.test.ts
@@ -1,0 +1,346 @@
+import { LiveTemplateClient } from "../livetemplate-client";
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  url: string;
+  readyState: number = MockWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  send(_data: string) {}
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    if (this.onclose) {
+      this.onclose(new CloseEvent("close", { code: 1000 }));
+    }
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    if (this.onopen) {
+      this.onopen(new Event("open"));
+    }
+  }
+
+  simulateClose() {
+    this.readyState = MockWebSocket.CLOSED;
+    if (this.onclose) {
+      this.onclose(new CloseEvent("close", { code: 1006 }));
+    }
+  }
+}
+
+let mockSockets: MockWebSocket[] = [];
+
+function installMockWebSocket() {
+  mockSockets = [];
+  const WS = jest.fn().mockImplementation((url: string) => {
+    const sock = new MockWebSocket(url);
+    mockSockets.push(sock);
+    return sock;
+  }) as any;
+  WS.CONNECTING = 0;
+  WS.OPEN = 1;
+  WS.CLOSING = 2;
+  WS.CLOSED = 3;
+  (global as any).WebSocket = WS;
+}
+
+function installFetchStub() {
+  if (typeof (globalThis as any).fetch !== "function") {
+    (globalThis as any).fetch = () => {};
+  }
+  jest.spyOn(globalThis as any, "fetch").mockImplementation((...args: unknown[]) => {
+    const opts = args[1] as any;
+    if (opts?.method === "HEAD") {
+      return Promise.resolve(
+        new Response(null, {
+          status: 200,
+          headers: { "X-LiveTemplate-WebSocket": "enabled" },
+        })
+      );
+    }
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  });
+}
+
+function createWrapper(): HTMLDivElement {
+  const wrapper = document.createElement("div");
+  wrapper.setAttribute("data-lvt-id", "test-visibility");
+  document.body.appendChild(wrapper);
+  return wrapper;
+}
+
+function fireVisibilityChange(hidden: boolean) {
+  Object.defineProperty(document, "hidden", {
+    value: hidden,
+    writable: true,
+    configurable: true,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+function firePageShow(persisted: boolean) {
+  const event = new PageTransitionEvent("pageshow", { persisted });
+  window.dispatchEvent(event);
+}
+
+// Simulates a background/foreground cycle with the given elapsed time
+function simulateBackground(ms: number) {
+  fireVisibilityChange(true);
+  jest.advanceTimersByTime(ms);
+  fireVisibilityChange(false);
+}
+
+describe("Visibility-based reconnection", () => {
+  let client: LiveTemplateClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.replaceChildren();
+    installMockWebSocket();
+    installFetchStub();
+    history.replaceState(null, "", "/test");
+  });
+
+  afterEach(() => {
+    client?.disconnect();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  async function connectClient(): Promise<void> {
+    createWrapper();
+    client = new LiveTemplateClient({ logLevel: "error" });
+    const connectPromise = client.connect();
+    // Resolve the HEAD fetch
+    await jest.advanceTimersByTimeAsync(0);
+    // Open the WebSocket
+    mockSockets[0]?.simulateOpen();
+    await connectPromise;
+  }
+
+  it("reconnects when page becomes visible after >3s with dead WebSocket", async () => {
+    await connectClient();
+    expect(client.isReady()).toBe(true);
+
+    // Simulate iOS background: WebSocket dies while hidden
+    fireVisibilityChange(true);
+    jest.advanceTimersByTime(1000);
+    mockSockets[0].simulateClose();
+    jest.advanceTimersByTime(4000);
+    fireVisibilityChange(false);
+
+    // Wait for the 500ms reconnect delay + resolve async connect
+    await jest.advanceTimersByTimeAsync(500);
+    // Let the HEAD fetch inside performVisibilityReconnect resolve
+    await jest.advanceTimersByTimeAsync(0);
+
+    // A new WebSocket should have been created for reconnection
+    expect(mockSockets.length).toBe(2);
+
+    // Simulate successful reconnection
+    mockSockets[1].simulateOpen();
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(client.isReady()).toBe(true);
+  });
+
+  it("does not reconnect on short background (<3s)", async () => {
+    await connectClient();
+    const initialSocketCount = mockSockets.length;
+
+    // Background for only 2 seconds then WebSocket dies
+    fireVisibilityChange(true);
+    jest.advanceTimersByTime(500);
+    mockSockets[0].simulateClose();
+    jest.advanceTimersByTime(1500);
+    fireVisibilityChange(false);
+
+    // Wait well past the 500ms delay
+    await jest.advanceTimersByTimeAsync(1000);
+
+    // No reconnection attempt — elapsed < 3s
+    expect(mockSockets.length).toBe(initialSocketCount);
+  });
+
+  it("reconnects even when WebSocket reports OPEN (zombie socket defense)", async () => {
+    await connectClient();
+    expect(client.isReady()).toBe(true);
+    const initialSocketCount = mockSockets.length;
+
+    // Background for 5 seconds — WebSocket stays OPEN (possible zombie)
+    simulateBackground(5000);
+
+    // Wait for the 500ms delay + resolve async connect
+    await jest.advanceTimersByTimeAsync(500);
+    await jest.advanceTimersByTimeAsync(0);
+
+    // Should reconnect regardless of readyState — iOS zombie defense
+    expect(mockSockets.length).toBe(initialSocketCount + 1);
+
+    // Complete the reconnection
+    mockSockets[mockSockets.length - 1].simulateOpen();
+    await jest.advanceTimersByTimeAsync(0);
+    expect(client.isReady()).toBe(true);
+  });
+
+  it("does not set hiddenAt when no WebSocket transport exists", () => {
+    // Unit-level guard test: in HTTP mode (or after disconnect), there
+    // is no WebSocket transport, so getReadyState() returns undefined.
+    // The visibility handler should not set hiddenAt and therefore
+    // never schedule a reconnect. This avoids needing to stand up a
+    // full HTTP-mode client with its complex async initialization.
+    createWrapper();
+    client = new LiveTemplateClient({ logLevel: "error" });
+
+    // Client hasn't connected — no transport exists.
+    // Fire visibility events to verify the handler guards work.
+    fireVisibilityChange(true);
+    fireVisibilityChange(false);
+
+    // With no transport, the hidden handler's readyState check blocks
+    // hiddenAt from being set. The visible handler sees hiddenAt === 0
+    // and returns early. No setTimeout is scheduled.
+    expect(jest.getTimerCount()).toBe(0);
+    expect(mockSockets.length).toBe(0);
+  });
+
+  it("prevents duplicate concurrent reconnects", async () => {
+    await connectClient();
+    const initialSocketCount = mockSockets.length;
+
+    // WebSocket dies while connected
+    fireVisibilityChange(true);
+    jest.advanceTimersByTime(500);
+    mockSockets[0].simulateClose();
+    jest.advanceTimersByTime(4500);
+    fireVisibilityChange(false);
+
+    // Schedule another visibility cycle before first reconnect fires
+    // (simulates rapid pageshow + visibilitychange in quick succession)
+    firePageShow(true);
+
+    // Wait for both 500ms delays to fire
+    await jest.advanceTimersByTimeAsync(600);
+    await jest.advanceTimersByTimeAsync(0);
+
+    // Only one reconnection attempt should have been made
+    expect(mockSockets.length).toBe(initialSocketCount + 1);
+  });
+
+  it("reconnects on pageshow with persisted=true", async () => {
+    await connectClient();
+    const initialSocketCount = mockSockets.length;
+
+    // Simulate WebSocket dying
+    mockSockets[0].simulateClose();
+
+    // Simulate bfcache restore
+    firePageShow(true);
+
+    // Wait for the 500ms delay + resolve async
+    await jest.advanceTimersByTimeAsync(500);
+    await jest.advanceTimersByTimeAsync(0);
+
+    // Should attempt reconnection
+    expect(mockSockets.length).toBe(initialSocketCount + 1);
+  });
+
+  it("does not reconnect on pageshow with persisted=false", async () => {
+    await connectClient();
+    const initialSocketCount = mockSockets.length;
+
+    // Simulate WebSocket dying
+    mockSockets[0].simulateClose();
+
+    // Normal page load (not from bfcache)
+    firePageShow(false);
+
+    await jest.advanceTimersByTimeAsync(500);
+
+    // No reconnection
+    expect(mockSockets.length).toBe(initialSocketCount);
+  });
+
+  it("registers visibility handler only once across multiple connect calls", async () => {
+    await connectClient();
+
+    const addEventSpy = jest.spyOn(document, "addEventListener");
+
+    // Reconnect — setupVisibilityReconnect should be a no-op
+    client.disconnect();
+    createWrapper();
+    const connectPromise = client.connect();
+    await jest.advanceTimersByTimeAsync(0);
+    mockSockets[mockSockets.length - 1]?.simulateOpen();
+    await connectPromise;
+
+    const visibilityCalls = addEventSpy.mock.calls.filter(
+      ([event]) => event === "visibilitychange"
+    );
+    expect(visibilityCalls.length).toBe(0);
+
+    addEventSpy.mockRestore();
+  });
+
+  it("dispatches lvt:reconnected event on successful reconnect", async () => {
+    await connectClient();
+
+    const wrapper = document.querySelector("[data-lvt-id]")!;
+    const reconnectedSpy = jest.fn();
+    wrapper.addEventListener("lvt:reconnected", reconnectedSpy);
+
+    // Simulate WebSocket dying while backgrounded
+    fireVisibilityChange(true);
+    jest.advanceTimersByTime(500);
+    mockSockets[0].simulateClose();
+    jest.advanceTimersByTime(4500);
+    fireVisibilityChange(false);
+
+    // Wait for 500ms delay
+    await jest.advanceTimersByTimeAsync(500);
+    // Resolve the HEAD fetch inside performVisibilityReconnect
+    await jest.advanceTimersByTimeAsync(0);
+
+    // Complete the reconnection
+    mockSockets[1].simulateOpen();
+    // Flush microtasks so performVisibilityReconnect() completes
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(reconnectedSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reconnect after intentional disconnect", async () => {
+    await connectClient();
+
+    // hiddenAt is tracked while connected
+    fireVisibilityChange(true);
+    jest.advanceTimersByTime(1000);
+
+    // Intentional disconnect while hidden
+    client.disconnect();
+
+    jest.advanceTimersByTime(4000);
+    fireVisibilityChange(false);
+
+    await jest.advanceTimersByTimeAsync(500);
+
+    // hiddenAt was reset by disconnect(), so no reconnection
+    const socketsAfterDisconnect = mockSockets.length;
+    expect(client.isReady()).toBe(false);
+    // No new sockets created — disconnect cleared hiddenAt
+    await jest.advanceTimersByTimeAsync(100);
+    expect(mockSockets.length).toBe(socketsAfterDisconnect);
+  });
+});

--- a/tests/visibility-reconnect.test.ts
+++ b/tests/visibility-reconnect.test.ts
@@ -354,6 +354,56 @@ describe("Visibility-based reconnection", () => {
     expect(mockSockets.length).toBe(socketsAfterDisconnect);
   });
 
+  it("a second schedule call cancels the first timer (rapid visibility+pageshow)", async () => {
+    await connectClient();
+    const initialSocketCount = mockSockets.length;
+
+    // Long background — first schedule queues a 500ms timer
+    fireVisibilityChange(true);
+    jest.advanceTimersByTime(4000);
+    fireVisibilityChange(false);
+    // bfcache restore fires almost immediately after — second schedule
+    firePageShow(true);
+
+    // Disconnect within the 500ms window. Without rescheduling cancelling
+    // the previous timer, the first timer would not be tracked by
+    // visibilityReconnectTimer (overwritten by the second), so
+    // teardownVisibilityReconnect() would only cancel the second.
+    // The first would fire after disconnect and trigger a reconnect.
+    client.disconnect();
+    await jest.advanceTimersByTimeAsync(600);
+
+    // No reconnect attempted after disconnect.
+    expect(mockSockets.length).toBe(initialSocketCount);
+  });
+
+  it("aborts the post-await continuation if disconnect ran mid-flight", async () => {
+    await connectClient();
+    const initialSocketCount = mockSockets.length;
+
+    // Trigger reconnect — performVisibilityReconnect awaits webSocketManager.connect()
+    fireVisibilityChange(true);
+    jest.advanceTimersByTime(4000);
+    fireVisibilityChange(false);
+    await jest.advanceTimersByTimeAsync(500);
+    // Now mid-flight: a second WebSocket has been allocated, but
+    // performVisibilityReconnect is awaiting its connect() resolution.
+
+    // disconnect() resets reconnecting=false. The pending await
+    // completion must observe that and bail without mutating state.
+    client.disconnect();
+
+    // Resolve the pending WebSocket connection.
+    mockSockets[mockSockets.length - 1]?.simulateOpen();
+    await jest.advanceTimersByTimeAsync(0);
+
+    // useHTTP should remain false (reset by disconnect), not be flipped
+    // by the bailed-out continuation.
+    expect((client as any).useHTTP).toBe(false);
+    // No new connection should be opened past the in-flight one.
+    expect(mockSockets.length).toBe(initialSocketCount + 1);
+  });
+
   it("cancels a pending reconnect timer when disconnect runs mid-window", async () => {
     await connectClient();
     const initialSocketCount = mockSockets.length;

--- a/tests/visibility-reconnect.test.ts
+++ b/tests/visibility-reconnect.test.ts
@@ -353,4 +353,35 @@ describe("Visibility-based reconnection", () => {
     await jest.advanceTimersByTimeAsync(100);
     expect(mockSockets.length).toBe(socketsAfterDisconnect);
   });
+
+  it("cancels a pending reconnect timer when disconnect runs mid-window", async () => {
+    await connectClient();
+    const initialSocketCount = mockSockets.length;
+
+    // Background long enough to queue a reconnect
+    fireVisibilityChange(true);
+    jest.advanceTimersByTime(4000);
+    fireVisibilityChange(false);
+    // 500ms timer is now queued but has not fired yet.
+
+    // disconnect → connect within the timer window. Without timer
+    // cancellation, the queued timer fires after the new connect()
+    // and triggers an unwanted performVisibilityReconnect() on the
+    // freshly connected client.
+    client.disconnect();
+    createWrapper();
+    const connectPromise = client.connect();
+    await jest.advanceTimersByTimeAsync(0);
+    mockSockets[mockSockets.length - 1]?.simulateOpen();
+    await connectPromise;
+    const socketsAfterConnect = mockSockets.length;
+
+    // Drain the previously queued 500ms timer — should be a no-op now.
+    await jest.advanceTimersByTimeAsync(600);
+
+    // No spurious second WebSocket opened by the cancelled timer.
+    expect(mockSockets.length).toBe(socketsAfterConnect);
+    // Sanity: the connect itself did open one socket past the initial.
+    expect(socketsAfterConnect).toBe(initialSocketCount + 1);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `visibilitychange` + `pageshow` listeners that reconnect the WebSocket after the browser tab returns from background (>3s hidden)
- Handles iOS 15+ zombie sockets (report `readyState === OPEN` with dead TCP) by always reconnecting after long background — morphdom diffs produce zero DOM changes on a healthy connection
- Guards: no-transport skip (HTTP mode / post-disconnect), concurrent reconnect flag, intentional disconnect reset, idempotent handler registration, 500ms delay for `onclose` delivery

## Test plan

- [x] 10 new tests in `tests/visibility-reconnect.test.ts` (all pass)
- [x] Full suite: 450/450 pass across 27 suites
- [x] Client build succeeds (81.3kb bundle)
- [x] devbox-dash tests pass with local client build
- [x] Deployed to devbox with `--client-branch visibility-reconnect`
- [ ] Manual iPhone test: background Safari 5+ seconds → page reconnects on return

🤖 Generated with [Claude Code](https://claude.com/claude-code)