### PR TITLE
fix: full reload when SPA navigation crosses an app boundary

### DIFF
--- a/dom/link-interceptor.ts
+++ b/dom/link-interceptor.ts
@@ -3,7 +3,7 @@ import { isHashLinkTarget, activateHashTarget } from "./hash-link";
 
 export interface LinkInterceptorContext {
   getWrapperElement(): Element | null;
-  handleNavigationResponse(html: string): void;
+  handleNavigationResponse(html: string, destinationHref: string): void;
   // Send an in-band navigate message over the existing WebSocket.
   // Returns true if the message was sent, false if it was dropped
   // (e.g. WS not open). The caller uses this to decide whether to push
@@ -239,7 +239,7 @@ export class LinkInterceptor {
       }
 
       this.currentHref = href;
-      this.context.handleNavigationResponse(html);
+      this.context.handleNavigationResponse(html, href);
     } catch (e: unknown) {
       // AbortError means a new navigation superseded this one — ignore
       if (e instanceof DOMException && e.name === "AbortError") return;

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -258,7 +258,8 @@ export class LiveTemplateClient {
     this.linkInterceptor = new LinkInterceptor(
       {
         getWrapperElement: () => this.wrapperElement,
-        handleNavigationResponse: (html: string) => this.handleNavigationResponse(html),
+        handleNavigationResponse: (html: string, destinationHref: string) =>
+          this.handleNavigationResponse(html, destinationHref),
         sendNavigate: (href: string) => this.sendNavigate(href),
         // Only take the in-band fast path when the WS is actually OPEN.
         // If WS is CONNECTING or CLOSED, falling through to the normal fetch
@@ -945,28 +946,33 @@ export class LiveTemplateClient {
    * Returns true when the two pages declare different stylesheets,
    * which is our signal that swapping the body alone would leave the
    * new content styled by the wrong app's CSS. URLs are compared as
-   * absolute (resolved against the relevant base) so that "/foo.css"
-   * and "https://host/foo.css" don't appear to differ.
+   * absolute (the live doc's via the browser-resolved .href; the
+   * fetched doc's via explicit base-URL resolution against the
+   * destination, since the parsed Document has no inherent base) so
+   * that "/foo.css" and "https://host/foo.css" don't appear to differ.
    */
-  private stylesheetsDiffer(doc: Document): boolean {
-    const baseHref = window.location.href;
-    const collect = (root: Document | DocumentFragment): Set<string> => {
-      const set = new Set<string>();
-      const links = root.querySelectorAll('link[rel~="stylesheet"][href]');
-      links.forEach((l) => {
-        const raw = l.getAttribute("href");
-        if (!raw) return;
-        try {
-          set.add(new URL(raw, baseHref).href);
-        } catch {
-          set.add(raw);
-        }
-      });
-      return set;
-    };
+  private stylesheetsDiffer(doc: Document, destinationHref: string): boolean {
+    const currentLinks = document.querySelectorAll(
+      'link[rel~="stylesheet"][href]'
+    );
+    const current = new Set<string>();
+    currentLinks.forEach((l) => {
+      const href = (l as HTMLLinkElement).href;
+      if (href) current.add(href);
+    });
 
-    const current = collect(document);
-    const fetched = collect(doc);
+    const fetchedLinks = doc.querySelectorAll('link[rel~="stylesheet"][href]');
+    const fetched = new Set<string>();
+    fetchedLinks.forEach((l) => {
+      const raw = l.getAttribute("href");
+      if (!raw) return;
+      try {
+        fetched.add(new URL(raw, destinationHref).href);
+      } catch {
+        fetched.add(raw);
+      }
+    });
+
     if (current.size !== fetched.size) return true;
     let differs = false;
     current.forEach((href) => {
@@ -975,7 +981,17 @@ export class LiveTemplateClient {
     return differs;
   }
 
-  private handleNavigationResponse(html: string): void {
+  /**
+   * Force a full document navigation to `destinationHref`. Used when
+   * an SPA-style body-swap is unsafe (e.g. cross-app navigation). The
+   * indirection exists for testability — jsdom locks the real Location
+   * object, so tests spy on this method instead.
+   */
+  private performFullNavigation(destinationHref: string): void {
+    window.location.href = destinationHref;
+  }
+
+  private handleNavigationResponse(html: string, destinationHref: string): void {
     if (!this.wrapperElement) return;
 
     const parser = new DOMParser();
@@ -1023,11 +1039,11 @@ export class LiveTemplateClient {
       // the new body styled by the previous app's CSS — broken layout
       // that "fixes itself on refresh" because a real navigation reloads
       // the head too. Detect this and fall through to a full navigation.
-      if (this.stylesheetsDiffer(doc)) {
+      if (this.stylesheetsDiffer(doc, destinationHref)) {
         this.logger.info(
-          "Cross-app navigation detected (different <link rel=\"stylesheet\"> set in fetched HTML); reloading to pick up the new head"
+          "Cross-app navigation detected (different <link rel=\"stylesheet\"> set in fetched HTML); falling back to full navigation"
         );
-        window.location.reload();
+        this.performFullNavigation(destinationHref);
         return;
       }
 

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -939,6 +939,42 @@ export class LiveTemplateClient {
    * (done in LinkInterceptor.navigate) so the WebSocket connects to
    * the correct handler.
    */
+  /**
+   * Compare the set of <link rel="stylesheet"> URLs in the current
+   * document's <head> against those in a fetched (parsed) document.
+   * Returns true when the two pages declare different stylesheets,
+   * which is our signal that swapping the body alone would leave the
+   * new content styled by the wrong app's CSS. URLs are compared as
+   * absolute (resolved against the relevant base) so that "/foo.css"
+   * and "https://host/foo.css" don't appear to differ.
+   */
+  private stylesheetsDiffer(doc: Document): boolean {
+    const baseHref = window.location.href;
+    const collect = (root: Document | DocumentFragment): Set<string> => {
+      const set = new Set<string>();
+      const links = root.querySelectorAll('link[rel~="stylesheet"][href]');
+      links.forEach((l) => {
+        const raw = l.getAttribute("href");
+        if (!raw) return;
+        try {
+          set.add(new URL(raw, baseHref).href);
+        } catch {
+          set.add(raw);
+        }
+      });
+      return set;
+    };
+
+    const current = collect(document);
+    const fetched = collect(doc);
+    if (current.size !== fetched.size) return true;
+    let differs = false;
+    current.forEach((href) => {
+      if (!fetched.has(href)) differs = true;
+    });
+    return differs;
+  }
+
   private handleNavigationResponse(html: string): void {
     if (!this.wrapperElement) return;
 
@@ -974,6 +1010,23 @@ export class LiveTemplateClient {
       // Guard: attribute exists (we queried by [data-lvt-id]) but could be empty
       if (!newId) {
         this.logger.warn("Cross-handler navigation: new wrapper has empty data-lvt-id");
+        window.location.reload();
+        return;
+      }
+
+      // Cross-app boundary: the SPA optimization (swap body, keep head)
+      // only works when both pages share the same <head> contract. When
+      // a user navigates from one deployed app to another that shares
+      // the origin (e.g., a docs site reverse-proxying a separately-
+      // deployed pattern showcase), the two apps may declare different
+      // <link rel="stylesheet"> URLs. Patching only the body would leave
+      // the new body styled by the previous app's CSS — broken layout
+      // that "fixes itself on refresh" because a real navigation reloads
+      // the head too. Detect this and fall through to a full navigation.
+      if (this.stylesheetsDiffer(doc)) {
+        this.logger.info(
+          "Cross-app navigation detected (different <link rel=\"stylesheet\"> set in fetched HTML); reloading to pick up the new head"
+        );
         window.location.reload();
         return;
       }

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -21,8 +21,11 @@ describe("handleNavigationResponse", () => {
     document.body.innerHTML = ""; // safe: test cleanup
   });
 
-  const callHandleNavigationResponse = (html: string) => {
-    (client as any).handleNavigationResponse(html);
+  const callHandleNavigationResponse = (
+    html: string,
+    destinationHref: string = "https://example.com/"
+  ) => {
+    (client as any).handleNavigationResponse(html, destinationHref);
   };
 
   describe("same-handler navigation", () => {
@@ -439,7 +442,7 @@ describe("handleNavigationResponse", () => {
       // stylesheet, then have the fetched doc declare a different one.
       const link = document.createElement("link");
       link.setAttribute("rel", "stylesheet");
-      link.setAttribute("href", "/assets/lt-patterns.css");
+      link.setAttribute("href", "https://example.com/assets/lt-patterns.css");
       document.head.appendChild(link);
     });
 
@@ -447,11 +450,10 @@ describe("handleNavigationResponse", () => {
       document.head.querySelectorAll('link[rel="stylesheet"]').forEach((l) => l.remove());
     });
 
-    it("skips body swap when fetched HTML declares a different set of stylesheets", () => {
-      // jsdom's Location is read-only and refuses both .reload override and
-      // defineProperty replacement. Test the observable consequence instead:
-      // when stylesheets differ, the body swap path (which calls disconnect)
-      // must NOT run — the cross-app reload short-circuit returns first.
+    it("triggers a full navigation when fetched HTML declares a different set of stylesheets", () => {
+      const performNavSpy = jest
+        .spyOn(client as any, "performFullNavigation")
+        .mockImplementation(() => {});
       const disconnectSpy = jest
         .spyOn(client, "disconnect")
         .mockImplementation(() => {});
@@ -459,7 +461,7 @@ describe("handleNavigationResponse", () => {
       const html = [
         "<html>",
         "<head>",
-        '  <link rel="stylesheet" href="/assets/docs-site.css">',
+        '  <link rel="stylesheet" href="https://example.com/assets/docs-site.css">',
         "</head>",
         "<body>",
         '  <div data-lvt-id="lvt-handler-a">',
@@ -469,10 +471,14 @@ describe("handleNavigationResponse", () => {
         "</html>",
       ].join("\n");
 
-      callHandleNavigationResponse(html);
+      callHandleNavigationResponse(html, "https://example.com/docs/intro");
 
-      // Body swap path NOT taken: disconnect() was the first observable
-      // side effect of the swap path, so it serves as the proxy signal.
+      // Cross-app boundary: full navigation called with the destination
+      // URL (NOT reload(), which would silently rely on caller-set
+      // window.location ordering — see PR #119 review).
+      expect(performNavSpy).toHaveBeenCalledWith("https://example.com/docs/intro");
+      // Body swap path NOT taken: disconnect serves as the proxy signal
+      // for "we proceeded into the swap path", and it must not have run.
       expect(disconnectSpy).not.toHaveBeenCalled();
       // Wrapper content unchanged — confirms we early-returned BEFORE
       // replaceChildren, so the page can't enter a half-swapped state.
@@ -491,7 +497,7 @@ describe("handleNavigationResponse", () => {
       const html = [
         "<html>",
         "<head>",
-        '  <link rel="stylesheet" href="/assets/lt-patterns.css">',
+        '  <link rel="stylesheet" href="https://example.com/assets/lt-patterns.css">',
         "</head>",
         "<body>",
         '  <div data-lvt-id="lvt-handler-b">',

--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -425,4 +425,86 @@ describe("handleNavigationResponse", () => {
       ).not.toThrow();
     });
   });
+
+  describe("cross-app boundary (different stylesheets)", () => {
+    // Real-world repro from livetemplate.fly.dev: a docs site reverse-proxies
+    // a separately-deployed app at /patterns/*. Each app owns its <head>
+    // (different <link rel="stylesheet"> URLs). Without this guard, clicking
+    // a link from the proxied app back to the docs root patches the docs body
+    // into a page whose head still references the proxied app's stylesheets,
+    // producing a broken layout that "fixes itself on refresh."
+
+    beforeEach(() => {
+      // Pre-populate the current document head with the "originating" app's
+      // stylesheet, then have the fetched doc declare a different one.
+      const link = document.createElement("link");
+      link.setAttribute("rel", "stylesheet");
+      link.setAttribute("href", "/assets/lt-patterns.css");
+      document.head.appendChild(link);
+    });
+
+    afterEach(() => {
+      document.head.querySelectorAll('link[rel="stylesheet"]').forEach((l) => l.remove());
+    });
+
+    it("skips body swap when fetched HTML declares a different set of stylesheets", () => {
+      // jsdom's Location is read-only and refuses both .reload override and
+      // defineProperty replacement. Test the observable consequence instead:
+      // when stylesheets differ, the body swap path (which calls disconnect)
+      // must NOT run — the cross-app reload short-circuit returns first.
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+
+      const html = [
+        "<html>",
+        "<head>",
+        '  <link rel="stylesheet" href="/assets/docs-site.css">',
+        "</head>",
+        "<body>",
+        '  <div data-lvt-id="lvt-handler-a">',
+        "    <p>Docs root content</p>",
+        "  </div>",
+        "</body>",
+        "</html>",
+      ].join("\n");
+
+      callHandleNavigationResponse(html);
+
+      // Body swap path NOT taken: disconnect() was the first observable
+      // side effect of the swap path, so it serves as the proxy signal.
+      expect(disconnectSpy).not.toHaveBeenCalled();
+      // Wrapper content unchanged — confirms we early-returned BEFORE
+      // replaceChildren, so the page can't enter a half-swapped state.
+      expect(wrapper.textContent).toContain("Handler A content");
+    });
+
+    it("performs body swap when fetched HTML has the same stylesheets", () => {
+      // Within-app navigation: same head, body swap is the correct
+      // optimization. This is the path that the cross-app guard must
+      // not regress.
+      const disconnectSpy = jest
+        .spyOn(client, "disconnect")
+        .mockImplementation(() => {});
+      jest.spyOn(client as any, "connect").mockResolvedValue(undefined);
+
+      const html = [
+        "<html>",
+        "<head>",
+        '  <link rel="stylesheet" href="/assets/lt-patterns.css">',
+        "</head>",
+        "<body>",
+        '  <div data-lvt-id="lvt-handler-b">',
+        "    <p>Same-app new route</p>",
+        "  </div>",
+        "</body>",
+        "</html>",
+      ].join("\n");
+
+      callHandleNavigationResponse(html);
+
+      // disconnect() was called — the body swap path proceeded
+      expect(disconnectSpy).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`LinkInterceptor`'s SPA optimization patches the body and updates `<title>` while leaving `<head>` alone. That's correct for navigating between routes within one app, but breaks when the destination is a different app whose `<head>` declares different stylesheets — the new body ends up styled by the previous app's CSS.

`handleNavigationResponse` now compares the set of `<link rel="stylesheet">` URLs in the fetched HTML to those in the live document. Different sets ⇒ `window.location.reload()` to force a real navigation. Same sets ⇒ proceed on the swap path as before.

## How this was reproduced

Live on `livetemplate.fly.dev` (the LiveTemplate docs site, which reverse-proxies `lt-patterns.fly.dev` at `/patterns/*`):

1. Open `/patterns/forms/click-to-edit` (proxied content from the patterns app)
2. Click the **Patterns** link in the header — `href=\"/\"`
3. Same-origin pathname change ⇒ LinkInterceptor fetches `/`, swaps the body
4. `<head>` still has the patterns app's `pico.min.css` + `livetemplate.css`; the docs site's `pico.css` + `tinkerdown-client.css` + `prism.css` are gone
5. Sidebar collapses to inline flow, layout grid breaks
6. Refresh fixes it (full document load)

Reproduced in chromedp:

```
Fresh load of /:    sb.position=fixed, externalCSS=[pico.css, tinkerdown-client.css, prism.css]
After click flow:   sb.position=STATIC, externalCSS=[pico.min.css, livetemplate.css]
```

## Test plan

- [x] New `cross-app boundary` describe block in `tests/navigation.test.ts`:
  - Different stylesheets ⇒ body swap path NOT taken (`disconnect` not called, wrapper content preserved — guarantees no half-swapped state)
  - Matching stylesheets ⇒ body swap proceeds normally
- [x] Full client suite green: 521/521 tests pass

## Why this heuristic

Stylesheet-href set is a noisy-but-effective proxy for "different `<head>`":
- Apps deployed independently almost always link different stylesheet bundles, even when both use Pico/etc — the URLs differ (one app's CDN vs another's `/assets/`)
- Routes within one app share a `<head>` template, so the set is identical
- Cheap to compute (one querySelectorAll + Set comparison)

Other signals considered and rejected:
- Compare every `<head>` child node ⇒ too noisy (transient `<style>` blocks added by LiveTemplate)
- Compare `<title>` ⇒ no signal; titles change within an app
- Whitelist same-handler-id ⇒ already the existing path; cross-app can have the same handler id by collision

## Notes

This is an additive guard. The optimization path is unchanged for any navigation where it's actually safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)