### PR TITLE
chore: Phase 1A migration ergonomics — shim, tests, docs (#46, #47, #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to @livetemplate/client will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Migration: Phase 1A breaking changes (v0.8.13 / v0.8.14)
+
+If you're upgrading from `< 0.8.13`, the attribute surface changed substantially. Run
+`grep -rn 'lvt-' templates/` to find call-sites that need updating.
+
+### Renamed attributes
+
+| Old | New | Phase |
+|-----|-----|-------|
+| `lvt-click`, `lvt-input`, `lvt-change`, `lvt-keydown`, `lvt-submit`, ... (16 event-specific attributes) | `lvt-on:{event}` (generic event router) | v0.8.13 |
+| `lvt-{action}-on:{event}` (reactive shortcuts) | `lvt-el:{method}:on:{state}` | v0.8.13 |
+| `lvt-data-*`, `lvt-value-*` | standard `data-*` attributes | v0.8.13 |
+| `lvt-disable-with` | `lvt-form:disable-with` | v0.8.13 |
+| `lvt-no-intercept` (on `<a>` links) | `lvt-nav:no-intercept` | v0.8.14 |
+| `lvt-no-intercept` (on `<form>`) | `lvt-form:no-intercept` | v0.8.14 |
+| (form action routing — implicit) | `lvt-form:action="..."` (explicit, highest priority) | v0.8.14 |
+
+### Removed (no replacement — use the standard-HTML alternative)
+
+| Removed | Use instead |
+|---------|-------------|
+| `ModalManager` / `lvt-modal-open` / `lvt-modal-close` | Native `<dialog>` element + `dialog.showModal()` / `dialog.close()` |
+| `lvt-confirm="message"` | `onclick="return confirm('message')"` (standard browser API) |
+| `lvt-disable-on:{event}` / `lvt-enable-on:{event}` reactive actions | `lvt-el:{method}:on:{state}` (e.g. `lvt-el:setAttr:disabled:on:save:pending`) |
+
+### New Tier 2 namespaces
+
+- `lvt-on:{event}` — DOM event handlers (Tier 1: standard HTML `onclick=...` is preferred when no server round-trip is needed)
+- `lvt-el:{method}:on:{state}` — reactive DOM mutations driven by client state
+- `lvt-fx:{directive}` — visual effects (`lvt-fx:scroll`, `lvt-fx:highlight`, `lvt-fx:animate`)
+- `lvt-form:{behavior}` — form-scoped behaviors (`preserve`, `disable-with`, `action`, `no-intercept`)
+- `lvt-nav:{behavior}` — navigation-scoped behaviors (`no-intercept`)
+- `lvt-mod:{modifier}` — event-handling modifiers (`debounce`, `throttle`)
+
+### Backward-compat shims
+
+The legacy `lvt-no-intercept` attribute on links is recognized via a backward-compat shim
+in `LinkInterceptor.shouldSkip()` so apps that upgrade the client without renaming all
+templates in lockstep keep working. **The shim will be removed in v0.9.0** — migrate to
+`lvt-nav:no-intercept` before then.
+
+For the full design rationale, see the [attribute-reduction proposal](https://github.com/livetemplate/livetemplate/blob/main/docs/archive/proposals/attribute-reduction-proposal.md) in the server repo.
+
 ## [v0.8.40] - 2026-05-02
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Migration: Phase 1A breaking changes (v0.8.13 / v0.8.14)
 
 If you're upgrading from `< 0.8.13`, the attribute surface changed substantially. Run
-`grep -rn 'lvt-' templates/` to find call-sites that need updating.
+`grep -rn 'lvt-' <your-template-dir>` (or `grep -rn 'lvt-' .` from your app root) to
+find call-sites that need updating.
 
 ### Renamed attributes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,12 @@ find call-sites that need updating.
 
 ### Backward-compat shims
 
-The legacy `lvt-no-intercept` attribute on links is recognized via a backward-compat shim
-in `LinkInterceptor.shouldSkip()` so apps that upgrade the client without renaming all
-templates in lockstep keep working. **The shim will be removed in v0.9.0** — migrate to
-`lvt-nav:no-intercept` before then.
+The legacy `lvt-no-intercept` attribute is recognized on both `<a>` links and `<form>`
+elements via a shared shim in `utils/legacy-attr.ts`. Apps that upgrade the client
+without renaming all templates in lockstep keep working. The first time a legacy
+attribute is encountered the client logs a one-time deprecation warning so app authors
+can find call-sites to migrate. **The shim will be removed in v0.9.0** — migrate to
+`lvt-nav:no-intercept` (links) and `lvt-form:no-intercept` (forms) before then.
 
 For the full design rationale, see the [attribute-reduction proposal](https://github.com/livetemplate/livetemplate/blob/main/docs/archive/proposals/attribute-reduction-proposal.md) in the server repo.
 

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -2,6 +2,7 @@ import { debounce, throttle } from "../utils/rate-limit";
 import { lvtSelector } from "../utils/lvt-selector";
 import { executeAction, resolveTarget, processElementInteraction, isDOMEventTrigger, type ReactiveAction } from "./reactive-attributes";
 import type { Logger } from "../utils/logger";
+import { hasNoInterceptOptOut } from "../utils/legacy-attr";
 
 // Methods supported by click-away, derived from ReactiveAction values
 const CLICK_AWAY_METHOD_MAP: Record<string, ReactiveAction> = {
@@ -192,7 +193,7 @@ export class EventDelegator {
           // enhancement fallback (no-JS POST). The client does not read it;
           // the server extracts it from form data directly.
           if (!action && eventType === "submit" && element instanceof HTMLFormElement) {
-            if (!element.hasAttribute("lvt-form:no-intercept")) {
+            if (!hasNoInterceptOptOut(element, "lvt-form:no-intercept", this.logger)) {
               // Check for explicit routing attribute first.
               // Empty string ("") falls through to submitter/form name resolution.
               const explicitAction = element.getAttribute("lvt-form:action");

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -1,4 +1,5 @@
 import type { Logger } from "../utils/logger";
+import { hasNoInterceptOptOut } from "../utils/legacy-attr";
 import { isHashLinkTarget, activateHashTarget } from "./hash-link";
 
 export interface LinkInterceptorContext {
@@ -35,7 +36,6 @@ export interface LinkInterceptorContext {
  * starts (rapid clicks, back/forward during fetch).
  */
 export class LinkInterceptor {
-  private static legacyNoInterceptWarned = false;
   private popstateListener: (() => void) | null = null;
   private abortController: AbortController | null = null;
   // Tracks the URL that was last successfully navigated to (or the initial
@@ -141,18 +141,10 @@ export class LinkInterceptor {
     if (link.target && link.target !== "_self") return true;
     // Download links
     if (link.hasAttribute("download")) return true;
-    // Opt-out attribute for link interception
-    if (link.hasAttribute("lvt-nav:no-intercept")) return true;
-    // Backward-compat shim for the pre-Phase 1A name. Drop in v0.9.0.
-    if (link.hasAttribute("lvt-no-intercept")) {
-      if (!LinkInterceptor.legacyNoInterceptWarned) {
-        LinkInterceptor.legacyNoInterceptWarned = true;
-        this.logger.warn(
-          "lvt-no-intercept is deprecated; use lvt-nav:no-intercept. The shim will be removed in v0.9.0."
-        );
-      }
-      return true;
-    }
+    // Opt-out attribute for link interception. hasNoInterceptOptOut also
+    // accepts the pre-Phase 1A `lvt-no-intercept` name and emits a one-time
+    // deprecation warning. The shim is removed in v0.9.0.
+    if (hasNoInterceptOptOut(link, "lvt-nav:no-intercept", this.logger)) return true;
     // mailto/tel/javascript
     const protocol = link.protocol;
     if (protocol !== "http:" && protocol !== "https:") return true;

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -140,6 +140,8 @@ export class LinkInterceptor {
     if (link.hasAttribute("download")) return true;
     // Opt-out attribute for link interception
     if (link.hasAttribute("lvt-nav:no-intercept")) return true;
+    // Backward-compat shim for the pre-Phase 1A name. Drop in v0.9.0.
+    if (link.hasAttribute("lvt-no-intercept")) return true;
     // mailto/tel/javascript
     const protocol = link.protocol;
     if (protocol !== "http:" && protocol !== "https:") return true;

--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -27,12 +27,15 @@ export interface LinkInterceptorContext {
  *   new HTML and hands it to handleNavigationResponse, which decides
  *   between same-handler DOM replace and cross-handler reconnect.
  * - External links, target="_blank", download, and lvt-nav:no-intercept
- *   are skipped.
+ *   are skipped. The legacy lvt-no-intercept attribute is also accepted via
+ *   a backward-compat shim in shouldSkip(); the shim emits a one-time
+ *   deprecation warning and is removed in v0.9.0.
  *
  * Uses AbortController to cancel in-flight fetches when a new navigation
  * starts (rapid clicks, back/forward during fetch).
  */
 export class LinkInterceptor {
+  private static legacyNoInterceptWarned = false;
   private popstateListener: (() => void) | null = null;
   private abortController: AbortController | null = null;
   // Tracks the URL that was last successfully navigated to (or the initial
@@ -141,7 +144,15 @@ export class LinkInterceptor {
     // Opt-out attribute for link interception
     if (link.hasAttribute("lvt-nav:no-intercept")) return true;
     // Backward-compat shim for the pre-Phase 1A name. Drop in v0.9.0.
-    if (link.hasAttribute("lvt-no-intercept")) return true;
+    if (link.hasAttribute("lvt-no-intercept")) {
+      if (!LinkInterceptor.legacyNoInterceptWarned) {
+        LinkInterceptor.legacyNoInterceptWarned = true;
+        this.logger.warn(
+          "lvt-no-intercept is deprecated; use lvt-nav:no-intercept. The shim will be removed in v0.9.0."
+        );
+      }
+      return true;
+    }
     // mailto/tel/javascript
     const protocol = link.protocol;
     if (protocol !== "http:" && protocol !== "https:") return true;

--- a/state/change-auto-wirer.ts
+++ b/state/change-auto-wirer.ts
@@ -2,6 +2,7 @@ import { debounce } from "../utils/rate-limit";
 import { DEFAULT_CHANGE_DEBOUNCE_MS } from "../constants";
 import type { TreeNode } from "../types";
 import type { Logger } from "../utils/logger";
+import { hasNoInterceptOptOut } from "../utils/legacy-attr";
 
 export type BindingType = "value" | "content" | "attribute";
 
@@ -77,7 +78,7 @@ export class ChangeAutoWirer {
         const parentForm = el.closest("form");
         if (parentForm) {
           if (parentForm.hasAttribute("lvt-change")) continue;
-          if (parentForm.hasAttribute("lvt-form:no-intercept")) continue;
+          if (hasNoInterceptOptOut(parentForm, "lvt-form:no-intercept", this.logger)) continue;
         }
 
         if (el instanceof HTMLInputElement) {

--- a/tests/change-auto-wirer.test.ts
+++ b/tests/change-auto-wirer.test.ts
@@ -1,6 +1,7 @@
 import { ChangeAutoWirer } from "../state/change-auto-wirer";
 import type { ChangeAutoWirerContext } from "../state/change-auto-wirer";
 import { createLogger } from "../utils/logger";
+import { _resetLegacyNoInterceptWarned } from "../utils/legacy-attr";
 
 describe("ChangeAutoWirer", () => {
   let wirer: ChangeAutoWirer;
@@ -19,6 +20,9 @@ describe("ChangeAutoWirer", () => {
     document.body.appendChild(wrapper);
     const logger = createLogger({ scope: "ChangeAutoWirerTest", level: "silent" });
     wirer = new ChangeAutoWirer(createContext(), logger);
+    // The lvt-no-intercept backward-compat shim warns once per process; reset
+    // the latch so each test starts fresh.
+    _resetLegacyNoInterceptWarned();
   });
 
   afterEach(() => {
@@ -351,6 +355,32 @@ describe("ChangeAutoWirer", () => {
     it("skips elements inside form with lvt-form:no-intercept", () => {
       const form = document.createElement("form");
       form.setAttribute("lvt-form:no-intercept", "");
+      const input = document.createElement("input");
+      input.setAttribute("name", "Title");
+      form.appendChild(input);
+      wrapper.appendChild(form);
+
+      setupWirer({
+        s: ['<input name="Title" value="', '">'],
+        "0": "",
+      });
+
+      wirer.wireElements();
+
+      input.value = "test";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      jest.advanceTimersByTime(300);
+
+      expect(sendSpy).not.toHaveBeenCalled();
+    });
+
+    it("skips elements inside form with legacy lvt-no-intercept (backward-compat shim)", () => {
+      // Pre-Phase 1A name. Apps that upgrade the client without renaming
+      // form attributes still get correct opt-out behavior. The shim is
+      // shared with the link interceptor; deprecation-warn coverage lives
+      // in tests/navigate.test.ts. Drop in v0.9.0.
+      const form = document.createElement("form");
+      form.setAttribute("lvt-no-intercept", "");
       const input = document.createElement("input");
       input.setAttribute("name", "Title");
       form.appendChild(input);

--- a/tests/navigate.test.ts
+++ b/tests/navigate.test.ts
@@ -17,6 +17,7 @@
 
 import { LinkInterceptor, LinkInterceptorContext } from "../dom/link-interceptor";
 import type { Logger } from "../utils/logger";
+import { _resetLegacyNoInterceptWarned } from "../utils/legacy-attr";
 
 function makeLogger(): Logger & { warn: jest.Mock } {
   return {
@@ -54,9 +55,9 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
     handleNavigationResponseSpy = jest.fn();
     logger = makeLogger();
     // Reset the once-per-process deprecation-warning latch so each test starts
-    // from a clean state. The shim's static flag is internal to LinkInterceptor
-    // and not part of its public API; this cast is intentional for test isolation.
-    (LinkInterceptor as unknown as { legacyNoInterceptWarned: boolean }).legacyNoInterceptWarned = false;
+    // from a clean state. The latch is module-level state in utils/legacy-attr,
+    // exposed via an @internal helper specifically for tests.
+    _resetLegacyNoInterceptWarned();
     // jsdom doesn't ship a global fetch; define a no-op stub so jest.spyOn
     // has something to wrap. jest.restoreAllMocks() in afterEach then cleans
     // up the spy automatically, even if beforeEach throws after this point.
@@ -220,7 +221,7 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
 
   it("lvt-no-intercept legacy shim warns only once across multiple clicks", async () => {
     // Avoid spamming the console: a single deprecation warning per process
-    // is enough to prompt migration. The static flag in LinkInterceptor
+    // is enough to prompt migration. The latch in utils/legacy-attr
     // suppresses subsequent warns until the page reloads.
     const link = document.createElement("a");
     link.href = "/claude?s=legacy-opt-out";
@@ -230,7 +231,9 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
     link.click();
     link.click();
     link.click();
-    await Promise.resolve();
+    // Use a macrotask boundary so we don't depend on jsdom's synchronous
+    // click dispatch. If a future jsdom makes click async, this still flushes.
+    await new Promise((r) => setTimeout(r, 0));
 
     expect(logger.warn).toHaveBeenCalledTimes(1);
   });

--- a/tests/navigate.test.ts
+++ b/tests/navigate.test.ts
@@ -137,6 +137,90 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
     expect(handleNavigationResponseSpy).not.toHaveBeenCalled();
   });
 
+  it("target=\"_blank\" link click is skipped", async () => {
+    const link = document.createElement("a");
+    link.href = "/claude?s=blank-target";
+    link.target = "_blank";
+    wrapper.appendChild(link);
+
+    link.click();
+    await Promise.resolve();
+
+    expect(sendNavigateSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("target=\"_self\" link click is intercepted (treated like default)", async () => {
+    const link = document.createElement("a");
+    link.href = "/claude?s=self-target";
+    link.target = "_self";
+    wrapper.appendChild(link);
+
+    link.click();
+    await Promise.resolve();
+
+    expect(sendNavigateSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("download link click is skipped", async () => {
+    const link = document.createElement("a");
+    link.href = "/claude?file=report.csv";
+    link.setAttribute("download", "report.csv");
+    wrapper.appendChild(link);
+
+    link.click();
+    await Promise.resolve();
+
+    expect(sendNavigateSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("lvt-nav:no-intercept link click is skipped", async () => {
+    const link = document.createElement("a");
+    link.href = "/claude?s=opt-out";
+    link.setAttribute("lvt-nav:no-intercept", "");
+    wrapper.appendChild(link);
+
+    link.click();
+    await Promise.resolve();
+
+    expect(sendNavigateSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("lvt-no-intercept (legacy) link click is skipped via backward-compat shim", async () => {
+    // Pre-Phase 1A name. The shim recognizes it so apps upgrading the
+    // client without simultaneously renaming all templates keep working.
+    // Drop the shim in v0.9.0 (see dom/link-interceptor.ts).
+    const link = document.createElement("a");
+    link.href = "/claude?s=legacy-opt-out";
+    link.setAttribute("lvt-no-intercept", "");
+    wrapper.appendChild(link);
+
+    link.click();
+    await Promise.resolve();
+
+    expect(sendNavigateSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["mailto:user@example.com", "mailto"],
+    ["tel:+1234567890", "tel"],
+    ["javascript:void(0)", "javascript"],
+  ])("non-http protocol %s is skipped", async (href, _name) => {
+    const link = document.createElement("a");
+    link.href = href;
+    wrapper.appendChild(link);
+
+    link.click();
+    await Promise.resolve();
+
+    expect(sendNavigateSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("same-pathname click aborts any in-flight cross-path fetch", async () => {
     // Regression: if a cross-path fetch is in flight and the user then
     // clicks a same-pathname link, the earlier fetch must be aborted so

--- a/tests/navigate.test.ts
+++ b/tests/navigate.test.ts
@@ -18,20 +18,23 @@
 import { LinkInterceptor, LinkInterceptorContext } from "../dom/link-interceptor";
 import type { Logger } from "../utils/logger";
 
-// Minimal logger stub — LinkInterceptor uses it only for debug/error logging.
-const silentLogger: Logger = {
-  isDebugEnabled: () => false,
-  isInfoEnabled: () => false,
-  isWarnEnabled: () => true,
-  isErrorEnabled: () => true,
-  child: () => silentLogger,
-  setLevel: () => {},
-  debug: () => {},
-  info: () => {},
-  warn: () => {},
-  error: () => {},
-  trace: () => {},
-} as unknown as Logger;
+function makeLogger(): Logger & { warn: jest.Mock } {
+  return {
+    isDebugEnabled: () => false,
+    isInfoEnabled: () => false,
+    isWarnEnabled: () => true,
+    isErrorEnabled: () => true,
+    child: function (this: Logger) {
+      return this;
+    },
+    setLevel: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: jest.fn(),
+    error: () => {},
+    trace: () => {},
+  } as unknown as Logger & { warn: jest.Mock };
+}
 
 describe("LinkInterceptor same-pathname navigate bypass", () => {
   let wrapper: HTMLElement;
@@ -39,6 +42,7 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
   let handleNavigationResponseSpy: jest.Mock<void, [string]>;
   let fetchMock: jest.SpyInstance;
   let interceptor: LinkInterceptor;
+  let logger: Logger & { warn: jest.Mock };
 
   beforeEach(() => {
     document.body.replaceChildren();
@@ -48,6 +52,11 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
 
     sendNavigateSpy = jest.fn().mockReturnValue(true);
     handleNavigationResponseSpy = jest.fn();
+    logger = makeLogger();
+    // Reset the once-per-process deprecation-warning latch so each test starts
+    // from a clean state. The shim's static flag is internal to LinkInterceptor
+    // and not part of its public API; this cast is intentional for test isolation.
+    (LinkInterceptor as unknown as { legacyNoInterceptWarned: boolean }).legacyNoInterceptWarned = false;
     // jsdom doesn't ship a global fetch; define a no-op stub so jest.spyOn
     // has something to wrap. jest.restoreAllMocks() in afterEach then cleans
     // up the spy automatically, even if beforeEach throws after this point.
@@ -66,7 +75,7 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
       sendNavigate: sendNavigateSpy,
       canSendNavigate: () => true,
     };
-    interceptor = new LinkInterceptor(ctx, silentLogger);
+    interceptor = new LinkInterceptor(ctx, logger);
     interceptor.setup(wrapper);
 
     // Pin the current location so test navigations have something to
@@ -203,6 +212,27 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
 
     expect(sendNavigateSpy).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
+    // Verify the deprecation warning was emitted so consumers can find
+    // call-sites to migrate before v0.9.0 removes the shim.
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0][0]).toMatch(/lvt-no-intercept.*deprecated/);
+  });
+
+  it("lvt-no-intercept legacy shim warns only once across multiple clicks", async () => {
+    // Avoid spamming the console: a single deprecation warning per process
+    // is enough to prompt migration. The static flag in LinkInterceptor
+    // suppresses subsequent warns until the page reloads.
+    const link = document.createElement("a");
+    link.href = "/claude?s=legacy-opt-out";
+    link.setAttribute("lvt-no-intercept", "");
+    wrapper.appendChild(link);
+
+    link.click();
+    link.click();
+    link.click();
+    await Promise.resolve();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 
   it.each([
@@ -292,7 +322,7 @@ describe("LinkInterceptor same-pathname navigate bypass", () => {
       sendNavigate: sendNavigateSpy,
       canSendNavigate: () => false, // HTTP mode
     };
-    const httpInterceptor = new LinkInterceptor(httpCtx, silentLogger);
+    const httpInterceptor = new LinkInterceptor(httpCtx, logger);
     httpInterceptor.setup(wrapper);
 
     const link = document.createElement("a");

--- a/utils/legacy-attr.ts
+++ b/utils/legacy-attr.ts
@@ -1,0 +1,46 @@
+import type { Logger } from "./logger";
+
+/**
+ * Module-level warn-once latch shared by all `lvt-no-intercept` shim sites
+ * (link interceptor + form auto-wiring + form submit handling). One warning
+ * per process is enough to prompt migration without spamming the console.
+ */
+let legacyNoInterceptWarned = false;
+
+/**
+ * Returns true when an element opts out of LiveTemplate interception.
+ *
+ * Recognizes both the current Tier 2 namespaced attribute (`newName`, e.g.
+ * `lvt-nav:no-intercept` for links or `lvt-form:no-intercept` for forms) and
+ * the pre-Phase 1A `lvt-no-intercept` name as a backward-compat shim. The
+ * legacy name emits a one-time deprecation warning through the supplied
+ * logger and is removed in v0.9.0.
+ */
+export function hasNoInterceptOptOut(
+  el: Element,
+  newName: string,
+  logger: Logger
+): boolean {
+  if (el.hasAttribute(newName)) return true;
+  if (el.hasAttribute("lvt-no-intercept")) {
+    if (!legacyNoInterceptWarned) {
+      legacyNoInterceptWarned = true;
+      logger.warn(
+        `lvt-no-intercept is deprecated; use ${newName}. The shim will be removed in v0.9.0.`
+      );
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Reset the warn-once latch. Internal — test code only. Tests that exercise
+ * the shim need to start from a clean state to assert that the warning fires
+ * exactly once per process.
+ *
+ * @internal
+ */
+export function _resetLegacyNoInterceptWarned(): void {
+  legacyNoInterceptWarned = false;
+}


### PR DESCRIPTION
## Summary

Three Phase 1A migration ergonomics fixes bundled together (they belong in one PR — the shim, its test, and the migration docs):

- **#47** — Add 7 new tests in `tests/navigate.test.ts` covering the four `LinkInterceptor.shouldSkip()` branches that were uncovered: `target="_blank"`, `target="_self"` (positive case), `download` attribute, `lvt-nav:no-intercept`, and the three non-HTTP protocols (`mailto:`, `tel:`, `javascript:`). Previously only the origin branch was tested.
- **#46** — Add `lvt-no-intercept` backward-compat shim in `LinkInterceptor.shouldSkip()`. The pre-Phase 1A attribute name is now silently recognized so apps that upgrade the client without renaming all templates in lockstep keep working. Code comment notes the shim is dropped in v0.9.0.
- **#48** — Add a Phase 1A breaking-changes migration section at the top of `CHANGELOG.md` with a rename table, removed-attribute table, new-namespace summary, and a callout for the backward-compat shim. Linked back to the attribute-reduction proposal.

## Test plan

- [x] `npm test` — 527 tests pass across 28 suites (15 in `navigate.test.ts` including the 7 new ones)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` (esbuild + tsc) clean
- [x] Pre-commit hook ran the full gate before commit

Closes #46. Closes #47. Closes #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)