### PR TITLE
refactor: remove dead StaticsMap code (#17)

### DIFF
--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -156,8 +156,8 @@ export class LiveTemplateClient {
     this.treeRenderer = new TreeRenderer(this.logger.child("TreeRenderer"));
     this.rangeDomApplier = new RangeDomApplier({
       logger: this.logger.child("RangeDomApplier"),
-      renderItem: (item, idx, statics, sm, sp) =>
-        this.treeRenderer.renderRangeItem(item, idx, statics, sm, sp),
+      renderItem: (item, idx, statics, sp) =>
+        this.treeRenderer.renderRangeItem(item, idx, statics, sp),
       executeLifecycleHook: (el, hook) => this.executeLifecycleHook(el, hook),
       itemLookup: (rangePath, key) => {
         // O(N) linear scan over range.d. For one `u` op per render this is

--- a/state/range-dom-applier.ts
+++ b/state/range-dom-applier.ts
@@ -16,7 +16,6 @@ type RenderItemFn = (
   item: any,
   itemIdx: number,
   statics: string[],
-  staticsMap?: Record<string, string[]>,
   statePath?: string
 ) => string;
 
@@ -194,7 +193,7 @@ export class RangeDomApplier {
     targetedOp: TargetedRangeOp,
     morphdomOptions?: any
   ): Element | null {
-    const { rangePath, ops, statics, staticsMap } = targetedOp;
+    const { rangePath, ops, statics } = targetedOp;
     const sampleKey = this.firstKnownKey(ops);
     const container = this.findContainer(wrapper, rangePath, sampleKey);
     if (!container) {
@@ -219,7 +218,6 @@ export class RangeDomApplier {
               container,
               op[1] as string,
               statics,
-              staticsMap,
               rangePath,
               morphdomOptions
             );
@@ -230,7 +228,6 @@ export class RangeDomApplier {
               op[1] as string,
               op[2],
               statics,
-              staticsMap,
               rangePath
             );
             break;
@@ -239,7 +236,6 @@ export class RangeDomApplier {
               container,
               op[1],
               statics,
-              staticsMap,
               rangePath
             );
             break;
@@ -248,7 +244,6 @@ export class RangeDomApplier {
               container,
               op[1],
               statics,
-              staticsMap,
               rangePath
             );
             break;
@@ -351,7 +346,6 @@ export class RangeDomApplier {
     container: Element,
     key: string,
     statics: string[],
-    staticsMap: Record<string, string[]> | undefined,
     rangePath: string,
     morphdomOptions?: any
   ): boolean {
@@ -374,7 +368,6 @@ export class RangeDomApplier {
       item,
       itemIdx,
       statics,
-      staticsMap,
       rangePath
     );
     const newRow = this.parseSingleRow(newHtml);
@@ -411,7 +404,6 @@ export class RangeDomApplier {
     afterKey: string,
     items: any | any[],
     statics: string[],
-    staticsMap: Record<string, string[]> | undefined,
     rangePath: string
   ): boolean {
     const anchor = this.findItemByKey(container, afterKey);
@@ -424,7 +416,6 @@ export class RangeDomApplier {
     return this.renderItemsAtomic(
       items,
       statics,
-      staticsMap,
       rangePath,
       this.indexOfChild(container, anchor) + 1,
       (frag) => container.insertBefore(frag, anchor.nextSibling)
@@ -435,13 +426,11 @@ export class RangeDomApplier {
     container: Element,
     items: any | any[],
     statics: string[],
-    staticsMap: Record<string, string[]> | undefined,
     rangePath: string
   ): boolean {
     return this.renderItemsAtomic(
       items,
       statics,
-      staticsMap,
       rangePath,
       container.children.length,
       (frag) => container.appendChild(frag)
@@ -452,13 +441,11 @@ export class RangeDomApplier {
     container: Element,
     items: any | any[],
     statics: string[],
-    staticsMap: Record<string, string[]> | undefined,
     rangePath: string
   ): boolean {
     return this.renderItemsAtomic(
       items,
       statics,
-      staticsMap,
       rangePath,
       0,
       (frag) => container.insertBefore(frag, container.firstChild)
@@ -475,7 +462,6 @@ export class RangeDomApplier {
   private renderItemsAtomic(
     items: any | any[],
     statics: string[],
-    staticsMap: Record<string, string[]> | undefined,
     rangePath: string,
     baseIdx: number,
     splice: (frag: DocumentFragment) => void
@@ -488,7 +474,6 @@ export class RangeDomApplier {
         list[i],
         baseIdx + i,
         statics,
-        staticsMap,
         rangePath
       );
       if (!newRow) {
@@ -561,16 +546,9 @@ export class RangeDomApplier {
     item: any,
     itemIdx: number,
     statics: string[],
-    staticsMap: Record<string, string[]> | undefined,
     rangePath: string
   ): Element | null {
-    const html = this.ctx.renderItem(
-      item,
-      itemIdx,
-      statics,
-      staticsMap,
-      rangePath
-    );
+    const html = this.ctx.renderItem(item, itemIdx, statics, rangePath);
     return this.parseSingleRow(html);
   }
 

--- a/state/tree-renderer.ts
+++ b/state/tree-renderer.ts
@@ -19,7 +19,6 @@ export interface ApplyUpdateOptions {
 interface RangeStateEntry {
   items: any[];
   statics: any[];
-  staticsMap?: Record<string, string[]>;
 }
 
 /**
@@ -177,7 +176,6 @@ export class TreeRenderer {
               rangePath: key,
               ops: value,
               statics: existing.s,
-              staticsMap: existing.sm,
               idKey: existing.m?.idKey,
             });
             skipPaths.add(key);
@@ -355,7 +353,6 @@ export class TreeRenderer {
       this.rangeState[statePath] = {
         items: currentItems,
         statics: rangeStructure.s,
-        staticsMap: rangeStructure.sm,
       };
     }
     // Also check for idKey metadata
@@ -489,7 +486,6 @@ export class TreeRenderer {
     this.rangeState[statePath] = {
       items: currentItems,
       statics: rangeStructure.s,
-      staticsMap: rangeStructure.sm,
     };
   }
 
@@ -566,7 +562,6 @@ export class TreeRenderer {
           this.rangeState[stateKey] = {
             items: value.d,
             statics: value.s,
-            staticsMap: value.sm,
           };
           if (
             value.m &&
@@ -638,7 +633,7 @@ export class TreeRenderer {
     fieldKey?: string,
     statePath?: string
   ): string {
-    const { d: dynamics, s: statics, sm: staticsMap } = rangeNode;
+    const { d: dynamics, s: statics } = rangeNode;
 
     if (!dynamics || !Array.isArray(dynamics)) {
       return "";
@@ -656,7 +651,7 @@ export class TreeRenderer {
     if (statics && Array.isArray(statics)) {
       return dynamics
         .map((item: any, itemIdx: number) =>
-          this.renderRangeItem(item, itemIdx, statics, staticsMap, statePath)
+          this.renderRangeItem(item, itemIdx, statics, statePath)
         )
         .join("");
     }
@@ -672,8 +667,7 @@ export class TreeRenderer {
 
   /**
    * Renders a single range item to HTML by interleaving its dynamic slots
-   * with the range's statics. Honors per-item statics (`_sk` lookup in
-   * `staticsMap`) when present.
+   * with the range's statics.
    *
    * Used by `renderRangeStructure` and `renderItemsWithStatics` for full
    * range rendering, and by `range-dom-applier` to render a single new
@@ -683,18 +677,9 @@ export class TreeRenderer {
     item: any,
     itemIdx: number,
     statics: string[],
-    staticsMap?: Record<string, string[]>,
     statePath?: string
   ): string {
-    let itemStatics = statics;
-    if (
-      staticsMap &&
-      typeof staticsMap === "object" &&
-      item._sk &&
-      staticsMap[item._sk]
-    ) {
-      itemStatics = staticsMap[item._sk];
-    }
+    const itemStatics = statics;
 
     let html = "";
 
@@ -837,13 +822,11 @@ export class TreeRenderer {
     this.rangeState[statePath] = {
       items: currentItems,
       statics: rangeData.statics,
-      staticsMap: rangeData.staticsMap,
     };
 
     this.treeState[statePath] = {
       d: currentItems,
       s: rangeData.statics,
-      sm: rangeData.staticsMap,
     };
 
     const rangeStructure = this.getCurrentRangeStructure(statePath);
@@ -851,7 +834,6 @@ export class TreeRenderer {
       return this.renderItemsWithStatics(
         currentItems,
         rangeStructure.s,
-        rangeStructure.sm,
         statePath
       );
     }
@@ -864,7 +846,6 @@ export class TreeRenderer {
       return {
         d: this.rangeState[stateKey].items,
         s: this.rangeState[stateKey].statics,
-        sm: this.rangeState[stateKey].staticsMap,
       };
     }
 
@@ -883,12 +864,11 @@ export class TreeRenderer {
   private renderItemsWithStatics(
     items: any[],
     statics: string[],
-    staticsMap?: Record<string, string[]>,
     statePath?: string
   ): string {
     const result = items
       .map((item: any, itemIdx: number) =>
-        this.renderRangeItem(item, itemIdx, statics, staticsMap, statePath)
+        this.renderRangeItem(item, itemIdx, statics, statePath)
       )
       .join("");
 

--- a/tests/range-dom-applier.test.ts
+++ b/tests/range-dom-applier.test.ts
@@ -60,8 +60,8 @@ function makeFixture(itemCount: number): Fixture {
   const hookCalls: Array<{ hook: string; key: string | null }> = [];
   const applier = new RangeDomApplier({
     logger,
-    renderItem: (item, idx, statics, sm, sp) =>
-      renderer.renderRangeItem(item, idx, statics, sm, sp),
+    renderItem: (item, idx, statics, sp) =>
+      renderer.renderRangeItem(item, idx, statics, sp),
     executeLifecycleHook: (el, hook) => {
       hookCalls.push({ hook, key: el.getAttribute("data-key") });
     },

--- a/types.ts
+++ b/types.ts
@@ -20,7 +20,6 @@ export interface TargetedRangeOp {
   rangePath: string;
   ops: any[];
   statics: string[];
-  staticsMap?: Record<string, string[]>;
   idKey?: string;
 }
 


### PR DESCRIPTION
## Summary

Closes #17. The server stopped emitting the `"sm"` (StaticsMap) field on TreeNode in v0.8.0 when fingerprint-based statics tracking replaced the per-path `ClientStructureRegistry` (livetemplate/livetemplate#86). The client kept the read path and the parameter chain alive as a no-op fallback, but the underlying data has not flowed since v0.8.0 — every reachable codepath now passes \`undefined\`.

## Changes

- **types.ts** — drop \`staticsMap?\` field from \`TargetedRangeOp\`.
- **state/tree-renderer.ts** — drop \`staticsMap?\` field from \`RangeStateEntry\`, the \`sm\` reads/writes (5 reads, 3 writes), the dead \`_sk\` lookup branch inside \`renderRangeItem\`, and the \`staticsMap?\` parameter from \`renderRangeItem\` and \`renderItemsWithStatics\`.
- **state/range-dom-applier.ts** — drop \`staticsMap\` parameter from \`RenderItemFn\` and 6 internal helpers (\`apply\`, \`applyUpdateRow\`, \`applyInsertAfter\`, \`applyAppend\`, \`applyPrepend\`, \`renderItemsAtomic\`, \`renderAndParse\`).
- **livetemplate-client.ts** — drop \`sm\` argument from the \`renderItem\` callback wiring.
- **tests/range-dom-applier.test.ts** — match the new 4-arg \`renderItem\` signature.

## Verification

No tests referenced \`StaticsMap\`, \`_sk\`, or \`"sm"\` before this commit, confirming the code path was unreachable.

- [x] \`grep -rn 'staticsMap\\|StaticsMap\\|_sk\\b\\|\"sm\"\\|\\bsm:' --include='*.ts'\` — 0 hits after the change
- [x] \`npm test\` — 529 tests pass across 28 suites
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean
- [x] Pre-commit hook ran the full gate before commit (lint + tests + build)

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)