### PR TITLE
feat: emit explicit submitter on the wire (livetemplate#237 Phase 2)

### DIFF
--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -71,6 +71,11 @@ export const DELEGATED_EVENT_TYPES = [
 ] as const;
 
 export class EventDelegator {
+  // Track forms we've already warned about for lvt-form:emit-submitter on
+  // GET. Per-form de-dup so dev consoles aren't flooded; WeakSet so forms
+  // GC'd from the DOM don't pin memory.
+  private warnedEmitSubmitterGETForms = new WeakSet<HTMLFormElement>();
+
   constructor(
     private readonly context: EventDelegationContext,
     private readonly logger: Logger
@@ -243,13 +248,23 @@ export class EventDelegator {
               // routing GET forms with multiple submit buttons should
               // either not opt into this directive or accept the URL
               // pollution as the cost of explicit routing.
+              if (element.method === "get" && !this.warnedEmitSubmitterGETForms.has(element)) {
+                this.logger.warn(
+                  "lvt-form:emit-submitter on a GET form serializes lvt-submitter into the URL query string, polluting browser history and any shared/bookmarked URLs. Use method=\"POST\" or remove the directive if URL pollution is unacceptable.",
+                  element
+                );
+                this.warnedEmitSubmitterGETForms.add(element);
+              }
               const submitter = (e as SubmitEvent).submitter as
                 | HTMLButtonElement
                 | HTMLInputElement
                 | null;
               if (submitter?.name) {
+                // Filter on type="hidden" so we never mutate a developer-
+                // authored visible <input name="lvt-submitter"> that happens
+                // to live in the form for some other purpose.
                 let hiddenInput = element.querySelector<HTMLInputElement>(
-                  'input[name="lvt-submitter"]'
+                  'input[type="hidden"][name="lvt-submitter"]'
                 );
                 if (!hiddenInput) {
                   hiddenInput = document.createElement("input");

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -248,18 +248,23 @@ export class EventDelegator {
               // routing GET forms with multiple submit buttons should
               // either not opt into this directive or accept the URL
               // pollution as the cost of explicit routing.
-              if (element.method === "get" && !this.warnedEmitSubmitterGETForms.has(element)) {
-                this.logger.warn(
-                  "lvt-form:emit-submitter on a GET form serializes lvt-submitter into the URL query string, polluting browser history and any shared/bookmarked URLs. Use method=\"POST\" or remove the directive if URL pollution is unacceptable.",
-                  element
-                );
-                this.warnedEmitSubmitterGETForms.add(element);
-              }
               const submitter = (e as SubmitEvent).submitter as
                 | HTMLButtonElement
                 | HTMLInputElement
                 | null;
               if (submitter?.name) {
+                // GET-form URL pollution: only warn when we'd actually
+                // inject a field (named submitter). A GET form whose
+                // current submission has no named submitter writes no
+                // lvt-submitter, so there's nothing to pollute and no
+                // warning to fire.
+                if (element.method === "get" && !this.warnedEmitSubmitterGETForms.has(element)) {
+                  this.logger.warn(
+                    "lvt-form:emit-submitter on a GET form serializes lvt-submitter into the URL query string, polluting browser history and any shared/bookmarked URLs. Use method=\"POST\" or remove the directive if URL pollution is unacceptable.",
+                    element
+                  );
+                  this.warnedEmitSubmitterGETForms.add(element);
+                }
                 // Filter on type="hidden" so we never mutate a developer-
                 // authored visible <input name="lvt-submitter"> that happens
                 // to live in the form for some other purpose.

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -278,6 +278,17 @@ export class EventDelegator {
                   element.appendChild(hiddenInput);
                 }
                 hiddenInput.value = submitter.name;
+              } else {
+                // No named submitter on this submission — clear any stale
+                // hidden input left over from a previous named submit.
+                // Without this, a [name=save] click followed by an unnamed
+                // click would send the stale "save" value to the server
+                // and misroute the action.
+                element
+                  .querySelector<HTMLInputElement>(
+                    'input[type="hidden"][name="lvt-submitter"]'
+                  )
+                  ?.remove();
               }
             }
           }

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -226,23 +226,39 @@ export class EventDelegator {
               // submissions, inject a hidden <input name="lvt-submitter">
               // populated from SubmitEvent.submitter.name so the server can
               // route the action without falling back to the empty-value
-              // heuristic. Updates an existing hidden input on subsequent
-              // submits; creates it on first submit if absent. Pure no-JS
-              // forms cannot use this — they keep relying on the heuristic.
+              // heuristic. Creates on first submit if absent; updates on
+              // subsequent submits. Pure no-JS forms cannot use this — they
+              // keep relying on the heuristic.
+              //
+              // Only acts when SubmitEvent.submitter has a non-empty name,
+              // matching the WS and HTTP-multipart paths above. Submits with
+              // no named submitter (e.g., programmatic dispatch — out of
+              // scope per the proposal) keep any previous value and fall
+              // through to the heuristic for that submission.
+              //
+              // GET-form caveat: a `method="GET"` form serializes form
+              // fields into the URL query string, so `lvt-submitter` will
+              // appear in the browser history bar and any shared/bookmarked
+              // URLs. The directive does not guard against this — apps
+              // routing GET forms with multiple submit buttons should
+              // either not opt into this directive or accept the URL
+              // pollution as the cost of explicit routing.
               const submitter = (e as SubmitEvent).submitter as
                 | HTMLButtonElement
                 | HTMLInputElement
                 | null;
-              let hiddenInput = element.querySelector<HTMLInputElement>(
-                'input[name="lvt-submitter"]'
-              );
-              if (!hiddenInput) {
-                hiddenInput = document.createElement("input");
-                hiddenInput.type = "hidden";
-                hiddenInput.name = "lvt-submitter";
-                element.appendChild(hiddenInput);
+              if (submitter?.name) {
+                let hiddenInput = element.querySelector<HTMLInputElement>(
+                  'input[name="lvt-submitter"]'
+                );
+                if (!hiddenInput) {
+                  hiddenInput = document.createElement("input");
+                  hiddenInput.type = "hidden";
+                  hiddenInput.name = "lvt-submitter";
+                  element.appendChild(hiddenInput);
+                }
+                hiddenInput.value = submitter.name;
               }
-              hiddenInput.value = submitter?.name ?? "";
             }
           }
 

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -221,6 +221,28 @@ export class EventDelegator {
               if (dialog && element.getAttribute("method")?.toLowerCase() === "dialog") {
                 (element as any).__lvtCloseDialog = dialog;
               }
+            } else if (element.hasAttribute("lvt-form:emit-submitter")) {
+              // Phase 2 of livetemplate#237: for non-intercepted (native HTML)
+              // submissions, inject a hidden <input name="lvt-submitter">
+              // populated from SubmitEvent.submitter.name so the server can
+              // route the action without falling back to the empty-value
+              // heuristic. Updates an existing hidden input on subsequent
+              // submits; creates it on first submit if absent. Pure no-JS
+              // forms cannot use this — they keep relying on the heuristic.
+              const submitter = (e as SubmitEvent).submitter as
+                | HTMLButtonElement
+                | HTMLInputElement
+                | null;
+              let hiddenInput = element.querySelector<HTMLInputElement>(
+                'input[name="lvt-submitter"]'
+              );
+              if (!hiddenInput) {
+                hiddenInput = document.createElement("input");
+                hiddenInput.type = "hidden";
+                hiddenInput.name = "lvt-submitter";
+                element.appendChild(hiddenInput);
+              }
+              hiddenInput.value = submitter?.name ?? "";
             }
           }
 
@@ -355,6 +377,9 @@ export class EventDelegator {
                 const submitter2 = (targetElement as any).__lvtSubmitter as HTMLButtonElement | undefined;
                 if (submitter2) {
                   this.extractButtonData(submitter2, message.data);
+                  if (submitter2.name) {
+                    message.submitter = submitter2.name;
+                  }
                   delete (targetElement as any).__lvtSubmitter;
                 }
 
@@ -451,6 +476,9 @@ export class EventDelegator {
                   // sendHTTPMultipart from mutating a caller-supplied
                   // FormData object.
                   tier1FormData.set("lvt-action", action);
+                  if (submitter?.name) {
+                    tier1FormData.set("lvt-submitter", submitter.name);
+                  }
                 }
               }
 

--- a/tests/event-delegation.test.ts
+++ b/tests/event-delegation.test.ts
@@ -1553,9 +1553,12 @@ describe("EventDelegator", () => {
 
     it("lvt-form:emit-submitter populates hidden input on keyboard submit (Enter)", () => {
       // Simulates browser behavior: Enter in a text input selects the form's
-      // default submit button as SubmitEvent.submitter.
+      // default submit button as SubmitEvent.submitter. Form uses POST to
+      // avoid the URL-pollution caveat documented in the directive — GET
+      // forms serialize lvt-submitter into the query string, which is fine
+      // for apps that opt in but unhelpful as a default in tests.
       setupForm(
-        `<form id="search-form" lvt-form:no-intercept lvt-form:emit-submitter action="/q" method="GET">
+        `<form id="search-form" lvt-form:no-intercept lvt-form:emit-submitter action="/q" method="POST">
           <input type="text" name="q" value="hello" />
           <button type="submit" id="default-submit" name="go">Go</button>
         </form>`,
@@ -1570,6 +1573,27 @@ describe("EventDelegator", () => {
       const hiddenInput = form.querySelector<HTMLInputElement>('input[name="lvt-submitter"]');
       expect(hiddenInput).not.toBeNull();
       expect(hiddenInput!.value).toBe("go");
+    });
+
+    it("lvt-form:emit-submitter does not create hidden input when submitter has no name", () => {
+      // Matches the WS and HTTP-multipart paths: when SubmitEvent.submitter
+      // has no name (or is null), do not write lvt-submitter. The server
+      // falls back to the heuristic for that submission. No empty-string
+      // lvt-submitter="" appears on the wire.
+      setupForm(
+        `<form id="anon-form" lvt-form:no-intercept lvt-form:emit-submitter action="/post" method="POST">
+          <input name="title" value="Hello" />
+          <button type="submit" id="unnamed-btn">Submit</button>
+        </form>`,
+        "wrapper-emit-submitter-no-name"
+      );
+
+      const form = document.getElementById("anon-form") as HTMLFormElement;
+      const unnamedBtn = document.getElementById("unnamed-btn") as HTMLButtonElement;
+
+      dispatchSubmit(form, unnamedBtn);
+
+      expect(form.querySelector('input[name="lvt-submitter"]')).toBeNull();
     });
 
     it("lvt-form:emit-submitter updates existing hidden input on subsequent submits", () => {

--- a/tests/event-delegation.test.ts
+++ b/tests/event-delegation.test.ts
@@ -1655,12 +1655,52 @@ describe("EventDelegator", () => {
       expect(hiddenInput).not.toBeNull();
       expect(hiddenInput!.value).toBe("save");
 
-      // Two inputs named lvt-submitter coexist: one user-visible, one hidden.
-      // The native browser form serializer will send both — the server's
-      // resolveSubmitterFallback (and the lvt-submitter form key extractor
-      // upstream of it) reads the first non-empty value, but this assertion
-      // documents the wire reality so future contributors aren't surprised.
-      expect(form.querySelectorAll('input[name="lvt-submitter"]').length).toBe(2);
+      // Two inputs named lvt-submitter coexist: one user-visible (declared
+      // first in the markup, so it appears first in DOM order), one hidden
+      // (appended by the directive). The native browser form serializer
+      // sends both values in DOM order, and the server's
+      // r.FormValue("lvt-submitter") returns the first value — so the
+      // user-visible input's value wins and the directive's hidden input is
+      // effectively a no-op for this submission. This matches the proposal's
+      // reserved-name semantics: apps that put user data in a field named
+      // lvt-submitter accept that the value will be routed as the submitter
+      // (i.e., used as the action), which is exactly what the developer
+      // asked for in this scenario even if accidentally. The framework
+      // does not arbitrate this conflict client-side.
+      const inputs = form.querySelectorAll('input[name="lvt-submitter"]');
+      expect(inputs.length).toBe(2);
+      expect(inputs[0]).toBe(visibleInput);
+      expect((inputs[1] as HTMLInputElement).type).toBe("hidden");
+    });
+
+    it("lvt-form:emit-submitter does not warn on GET form when submitter is unnamed (no field injected)", () => {
+      // Regression for a false-positive bug: an earlier draft of the
+      // warning fired on every GET-form submission, even when the
+      // submitter had no name and the directive was about to skip
+      // injection. No injection means no URL pollution, so no warning.
+      const warnSpy = jest.fn();
+      const wrapper = document.createElement("div");
+      wrapper.setAttribute("data-lvt-id", "wrapper-emit-submitter-get-no-name");
+      wrapper.innerHTML = `<form id="get-anon-form" lvt-form:no-intercept lvt-form:emit-submitter action="/q" method="GET">
+        <input type="text" name="q" value="hello" />
+        <button type="submit" id="anon-btn">Submit</button>
+      </form>`;
+      document.body.appendChild(wrapper);
+
+      const context = createContext(wrapper);
+      const delegator = new EventDelegator(
+        context,
+        { debug: jest.fn(), info: jest.fn(), warn: warnSpy, error: jest.fn() } as any
+      );
+      delegator.setupEventDelegation();
+
+      const form = document.getElementById("get-anon-form") as HTMLFormElement;
+      const anonBtn = document.getElementById("anon-btn") as HTMLButtonElement;
+
+      dispatchSubmit(form, anonBtn);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(form.querySelector('input[name="lvt-submitter"]')).toBeNull();
     });
 
     it("lvt-form:emit-submitter warns once per form when used on a GET form", () => {

--- a/tests/event-delegation.test.ts
+++ b/tests/event-delegation.test.ts
@@ -1580,6 +1580,34 @@ describe("EventDelegator", () => {
       expect(hiddenInput!.value).toBe("go");
     });
 
+    it("lvt-form:emit-submitter clears stale hidden input on unnamed follow-up submission", () => {
+      // Regression: a named submit creates the hidden input with "save",
+      // then an unnamed submit must not leave that value on the form.
+      // Without the clear-on-unnamed branch, the server would receive
+      // the stale value and misroute the unnamed submit to the "save"
+      // action.
+      setupForm(
+        `<form id="seq-form" lvt-form:no-intercept lvt-form:emit-submitter action="/post" method="POST">
+          <input name="title" value="Hello" />
+          <button type="submit" id="save-btn" name="save">Save</button>
+          <button type="submit" id="unnamed-btn">Submit</button>
+        </form>`,
+        "wrapper-emit-submitter-named-then-unnamed"
+      );
+
+      const form = document.getElementById("seq-form") as HTMLFormElement;
+      const saveBtn = document.getElementById("save-btn") as HTMLButtonElement;
+      const unnamedBtn = document.getElementById("unnamed-btn") as HTMLButtonElement;
+
+      dispatchSubmit(form, saveBtn);
+      expect(
+        form.querySelector<HTMLInputElement>('input[type="hidden"][name="lvt-submitter"]')!.value
+      ).toBe("save");
+
+      dispatchSubmit(form, unnamedBtn);
+      expect(form.querySelector('input[name="lvt-submitter"]')).toBeNull();
+    });
+
     it("lvt-form:emit-submitter does not create hidden input when submitter has no name", () => {
       // Matches the WS and HTTP-multipart paths: when SubmitEvent.submitter
       // has no name (or is null), do not write lvt-submitter. The server

--- a/tests/event-delegation.test.ts
+++ b/tests/event-delegation.test.ts
@@ -1450,6 +1450,11 @@ describe("EventDelegator", () => {
     };
 
     const dispatchSubmit = (form: HTMLFormElement, submitter: HTMLButtonElement | HTMLInputElement | null) => {
+      // jsdom's SubmitEvent constructor does not accept a submitter option
+      // (and pre-jsdom-20 didn't expose SubmitEvent at all), so we construct
+      // a plain Event and assign .submitter directly. The cast matches the
+      // existing pattern in this test file (see the password-field test
+      // around line 130 for the canonical reference).
       const event = new Event("submit", {
         bubbles: true,
         cancelable: true,
@@ -1619,6 +1624,74 @@ describe("EventDelegator", () => {
       expect(hiddenInput!.value).toBe("draft");
       // Exactly one hidden input — not created twice.
       expect(form.querySelectorAll('input[name="lvt-submitter"]').length).toBe(1);
+    });
+
+    it("lvt-form:emit-submitter does not hijack a developer-authored visible lvt-submitter input", () => {
+      // Regression for a selector bug: looking up the lvt-submitter input
+      // without an explicit type="hidden" filter would silently mutate any
+      // existing user-visible <input name="lvt-submitter"> in the form.
+      setupForm(
+        `<form id="manual-form" lvt-form:no-intercept lvt-form:emit-submitter action="/post" method="POST">
+          <input type="text" name="lvt-submitter" value="user-chose-me" id="visible-input" />
+          <button type="submit" id="save-btn" name="save">Save</button>
+        </form>`,
+        "wrapper-emit-submitter-hidden-only"
+      );
+
+      const form = document.getElementById("manual-form") as HTMLFormElement;
+      const saveBtn = document.getElementById("save-btn") as HTMLButtonElement;
+      const visibleInput = document.getElementById("visible-input") as HTMLInputElement;
+
+      dispatchSubmit(form, saveBtn);
+
+      // Visible input must not have been touched.
+      expect(visibleInput.value).toBe("user-chose-me");
+      expect(visibleInput.type).toBe("text");
+
+      // A separate hidden input was injected for the directive's purpose.
+      const hiddenInput = form.querySelector<HTMLInputElement>(
+        'input[type="hidden"][name="lvt-submitter"]'
+      );
+      expect(hiddenInput).not.toBeNull();
+      expect(hiddenInput!.value).toBe("save");
+
+      // Two inputs named lvt-submitter coexist: one user-visible, one hidden.
+      // The native browser form serializer will send both — the server's
+      // resolveSubmitterFallback (and the lvt-submitter form key extractor
+      // upstream of it) reads the first non-empty value, but this assertion
+      // documents the wire reality so future contributors aren't surprised.
+      expect(form.querySelectorAll('input[name="lvt-submitter"]').length).toBe(2);
+    });
+
+    it("lvt-form:emit-submitter warns once per form when used on a GET form", () => {
+      const warnSpy = jest.fn();
+      const wrapper = document.createElement("div");
+      wrapper.setAttribute("data-lvt-id", "wrapper-emit-submitter-get-warn");
+      wrapper.innerHTML = `<form id="get-form" lvt-form:no-intercept lvt-form:emit-submitter action="/q" method="GET">
+        <input type="text" name="q" value="hello" />
+        <button type="submit" id="go-btn" name="go">Go</button>
+      </form>`;
+      document.body.appendChild(wrapper);
+
+      const context = createContext(wrapper);
+      const delegator = new EventDelegator(
+        context,
+        // Custom logger captures warn calls without scoping or formatting.
+        { debug: jest.fn(), info: jest.fn(), warn: warnSpy, error: jest.fn() } as any
+      );
+      delegator.setupEventDelegation();
+
+      const form = document.getElementById("get-form") as HTMLFormElement;
+      const goBtn = document.getElementById("go-btn") as HTMLButtonElement;
+
+      dispatchSubmit(form, goBtn);
+      dispatchSubmit(form, goBtn);
+      dispatchSubmit(form, goBtn);
+
+      // Warning emitted exactly once across three submissions.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("lvt-form:emit-submitter");
+      expect(warnSpy.mock.calls[0][0]).toContain("GET");
     });
 
     it("lvt-form:emit-submitter does not run when form is auto-intercepted", () => {

--- a/tests/event-delegation.test.ts
+++ b/tests/event-delegation.test.ts
@@ -1427,4 +1427,196 @@ describe("EventDelegator", () => {
       });
     });
   });
+
+  describe("explicit submitter on the wire (livetemplate#237 Phase 2)", () => {
+    const setupForm = (
+      innerHTML: string,
+      wrapperId: string,
+      overrides: Partial<EventDelegationContext> = {}
+    ) => {
+      const wrapper = document.createElement("div");
+      wrapper.setAttribute("data-lvt-id", wrapperId);
+      wrapper.innerHTML = innerHTML;
+      document.body.appendChild(wrapper);
+
+      const context = createContext(wrapper, overrides);
+      const delegator = new EventDelegator(
+        context,
+        createLogger({ scope: "EventDelegatorTest", level: "silent" })
+      );
+      delegator.setupEventDelegation();
+
+      return { wrapper, context };
+    };
+
+    const dispatchSubmit = (form: HTMLFormElement, submitter: HTMLButtonElement | HTMLInputElement | null) => {
+      const event = new Event("submit", {
+        bubbles: true,
+        cancelable: true,
+      }) as SubmitEvent & { submitter?: HTMLButtonElement | HTMLInputElement | null };
+      event.submitter = submitter;
+      form.dispatchEvent(event);
+    };
+
+    it("WS message includes submitter field when submitter has a name", () => {
+      const { context } = setupForm(
+        `<form id="post-form">
+          <input name="title" value="My Post" />
+          <button type="submit" id="draft-btn" name="draft">Save as Draft</button>
+        </form>`,
+        "wrapper-submitter-ws-named"
+      );
+
+      const form = document.getElementById("post-form") as HTMLFormElement;
+      const draftBtn = document.getElementById("draft-btn") as HTMLButtonElement;
+      dispatchSubmit(form, draftBtn);
+
+      expect(context.send).toHaveBeenCalledTimes(1);
+      expect(context.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "draft",
+          submitter: "draft",
+        })
+      );
+    });
+
+    it("WS message omits submitter field when submitter has no name", () => {
+      const { context } = setupForm(
+        `<form id="anon-form" lvt-form:action="post">
+          <input name="title" value="My Post" />
+          <button type="submit" id="anon-btn">Post</button>
+        </form>`,
+        "wrapper-submitter-ws-unnamed"
+      );
+
+      const form = document.getElementById("anon-form") as HTMLFormElement;
+      const anonBtn = document.getElementById("anon-btn") as HTMLButtonElement;
+      dispatchSubmit(form, anonBtn);
+
+      expect(context.send).toHaveBeenCalledTimes(1);
+      const sent = context.send.mock.calls[0][0];
+      expect(sent.action).toBe("post");
+      expect(sent.submitter).toBeUndefined();
+    });
+
+    it("HTTP Tier 1 multipart sets lvt-submitter when submitter has a name", () => {
+      const { context } = setupForm(
+        `<form id="upload-form">
+          <input type="file" id="file-input" name="avatar" />
+          <button type="submit" id="save-btn" name="save">Save</button>
+        </form>`,
+        "wrapper-submitter-multipart"
+      );
+
+      const form = document.getElementById("upload-form") as HTMLFormElement;
+      const fileInput = document.getElementById("file-input") as HTMLInputElement;
+      const saveBtn = document.getElementById("save-btn") as HTMLButtonElement;
+
+      // jsdom: stub the FileList so the Tier 1 multipart path triggers.
+      Object.defineProperty(fileInput, "files", {
+        value: [new File(["data"], "avatar.png", { type: "image/png" })],
+        configurable: true,
+      });
+
+      dispatchSubmit(form, saveBtn);
+
+      expect(context.sendHTTPMultipart).toHaveBeenCalledTimes(1);
+      const [, action, formData] = (context.sendHTTPMultipart as jest.Mock).mock.calls[0];
+      expect(action).toBe("save");
+      expect((formData as FormData).get("lvt-action")).toBe("save");
+      expect((formData as FormData).get("lvt-submitter")).toBe("save");
+    });
+
+    it("lvt-form:emit-submitter creates hidden input on first submit (click)", () => {
+      const { context } = setupForm(
+        `<form id="native-form" lvt-form:no-intercept lvt-form:emit-submitter action="/post" method="POST">
+          <input name="title" value="Hello" />
+          <button type="submit" id="draft-btn" name="draft">Save as Draft</button>
+        </form>`,
+        "wrapper-emit-submitter-click"
+      );
+
+      const form = document.getElementById("native-form") as HTMLFormElement;
+      const draftBtn = document.getElementById("draft-btn") as HTMLButtonElement;
+
+      expect(form.querySelector('input[name="lvt-submitter"]')).toBeNull();
+
+      dispatchSubmit(form, draftBtn);
+
+      const hiddenInput = form.querySelector<HTMLInputElement>('input[name="lvt-submitter"]');
+      expect(hiddenInput).not.toBeNull();
+      expect(hiddenInput!.type).toBe("hidden");
+      expect(hiddenInput!.value).toBe("draft");
+      // Non-intercepted form: client did not send a WS message.
+      expect(context.send).not.toHaveBeenCalled();
+    });
+
+    it("lvt-form:emit-submitter populates hidden input on keyboard submit (Enter)", () => {
+      // Simulates browser behavior: Enter in a text input selects the form's
+      // default submit button as SubmitEvent.submitter.
+      setupForm(
+        `<form id="search-form" lvt-form:no-intercept lvt-form:emit-submitter action="/q" method="GET">
+          <input type="text" name="q" value="hello" />
+          <button type="submit" id="default-submit" name="go">Go</button>
+        </form>`,
+        "wrapper-emit-submitter-keyboard"
+      );
+
+      const form = document.getElementById("search-form") as HTMLFormElement;
+      const defaultSubmit = document.getElementById("default-submit") as HTMLButtonElement;
+
+      dispatchSubmit(form, defaultSubmit);
+
+      const hiddenInput = form.querySelector<HTMLInputElement>('input[name="lvt-submitter"]');
+      expect(hiddenInput).not.toBeNull();
+      expect(hiddenInput!.value).toBe("go");
+    });
+
+    it("lvt-form:emit-submitter updates existing hidden input on subsequent submits", () => {
+      setupForm(
+        `<form id="multi-btn-form" lvt-form:no-intercept lvt-form:emit-submitter action="/post" method="POST">
+          <input name="title" value="My Post" />
+          <button type="submit" id="save-btn" name="save">Save</button>
+          <button type="submit" id="draft-btn" name="draft">Save as Draft</button>
+        </form>`,
+        "wrapper-emit-submitter-update"
+      );
+
+      const form = document.getElementById("multi-btn-form") as HTMLFormElement;
+      const saveBtn = document.getElementById("save-btn") as HTMLButtonElement;
+      const draftBtn = document.getElementById("draft-btn") as HTMLButtonElement;
+
+      dispatchSubmit(form, saveBtn);
+      let hiddenInput = form.querySelector<HTMLInputElement>('input[name="lvt-submitter"]');
+      expect(hiddenInput!.value).toBe("save");
+
+      dispatchSubmit(form, draftBtn);
+      hiddenInput = form.querySelector<HTMLInputElement>('input[name="lvt-submitter"]');
+      expect(hiddenInput!.value).toBe("draft");
+      // Exactly one hidden input — not created twice.
+      expect(form.querySelectorAll('input[name="lvt-submitter"]').length).toBe(1);
+    });
+
+    it("lvt-form:emit-submitter does not run when form is auto-intercepted", () => {
+      // Without lvt-form:no-intercept, the auto-intercept path handles the
+      // submitter via __lvtSubmitter / message.submitter — no hidden input
+      // should be injected into the form.
+      const { context } = setupForm(
+        `<form id="intercepted-form" lvt-form:emit-submitter>
+          <input name="title" value="Hello" />
+          <button type="submit" id="save-btn" name="save">Save</button>
+        </form>`,
+        "wrapper-emit-submitter-intercepted"
+      );
+
+      const form = document.getElementById("intercepted-form") as HTMLFormElement;
+      const saveBtn = document.getElementById("save-btn") as HTMLButtonElement;
+      dispatchSubmit(form, saveBtn);
+
+      expect(form.querySelector('input[name="lvt-submitter"]')).toBeNull();
+      expect(context.send).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "save", submitter: "save" })
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Phase 2 of the explicit-submitter contract documented in [`livetemplate/livetemplate`'s `docs/proposals/explicit-submitter.md`](https://github.com/livetemplate/livetemplate/blob/main/docs/proposals/explicit-submitter.md). Phase 1 (server-side acceptance via `ActionMessage.Submitter` + `resolveSubmitterFallback` helper) shipped in [livetemplate/livetemplate#396](https://github.com/livetemplate/livetemplate/pull/396); this PR adds the client-side emission so the server can route the clicked-button action without falling back to the empty-value heuristic.

Tracked under [livetemplate/livetemplate#237](https://github.com/livetemplate/livetemplate/issues/237).

## What changes (`dom/event-delegation.ts`)

Three wire-format edits, plus the new `lvt-form:emit-submitter` directive:

- **WS path** — after the `__lvtSubmitter` capture and `message.data` assembly, set `message.submitter = submitter.name` when the submitter has a name. `action` continues to be populated inline from `submitter.name` as today; the new `submitter` field is additive belt-and-suspenders.
- **HTTP Tier 1 multipart path** — after the existing `tier1FormData.set("lvt-action", action)`, set `tier1FormData.set("lvt-submitter", submitter.name)` when the submitter has a name. Skip the set on empty (no wire noise; server's `resolveSubmitterFallback` only fires when `Submitter != ""`).
- **`lvt-form:emit-submitter` directive (lite-JS opt-in)** — in the existing event-delegated submit listener, when a form has `lvt-form:no-intercept` AND `lvt-form:emit-submitter`, inject or update a hidden `<input type="hidden" name="lvt-submitter">` populated from `SubmitEvent.submitter.name` before the browser serializes the form natively. When a follow-up submit has no named submitter, the directive **clears** any stale hidden input so the server doesn't see leaked state from an earlier named submit. Wrapper-delegated, not per-form. Uses the `submit` event (not `click`) so keyboard-triggered submits work — Enter in a text input picks up the form's default submit button as `submitter`, populating the field correctly. Emits a one-shot `logger.warn` per form when used on a GET form (URL-pollution caveat).

The directive is intentionally inert on auto-intercepted forms (those without `lvt-form:no-intercept`) — the WS path already covers those via `message.submitter`. The directive is the "I want this contract on natively-submitted forms too" opt-in.

## What this PR does NOT do

- No `application/x-www-form-urlencoded` edit. Per Phase 2 spec, verified at the proposal-revision PR that the client never produces URL-encoded request bodies — `sendHTTP()` sends `application/json` and `sendHTTPMultipart()` sends `multipart/form-data`. The server's URL-encoded parser is exercised only by native browser submissions, which `lvt-form:emit-submitter` covers.
- No CHANGELOG / VERSION / `package.json` bump. The release commit aggregates this and any other features into a `chore(release):` section at release time (per the existing pattern, e.g. `94e049d chore(release): v0.8.42`).
- No e2e test in this PR. The chromedp e2e test referenced in [Verification item 3 of the proposal](https://github.com/livetemplate/livetemplate/blob/main/docs/proposals/explicit-submitter.md#verification) lives in the lvt repo and lands as a follow-up after this client release ships to npm.

## Test plan

- [x] All 544 client tests pass (`npm test`)
- [x] 12 new tests in `tests/event-delegation.test.ts` (`describe("explicit submitter on the wire (livetemplate#237 Phase 2)")`):
  - WS submitter present (named) / absent (unnamed)
  - HTTP multipart sets `lvt-submitter`
  - `lvt-form:emit-submitter` creates hidden input on first click submit
  - Populates on keyboard submit (Enter → form's default submit button)
  - Updates existing input on subsequent submits with different named buttons
  - Does not create hidden input when submitter is unnamed
  - Clears stale hidden input on named-then-unnamed sequence
  - Does not hijack a developer-authored visible `lvt-submitter` input (`type="hidden"` selector filter)
  - Warns once per form on GET-form misuse; does not warn on unnamed-submitter case (no field actually injected)
  - Inert on auto-intercepted forms (the WS path covers those via `message.submitter`)
- [x] `npm run build` succeeds (tsc + esbuild bundle, ~92.8 KB minified, no regressions vs. v0.8.42)
- [x] Pre-commit hook green
- [ ] After merge + release: client published to npm, then lvt-repo chromedp e2e test added (out of scope of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)