### PR TITLE
fix: remove empty style attribute after lvt-fx:highlight cleanup

### DIFF
--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -179,12 +179,20 @@ function applyFxEffect(htmlElement: HTMLElement, effect: string, config: string)
         if (!htmlElement.isConnected) {
           htmlElement.style.backgroundColor = originalBackground;
           htmlElement.style.transition = originalTransition;
+          if (htmlElement.style.length === 0) {
+            htmlElement.removeAttribute("style");
+          }
           (htmlElement as any).__lvtHighlighting = false;
           return;
         }
         htmlElement.style.backgroundColor = originalBackground;
         setTimeout(() => {
-          if (htmlElement.isConnected) htmlElement.style.transition = originalTransition;
+          if (htmlElement.isConnected) {
+            htmlElement.style.transition = originalTransition;
+            if (htmlElement.style.length === 0) {
+              htmlElement.removeAttribute("style");
+            }
+          }
           (htmlElement as any).__lvtHighlighting = false;
         }, duration);
       }, 50);

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -216,6 +216,54 @@ describe("handleHighlightDirectives", () => {
 
     expect(target.style.backgroundColor).toBe(originalBg);
   });
+
+  it("removes empty style attribute after cleanup", () => {
+    document.body.innerHTML = `<div id="target" lvt-fx:highlight="flash"></div>`;
+    const target = document.getElementById("target")!;
+
+    handleHighlightDirectives(document.body);
+
+    // While the highlight is in flight, the directive's transition + bg are
+    // present, so style attribute exists.
+    expect(target.hasAttribute("style")).toBe(true);
+
+    // Advance past the inner setTimeout (50ms initial + 500ms duration default)
+    jest.advanceTimersByTime(50);
+    jest.advanceTimersByTime(500);
+
+    // After full cycle: directive's bg + transition removed; nothing user-set
+    // remains on this element, so style attribute is gone.
+    expect(target.hasAttribute("style")).toBe(false);
+  });
+
+  it("preserves style attribute when user-set CSS vars remain after cleanup", () => {
+    document.body.innerHTML = `<div id="target" lvt-fx:highlight="flash" style="--lvt-highlight-color: #ff0000;"></div>`;
+    const target = document.getElementById("target")!;
+
+    handleHighlightDirectives(document.body);
+
+    jest.advanceTimersByTime(50);
+    jest.advanceTimersByTime(500);
+
+    // Directive's own properties cleared, but the user's --lvt-highlight-color
+    // CSS var must survive — style.length>0 keeps the attribute.
+    expect(target.hasAttribute("style")).toBe(true);
+    expect(target.style.getPropertyValue("--lvt-highlight-color")).toBe("#ff0000");
+  });
+
+  it("removes empty style attribute when element disconnects mid-cycle", () => {
+    document.body.innerHTML = `<div id="target" lvt-fx:highlight="flash"></div>`;
+    const target = document.getElementById("target")!;
+
+    handleHighlightDirectives(document.body);
+
+    // Disconnect before the inner setTimeout fires (between 0 and 50ms)
+    target.remove();
+    jest.advanceTimersByTime(50);
+
+    // Even on the disconnected path, cleanup should leave no empty style attr
+    expect(target.hasAttribute("style")).toBe(false);
+  });
 });
 
 describe("handleAnimateDirectives", () => {


### PR DESCRIPTION
## Summary

Closes #100.

\`lvt-fx:highlight="flash"\` left an empty \`style=""\` attribute on the target element after its cycle completed. \`lvt-fx:animate\` already handles this idiom — this change mirrors that pattern on both highlight cleanup paths (the disconnected-during-50ms branch and the happy path after the inner setTimeout).

## Why this matters

Functionally invisible in normal rendering (an empty \`style\` attribute is a no-op for CSS), but flagged as a violation by strict-CSP test validators that select \`[style]\` regardless of content — including \`lvt/testing/chrome.go\`'s \`runUIStandards\` checks. The livetemplate/examples Session 5 \`Highlight on Change\` pattern currently skips its \`UI_Standards\` subtest specifically to dodge this; with the cleanup landed, that opt-out can be removed.

## Implementation

\`\`\`ts
htmlElement.style.transition = originalTransition;
if (htmlElement.style.length === 0) {
  htmlElement.removeAttribute("style");
}
\`\`\`

\`style.length\` counts CSS declarations including custom properties, so \`style="--lvt-highlight-color: red"\` has length 1 — the check correctly preserves user-set CSS vars while removing the directive's own properties.

## Test plan

- [x] All 461 existing tests still pass (27 suites)
- [x] Three new tests:
  - Post-cycle: \`hasAttribute("style") === false\` after full cycle on a clean element
  - Preserves user CSS vars: \`style="--lvt-highlight-color: #ff0000"\` survives the cleanup
  - Disconnected mid-cycle: same cleanup applies on the early-return path
- [x] \`tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)