### PR TITLE
feat: hydrate Declarative Shadow DOM after morphdom inserts templates

### DIFF
--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -733,3 +733,64 @@ function createToastElement(msg: ToastMessage): HTMLElement {
   return el;
 }
 
+/**
+ * Activate Declarative Shadow DOM for `<template shadowrootmode>` elements
+ * that the client inserted via DOM APIs (innerHTML setter, morphdom's
+ * createElement+appendChild path). The HTML parser activates declarative
+ * shadow roots only at parse time or via setHTMLUnsafe / parseHTMLUnsafe;
+ * a `<template shadowrootmode>` set via `.innerHTML = ...` is parked as a
+ * plain template with content but no attached shadow root. This sweep
+ * closes that gap so server-emitted shadow roots survive a client
+ * re-render.
+ *
+ * For each matching template found under rootElement:
+ *  - attach a shadow root on the parent (open by default; "closed" when
+ *    shadowrootmode="closed");
+ *  - move the template's content into the shadow root (replaceChildren
+ *    so re-renders cleanly reset prior shadow content);
+ *  - remove the template.
+ *
+ * Hosts that can't accept a shadow root (a small fixed set: <input>,
+ * <textarea>, void elements, etc.) silently drop the template — better
+ * than an unhandled exception that kills the render.
+ *
+ * Idempotent: a re-run with no remaining templates is one querySelector
+ * call (no allocations, sub-millisecond on hundreds-of-rows pages).
+ */
+export function handleShadowRootHydration(rootElement: Element): void {
+  if (rootElement.querySelector("template[shadowrootmode]") === null) {
+    return;
+  }
+
+  const templates = Array.from(
+    rootElement.querySelectorAll("template[shadowrootmode]")
+  );
+  for (const tpl of templates) {
+    const parent = tpl.parentElement;
+    if (!parent) {
+      tpl.remove();
+      continue;
+    }
+    const modeAttr = tpl.getAttribute("shadowrootmode");
+    const mode: ShadowRootMode = modeAttr === "closed" ? "closed" : "open";
+
+    let shadow = parent.shadowRoot;
+    if (!shadow) {
+      try {
+        shadow = parent.attachShadow({ mode });
+      } catch {
+        // attachShadow throws for hosts that can't accept one (void
+        // elements, <input>, <textarea>, custom elements that declared a
+        // different mode, etc.). Drop the template so it doesn't keep
+        // tripping this hook on every render.
+        tpl.remove();
+        continue;
+      }
+    }
+
+    shadow.replaceChildren(
+      ...((tpl as HTMLTemplateElement).content.childNodes as unknown as Node[])
+    );
+    tpl.remove();
+  }
+}

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -733,6 +733,16 @@ function createToastElement(msg: ToastMessage): HTMLElement {
   return el;
 }
 
+// closedShadowRoots tracks shadow roots created in "closed" mode. The
+// platform makes them unreachable via `parent.shadowRoot` (it returns
+// null) — closed mode's whole point is that the host's normal DOM API
+// can't see them. On a re-render, without this side channel, the code
+// would call attachShadow a second time on the same host, throw
+// NotSupportedError, hit the catch, and silently drop the new content.
+// Open roots are reachable via parent.shadowRoot, so they don't need
+// the map.
+const closedShadowRoots = new WeakMap<Element, ShadowRoot>();
+
 /**
  * Activate Declarative Shadow DOM for `<template shadowrootmode>` elements
  * that the client inserted via DOM APIs (innerHTML setter, morphdom's
@@ -747,6 +757,7 @@ function createToastElement(msg: ToastMessage): HTMLElement {
  *  - attach a shadow root on the parent (open by default; "closed" when
  *    shadowrootmode="closed");
  *  - move the template's content into the shadow root (replaceChildren
+ *    accepts a DocumentFragment and re-parents its children atomically,
  *    so re-renders cleanly reset prior shadow content);
  *  - remove the template.
  *
@@ -754,8 +765,18 @@ function createToastElement(msg: ToastMessage): HTMLElement {
  * <textarea>, void elements, etc.) silently drop the template — better
  * than an unhandled exception that kills the render.
  *
- * Idempotent: a re-run with no remaining templates is one querySelector
- * call (no allocations, sub-millisecond on hundreds-of-rows pages).
+ * Closed-mode roots are tracked in a module-level WeakMap so re-renders
+ * can locate them (parent.shadowRoot returns null for closed roots).
+ *
+ * Idempotent: a re-run with no remaining templates is one qsa walk and
+ * an early return (sub-millisecond on hundreds-of-rows pages).
+ *
+ * Known limitation: nested DSD templates inside an already-hydrated
+ * shadow root are not activated. querySelectorAll only walks the light
+ * DOM, so once a `<template shadowrootmode>` has been moved into a
+ * shadow root its children are out of reach. Mirrors the native parser
+ * behaviour for HTML parsed via innerHTML; if nested DSD is ever
+ * needed, a recursive sweep per new shadow root would close that gap.
  */
 export function handleShadowRootHydration(rootElement: Element): void {
   // Single qsa for both the empty-fast-path and the actual work — querySelector
@@ -774,7 +795,10 @@ export function handleShadowRootHydration(rootElement: Element): void {
     const modeAttr = tpl.getAttribute("shadowrootmode");
     const mode: ShadowRootMode = modeAttr === "closed" ? "closed" : "open";
 
-    let shadow = parent.shadowRoot;
+    // For open roots, parent.shadowRoot is the reachable handle. For
+    // closed roots, the platform returns null on purpose — consult the
+    // WeakMap that we populated when we first attached the root.
+    let shadow = parent.shadowRoot ?? closedShadowRoots.get(parent);
     if (!shadow) {
       try {
         // Forward all Declarative Shadow DOM attributes so the hydrated
@@ -790,6 +814,9 @@ export function handleShadowRootHydration(rootElement: Element): void {
           clonable: tpl.hasAttribute("shadowrootclonable"),
           serializable: tpl.hasAttribute("shadowrootserializable"),
         });
+        if (mode === "closed") {
+          closedShadowRoots.set(parent, shadow);
+        }
       } catch {
         // attachShadow throws for hosts that can't accept one (void
         // elements, <input>, <textarea>, custom elements that declared a

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -798,7 +798,11 @@ export function handleShadowRootHydration(rootElement: Element): void {
   // templates are present. NodeList from querySelectorAll is static
   // (not live), so removing templates inside the loop doesn't disturb
   // iteration; no Array.from copy needed.
-  const templates = rootElement.querySelectorAll("template[shadowrootmode]");
+  // The selector guarantees <template> elements, so the typed qsa
+  // overload removes the `as HTMLTemplateElement` cast inside the loop.
+  const templates = rootElement.querySelectorAll<HTMLTemplateElement>(
+    "template[shadowrootmode]"
+  );
   if (templates.length === 0) return;
   for (const tpl of templates) {
     // qsa on an Element always returns descendants with a parentElement,
@@ -855,13 +859,21 @@ export function handleShadowRootHydration(rootElement: Element): void {
         // attachShadow throws DOMException for hosts that can't accept
         // one (void elements, <input>, <textarea>, custom elements that
         // declared a different mode, etc.). Drop the template so it
-        // doesn't keep tripping this hook on every render.
+        // doesn't keep tripping this hook on every render, AND warn so
+        // a developer accidentally putting shadow content on an invalid
+        // host gets a console signal rather than a mysteriously empty
+        // preview.
         //
         // Anything OTHER than a DOMException is a real bug (typo in the
         // options object, runtime fault); re-raise so it surfaces in the
         // console instead of getting silently masked as "unsupported
         // host".
         if (!(e instanceof DOMException)) throw e;
+        console.warn(
+          `livetemplate: attachShadow rejected on <${parent.tagName.toLowerCase()}> ` +
+            `(${e.name}: ${e.message}). Template removed.`,
+          parent
+        );
         tpl.remove();
         continue;
       }
@@ -871,7 +883,7 @@ export function handleShadowRootHydration(rootElement: Element): void {
     // children into the shadow root in one atomic platform call. Avoids
     // both the spread (which could hit call-stack argument limits on
     // very large NodeLists) and the intermediate Array.from allocation.
-    shadow.replaceChildren((tpl as HTMLTemplateElement).content);
+    shadow.replaceChildren(tpl.content);
     tpl.remove();
   }
 }

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -812,10 +812,19 @@ export function handleShadowRootHydration(rootElement: Element): void {
     }
     const modeAttr = tpl.getAttribute("shadowrootmode");
     // Align with the HTML parser: only "open" and "closed" trigger
-    // activation. A typo like shadowrootmode="opne" should be left as
-    // an inert template (matching what initial parse would do) rather
-    // than silently coerced to open with no warning to the author.
+    // activation. A typo like shadowrootmode="opne" was previously
+    // left in place "so the author can inspect" — but on every
+    // subsequent render the qsa would re-find it, defeating the
+    // fast-path advertised in the docblock. Remove it AND log a
+    // console.warn so authors actually see the typo (the next morphdom
+    // pass would overwrite it anyway).
     if (modeAttr !== "open" && modeAttr !== "closed") {
+      console.warn(
+        `livetemplate: invalid shadowrootmode=${JSON.stringify(modeAttr)}; ` +
+          `expected "open" or "closed". Template removed.`,
+        tpl
+      );
+      tpl.remove();
       continue;
     }
     const mode: ShadowRootMode = modeAttr;

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -777,12 +777,14 @@ const closedShadowRoots = new WeakMap<Element, ShadowRoot>();
  *
  * Known limitations:
  *
- * - Nested DSD templates are activated only when the outer template is
- *   processed and its children are still in the light DOM at qsa time.
- *   Once a `<template shadowrootmode>` has been moved into a shadow root
- *   by a prior call, subsequent calls can't see its descendants (qsa
- *   stops at shadow boundaries) — a re-render that regenerates only the
- *   outer host would leave inner DSD inert.
+ * - Nested DSD is inert on EVERY render, not just re-renders. A
+ *   `<template>`'s content lives in a DocumentFragment (`tpl.content`),
+ *   not in the light DOM, and `querySelectorAll` does not descend into
+ *   that fragment. So a `<template shadowrootmode>` nested inside
+ *   another `<template>` is never in the qsa result. Once the outer
+ *   shadow has been attached, the inner template ends up behind a
+ *   shadow boundary — still unreachable. The fix would be a recursive
+ *   sweep per new shadow root from within this loop.
  *
  * - Shadow-root options (`delegatesFocus`, `clonable`, `serializable`,
  *   even `mode`) are fixed at first attach. A re-render that toggles
@@ -790,7 +792,8 @@ const closedShadowRoots = new WeakMap<Element, ShadowRoot>();
  *   won't change the existing root's focus behaviour — re-attach isn't
  *   possible. Matches the HTML parser, which would have made the same
  *   one-shot decision; if the server needs to flip these flags, it
- *   needs to swap the host element entirely.
+ *   needs to swap the host element entirely. The mode-mismatch case
+ *   also logs a console.warn so the divergence is visible.
  */
 export function handleShadowRootHydration(rootElement: Element): void {
   // Single qsa for both the empty-fast-path and the actual work — a

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -837,6 +837,17 @@ export function handleShadowRootHydration(rootElement: Element): void {
     // closed roots, the platform returns null on purpose — consult the
     // WeakMap that we populated when we first attached the root.
     let shadow = parent.shadowRoot ?? closedShadowRoots.get(parent);
+    // If the server flips shadowrootmode on a re-render (e.g. open →
+    // closed), attachShadow can't be called a second time — the existing
+    // mode silently wins. Warn so the author notices the mistake instead
+    // of debugging mysterious focus/encapsulation behaviour later.
+    if (shadow && shadow.mode !== modeAttr) {
+      console.warn(
+        `livetemplate: shadowrootmode changed from "${shadow.mode}" to "${modeAttr}" ` +
+          `on re-render — mode is fixed at first attach and cannot be changed.`,
+        parent
+      );
+    }
     if (!shadow) {
       try {
         // Forward all Declarative Shadow DOM attributes so the hydrated

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -758,13 +758,13 @@ function createToastElement(msg: ToastMessage): HTMLElement {
  * call (no allocations, sub-millisecond on hundreds-of-rows pages).
  */
 export function handleShadowRootHydration(rootElement: Element): void {
-  if (rootElement.querySelector("template[shadowrootmode]") === null) {
-    return;
-  }
-
+  // Single qsa for both the empty-fast-path and the actual work — querySelector
+  // followed by querySelectorAll would double-walk the tree when templates
+  // are present, defeating the optimisation we wanted there.
   const templates = Array.from(
     rootElement.querySelectorAll("template[shadowrootmode]")
   );
+  if (templates.length === 0) return;
   for (const tpl of templates) {
     const parent = tpl.parentElement;
     if (!parent) {
@@ -800,9 +800,11 @@ export function handleShadowRootHydration(rootElement: Element): void {
       }
     }
 
-    shadow.replaceChildren(
-      ...Array.from((tpl as HTMLTemplateElement).content.childNodes)
-    );
+    // Pass the DocumentFragment directly — replaceChildren moves its
+    // children into the shadow root in one atomic platform call. Avoids
+    // both the spread (which could hit call-stack argument limits on
+    // very large NodeLists) and the intermediate Array.from allocation.
+    shadow.replaceChildren((tpl as HTMLTemplateElement).content);
     tpl.remove();
   }
 }

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -799,7 +799,14 @@ export function handleShadowRootHydration(rootElement: Element): void {
       continue;
     }
     const modeAttr = tpl.getAttribute("shadowrootmode");
-    const mode: ShadowRootMode = modeAttr === "closed" ? "closed" : "open";
+    // Align with the HTML parser: only "open" and "closed" trigger
+    // activation. A typo like shadowrootmode="opne" should be left as
+    // an inert template (matching what initial parse would do) rather
+    // than silently coerced to open with no warning to the author.
+    if (modeAttr !== "open" && modeAttr !== "closed") {
+      continue;
+    }
+    const mode: ShadowRootMode = modeAttr;
 
     // For open roots, parent.shadowRoot is the reachable handle. For
     // closed roots, the platform returns null on purpose — consult the

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -775,14 +775,22 @@ const closedShadowRoots = new WeakMap<Element, ShadowRoot>();
  * Idempotent: a re-run with no remaining templates is one qsa walk and
  * an early return (sub-millisecond on hundreds-of-rows pages).
  *
- * Known limitation: nested DSD templates are activated only when the
- * outer template is processed and its children are still in the light
- * DOM at qsa time. Once a `<template shadowrootmode>` has been moved
- * into a shadow root by a prior call, subsequent calls can't see its
- * descendants (qsa stops at shadow boundaries) — a re-render that
- * regenerates only the outer host would leave inner DSD inert. If
- * nested DSD across re-renders is ever needed, a recursive sweep per
- * new shadow root would close that gap.
+ * Known limitations:
+ *
+ * - Nested DSD templates are activated only when the outer template is
+ *   processed and its children are still in the light DOM at qsa time.
+ *   Once a `<template shadowrootmode>` has been moved into a shadow root
+ *   by a prior call, subsequent calls can't see its descendants (qsa
+ *   stops at shadow boundaries) — a re-render that regenerates only the
+ *   outer host would leave inner DSD inert.
+ *
+ * - Shadow-root options (`delegatesFocus`, `clonable`, `serializable`,
+ *   even `mode`) are fixed at first attach. A re-render that toggles
+ *   `shadowrootdelegatesfocus` on a host that already has a shadow root
+ *   won't change the existing root's focus behaviour — re-attach isn't
+ *   possible. Matches the HTML parser, which would have made the same
+ *   one-shot decision; if the server needs to flip these flags, it
+ *   needs to swap the host element entirely.
  */
 export function handleShadowRootHydration(rootElement: Element): void {
   // Single qsa for both the empty-fast-path and the actual work — a
@@ -793,6 +801,10 @@ export function handleShadowRootHydration(rootElement: Element): void {
   const templates = rootElement.querySelectorAll("template[shadowrootmode]");
   if (templates.length === 0) return;
   for (const tpl of templates) {
+    // qsa on an Element always returns descendants with a parentElement,
+    // so !parent should be unreachable today. Kept as a defensive guard
+    // in case a future caller passes a DocumentFragment-rooted tree
+    // where the matched template could be a fragment's direct child.
     const parent = tpl.parentElement;
     if (!parent) {
       tpl.remove();

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -777,7 +777,19 @@ export function handleShadowRootHydration(rootElement: Element): void {
     let shadow = parent.shadowRoot;
     if (!shadow) {
       try {
-        shadow = parent.attachShadow({ mode });
+        // Forward all Declarative Shadow DOM attributes so the hydrated
+        // root matches the one the HTML parser would build natively:
+        // - shadowrootdelegatesfocus  → delegatesFocus
+        // - shadowrootclonable        → clonable        (Chrome 124+)
+        // - shadowrootserializable    → serializable    (Chrome 125+)
+        // Unknown flags from older runtimes are silently ignored by
+        // attachShadow, so we don't need a feature-detect.
+        shadow = parent.attachShadow({
+          mode,
+          delegatesFocus: tpl.hasAttribute("shadowrootdelegatesfocus"),
+          clonable: tpl.hasAttribute("shadowrootclonable"),
+          serializable: tpl.hasAttribute("shadowrootserializable"),
+        });
       } catch {
         // attachShadow throws for hosts that can't accept one (void
         // elements, <input>, <textarea>, custom elements that declared a
@@ -789,7 +801,7 @@ export function handleShadowRootHydration(rootElement: Element): void {
     }
 
     shadow.replaceChildren(
-      ...((tpl as HTMLTemplateElement).content.childNodes as unknown as Node[])
+      ...Array.from((tpl as HTMLTemplateElement).content.childNodes)
     );
     tpl.remove();
   }

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -785,12 +785,12 @@ const closedShadowRoots = new WeakMap<Element, ShadowRoot>();
  * new shadow root would close that gap.
  */
 export function handleShadowRootHydration(rootElement: Element): void {
-  // Single qsa for both the empty-fast-path and the actual work — querySelector
-  // followed by querySelectorAll would double-walk the tree when templates
-  // are present, defeating the optimisation we wanted there.
-  const templates = Array.from(
-    rootElement.querySelectorAll("template[shadowrootmode]")
-  );
+  // Single qsa for both the empty-fast-path and the actual work — a
+  // leading querySelector check would double-walk the tree when
+  // templates are present. NodeList from querySelectorAll is static
+  // (not live), so removing templates inside the loop doesn't disturb
+  // iteration; no Array.from copy needed.
+  const templates = rootElement.querySelectorAll("template[shadowrootmode]");
   if (templates.length === 0) return;
   for (const tpl of templates) {
     const parent = tpl.parentElement;

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -741,6 +741,10 @@ function createToastElement(msg: ToastMessage): HTMLElement {
 // NotSupportedError, hit the catch, and silently drop the new content.
 // Open roots are reachable via parent.shadowRoot, so they don't need
 // the map.
+//
+// Module-scoped on purpose: WeakMap keys are garbage-collected with
+// their hosts, so detached elements don't leak. A function-scoped map
+// would forget closed roots across renders and the bug would return.
 const closedShadowRoots = new WeakMap<Element, ShadowRoot>();
 
 /**
@@ -771,12 +775,14 @@ const closedShadowRoots = new WeakMap<Element, ShadowRoot>();
  * Idempotent: a re-run with no remaining templates is one qsa walk and
  * an early return (sub-millisecond on hundreds-of-rows pages).
  *
- * Known limitation: nested DSD templates inside an already-hydrated
- * shadow root are not activated. querySelectorAll only walks the light
- * DOM, so once a `<template shadowrootmode>` has been moved into a
- * shadow root its children are out of reach. Mirrors the native parser
- * behaviour for HTML parsed via innerHTML; if nested DSD is ever
- * needed, a recursive sweep per new shadow root would close that gap.
+ * Known limitation: nested DSD templates are activated only when the
+ * outer template is processed and its children are still in the light
+ * DOM at qsa time. Once a `<template shadowrootmode>` has been moved
+ * into a shadow root by a prior call, subsequent calls can't see its
+ * descendants (qsa stops at shadow boundaries) — a re-render that
+ * regenerates only the outer host would leave inner DSD inert. If
+ * nested DSD across re-renders is ever needed, a recursive sweep per
+ * new shadow root would close that gap.
  */
 export function handleShadowRootHydration(rootElement: Element): void {
   // Single qsa for both the empty-fast-path and the actual work — querySelector
@@ -817,11 +823,17 @@ export function handleShadowRootHydration(rootElement: Element): void {
         if (mode === "closed") {
           closedShadowRoots.set(parent, shadow);
         }
-      } catch {
-        // attachShadow throws for hosts that can't accept one (void
-        // elements, <input>, <textarea>, custom elements that declared a
-        // different mode, etc.). Drop the template so it doesn't keep
-        // tripping this hook on every render.
+      } catch (e) {
+        // attachShadow throws DOMException for hosts that can't accept
+        // one (void elements, <input>, <textarea>, custom elements that
+        // declared a different mode, etc.). Drop the template so it
+        // doesn't keep tripping this hook on every render.
+        //
+        // Anything OTHER than a DOMException is a real bug (typo in the
+        // options object, runtime fault); re-raise so it surfaces in the
+        // console instead of getting silently masked as "unsupported
+        // host".
+        if (!(e instanceof DOMException)) throw e;
         tpl.remove();
         continue;
       }

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1836,16 +1836,16 @@ export class LiveTemplateClient {
     // morphdom inserted via DOM APIs (which don't auto-activate them).
     // Cheap when no templates are present (one querySelectorAll).
     //
-    // Ordering note: this runs AFTER the directive sweeps above, so
-    // livetemplate directives nested INSIDE shadow content (e.g.
-    // lvt-on:click on an element inside a `<template shadowrootmode>`)
-    // are inert on the render that first hydrates them — those sweeps
-    // already finished by the time the shadow root exists. Today's
-    // consumer (prereview's HTML preview) wraps sanitised user HTML in
-    // shadow DOM for style isolation, no livetemplate directives
-    // inside. If a future consumer needs directives inside shadow
-    // content, they should fire setupFxDOMEventTriggers etc. against
-    // the new shadowRoot from within the hydration loop.
+    // Hard limitation: livetemplate directives placed INSIDE shadow
+    // content (e.g. lvt-on:click on an element inside a `<template
+    // shadowrootmode>`) NEVER register, on any render. The directive
+    // sweeps above (setupFxDOMEventTriggers, eventDelegator) walk via
+    // querySelectorAll which stops at shadow boundaries, and the
+    // hydration that follows doesn't run them against the new shadow
+    // root either. Treat shadow DOM as a style/structure isolation
+    // primitive only — keep directives in light DOM. Today's consumer
+    // (prereview's HTML preview) wraps sanitised user HTML in shadow
+    // DOM purely for style isolation; no directives go in.
     handleShadowRootHydration(element);
     setupScrollAway(element);
     setupSpy(element);

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -12,6 +12,7 @@ import {
   handleAutoClickDirectives,
   handleHighlightDirectives,
   handleScrollDirectives,
+  handleShadowRootHydration,
   handleToastDirectives,
   teardownAutoClickTimers,
   setupToastClickOutside,
@@ -1831,6 +1832,10 @@ export class LiveTemplateClient {
     handleAnimateDirectives(element);
     handleToastDirectives(element);
     handleAutoClickDirectives(element);
+    // Hydrate any server-emitted Declarative Shadow DOM templates that
+    // morphdom inserted via DOM APIs (which don't auto-activate them).
+    // Cheap when no templates are present (one querySelector check).
+    handleShadowRootHydration(element);
     setupScrollAway(element);
     setupSpy(element);
     if (this.nodesAddedThisRender > 0 || this.directiveTouchedThisRender) {

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1834,7 +1834,18 @@ export class LiveTemplateClient {
     handleAutoClickDirectives(element);
     // Hydrate any server-emitted Declarative Shadow DOM templates that
     // morphdom inserted via DOM APIs (which don't auto-activate them).
-    // Cheap when no templates are present (one querySelector check).
+    // Cheap when no templates are present (one querySelectorAll).
+    //
+    // Ordering note: this runs AFTER the directive sweeps above, so
+    // livetemplate directives nested INSIDE shadow content (e.g.
+    // lvt-on:click on an element inside a `<template shadowrootmode>`)
+    // are inert on the render that first hydrates them — those sweeps
+    // already finished by the time the shadow root exists. Today's
+    // consumer (prereview's HTML preview) wraps sanitised user HTML in
+    // shadow DOM for style isolation, no livetemplate directives
+    // inside. If a future consumer needs directives inside shadow
+    // content, they should fire setupFxDOMEventTriggers etc. against
+    // the new shadowRoot from within the hydration loop.
     handleShadowRootHydration(element);
     setupScrollAway(element);
     setupSpy(element);

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -903,6 +903,29 @@ describe("handleShadowRootHydration", () => {
     expect(document.body.innerHTML).toBe(before);
   });
 
+  it("replaces existing shadow content on re-hydration in closed mode (WeakMap fallback)", () => {
+    // parent.shadowRoot is null for closed roots by spec, so a re-render
+    // would otherwise re-call attachShadow, throw NotSupportedError, and
+    // silently drop the new content. The WeakMap side-channel locates
+    // the prior root so replaceChildren actually updates it.
+    document.body.innerHTML = `
+      <div id="host">
+        <template shadowrootmode="closed"><span class="round">1</span></template>
+      </div>
+    `;
+    const host = document.getElementById("host")!;
+    handleShadowRootHydration(document.body);
+    expect(host.shadowRoot).toBeNull(); // closed — spec confirms
+
+    // The directive's WeakMap holds the closed root; we can't observe its
+    // content via host.shadowRoot, but we CAN verify the re-render path
+    // doesn't throw and doesn't drop the template, which is the exact
+    // failure mode pre-fix.
+    host.innerHTML = `<template shadowrootmode="closed"><span class="round">2</span></template>`;
+    expect(() => handleShadowRootHydration(document.body)).not.toThrow();
+    expect(host.querySelector("template")).toBeNull();
+  });
+
   it("replaces existing shadow content on re-hydration (server re-render)", () => {
     document.body.innerHTML = `
       <div id="host">

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -995,6 +995,31 @@ describe("handleShadowRootHydration", () => {
     host.remove();
   });
 
+  it("warns when attachShadow rejects the host (DOMException path)", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const host = document.createElement("div");
+    host.id = "warn-host";
+    document.body.appendChild(host);
+    const tpl = document.createElement("template");
+    tpl.setAttribute("shadowrootmode", "open");
+    host.appendChild(tpl);
+    host.attachShadow = () => {
+      throw new DOMException(
+        "Operation is not supported",
+        "NotSupportedError"
+      );
+    };
+
+    handleShadowRootHydration(document.body);
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("attachShadow rejected"),
+      host
+    );
+    warn.mockRestore();
+    host.remove();
+  });
+
   it("removes templates with an unrecognised shadowrootmode and warns", () => {
     // The HTML parser doesn't activate a `<template shadowrootmode>`
     // with an unknown mode value. The directive removes the template
@@ -1066,6 +1091,51 @@ describe("handleShadowRootHydration", () => {
       clonable: true,
       serializable: true,
     });
+  });
+
+  // Documented limitations — kept as it.skip so a future PR that
+  // closes either gap can flip the skip and have an instant test.
+
+  it.skip("mode mismatch on re-render is silently ignored (one-shot attach)", () => {
+    // First render: shadowrootmode="open" → open root attached.
+    // Second render: shadowrootmode="closed" → ignored, root stays open.
+    // The docblock calls this a known limitation; this skipped test pins
+    // the contract so a future "fix" gets the right test coverage.
+    document.body.innerHTML = `
+      <div id="host">
+        <template shadowrootmode="open"><span>first</span></template>
+      </div>
+    `;
+    const host = document.getElementById("host")!;
+    handleShadowRootHydration(document.body);
+    host.innerHTML = `<template shadowrootmode="closed"><span>second</span></template>`;
+    handleShadowRootHydration(document.body);
+    // Today: open root persists because attachShadow is only called on
+    // first attach. If this test ever passes, see the JSDoc — the new
+    // behaviour needs documenting.
+    expect(host.shadowRoot).toBeNull();
+  });
+
+  it.skip("nested DSD across re-renders is left inert (qsa stops at shadow boundary)", () => {
+    // Outer shadow root hydrated. Server re-renders the outer host with
+    // a new inner `<template shadowrootmode>`. qsa from rootElement
+    // won't cross into the existing shadow root to find it.
+    document.body.innerHTML = `
+      <div id="outer">
+        <template shadowrootmode="open">
+          <div id="inner"></div>
+        </template>
+      </div>
+    `;
+    handleShadowRootHydration(document.body);
+    const outer = document.getElementById("outer")!;
+    // Simulate the server re-rendering the inner host with nested DSD.
+    outer.shadowRoot!.getElementById("inner")!.innerHTML = `
+      <template shadowrootmode="open"><span>nested</span></template>
+    `;
+    handleShadowRootHydration(document.body);
+    const inner = outer.shadowRoot!.getElementById("inner")!;
+    expect(inner.shadowRoot).toBeNull();
   });
 
   it("defaults all extended options to false when attrs are absent", () => {

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -961,28 +961,19 @@ describe("handleShadowRootHydration", () => {
   });
 
   it("silently drops the template when the host can't accept a shadow root", () => {
-    // <input> can't host a shadow root. attachShadow throws; the hook
-    // must catch and remove the template instead of leaving a re-trigger
-    // ticking on every render.
-    document.body.innerHTML = `
-      <input id="bad" />
-    `;
-    const input = document.getElementById("bad")! as HTMLInputElement;
-    // Manually insert the template under <input>'s parent so the
-    // template's parentElement is the <input>'s container — but we want
-    // to test the actual fail-and-recover. Use a <div> we manually
-    // force to reject:
+    // Real-world hosts that can't accept a shadow root (void elements,
+    // <input>, <textarea>, custom-element mode conflicts) make
+    // attachShadow throw a DOMException. The hook must catch and
+    // remove the template instead of leaving a re-trigger ticking on
+    // every render. Drive the failure path via a stub on a regular
+    // <div> so this test doesn't depend on jsdom's <input>-as-host
+    // behaviour, which varies across versions.
     const host = document.createElement("div");
     host.id = "host";
     document.body.appendChild(host);
     const tpl = document.createElement("template");
     tpl.setAttribute("shadowrootmode", "open");
     host.appendChild(tpl);
-    // Force attachShadow to throw the same DOMException the platform
-    // would for an unsupported host. Plain Errors are deliberately NOT
-    // caught (a typo in the options object should surface, not silently
-    // drop content) — see the "rethrows non-DOMException errors" test
-    // below.
     const orig = host.attachShadow.bind(host);
     host.attachShadow = () => {
       throw new DOMException(
@@ -997,8 +988,25 @@ describe("handleShadowRootHydration", () => {
     expect(host.shadowRoot).toBeNull();
 
     host.attachShadow = orig;
-    input.remove();
     host.remove();
+  });
+
+  it("skips templates with an unrecognised shadowrootmode (parser parity)", () => {
+    // The HTML parser doesn't activate a `<template shadowrootmode>`
+    // with an unknown mode value — it leaves the template inert. The
+    // directive should match that behaviour rather than silently
+    // coercing "opne" / "openn" / typos to "open".
+    document.body.innerHTML = `
+      <div id="host">
+        <template shadowrootmode="opne"><span>typo</span></template>
+      </div>
+    `;
+    const host = document.getElementById("host")!;
+    handleShadowRootHydration(document.body);
+    expect(host.shadowRoot).toBeNull();
+    // The template is left in place so the author can spot the typo on
+    // inspection rather than the content silently disappearing.
+    expect(host.querySelector("template")).not.toBeNull();
   });
 
   it("rethrows non-DOMException errors so real bugs surface", () => {

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -859,10 +859,6 @@ describe("handleAutoClickDirectives", () => {
 describe("handleShadowRootHydration", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
-    jest.spyOn(console, "warn").mockImplementation(() => {});
-  });
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   it("attaches an open shadow root and moves template content into it", () => {
@@ -984,5 +980,49 @@ describe("handleShadowRootHydration", () => {
     handleShadowRootHydration(document.body);
     const host = document.getElementById("host")!;
     expect(host.shadowRoot).toBeNull();
+  });
+
+  it("forwards shadowrootdelegatesfocus / clonable / serializable to attachShadow", () => {
+    // Use a spy because jsdom doesn't expose the options on the resulting
+    // ShadowRoot in a stable way across versions — checking the call args
+    // is what we actually want to assert ("the directive forwards
+    // attributes faithfully to the platform call").
+    document.body.innerHTML = `
+      <div id="host">
+        <template shadowrootmode="open" shadowrootdelegatesfocus shadowrootclonable shadowrootserializable>
+          <span>focus me</span>
+        </template>
+      </div>
+    `;
+    const host = document.getElementById("host")!;
+    const spy = jest.spyOn(host, "attachShadow");
+
+    handleShadowRootHydration(document.body);
+
+    expect(spy).toHaveBeenCalledWith({
+      mode: "open",
+      delegatesFocus: true,
+      clonable: true,
+      serializable: true,
+    });
+  });
+
+  it("defaults all extended options to false when attrs are absent", () => {
+    document.body.innerHTML = `
+      <div id="host">
+        <template shadowrootmode="open"><span>x</span></template>
+      </div>
+    `;
+    const host = document.getElementById("host")!;
+    const spy = jest.spyOn(host, "attachShadow");
+
+    handleShadowRootHydration(document.body);
+
+    expect(spy).toHaveBeenCalledWith({
+      mode: "open",
+      delegatesFocus: false,
+      clonable: false,
+      serializable: false,
+    });
   });
 });

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -917,13 +917,17 @@ describe("handleShadowRootHydration", () => {
     handleShadowRootHydration(document.body);
     expect(host.shadowRoot).toBeNull(); // closed — spec confirms
 
-    // The directive's WeakMap holds the closed root; we can't observe its
-    // content via host.shadowRoot, but we CAN verify the re-render path
-    // doesn't throw and doesn't drop the template, which is the exact
-    // failure mode pre-fix.
+    // The directive's WeakMap holds the closed root; we can't observe
+    // its content via host.shadowRoot, but we CAN verify (a) the
+    // re-render path doesn't throw, (b) the template gets consumed,
+    // and (c) the template's content left the light DOM — together,
+    // strong evidence the content moved into the cached shadow root
+    // rather than vanishing or staying parked as an inert template
+    // (the exact failure mode pre-fix).
     host.innerHTML = `<template shadowrootmode="closed"><span class="round">2</span></template>`;
     expect(() => handleShadowRootHydration(document.body)).not.toThrow();
     expect(host.querySelector("template")).toBeNull();
+    expect(host.children.length).toBe(0); // content lives in shadow, not light DOM
   });
 
   it("replaces existing shadow content on re-hydration (server re-render)", () => {

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -978,12 +978,17 @@ describe("handleShadowRootHydration", () => {
     const tpl = document.createElement("template");
     tpl.setAttribute("shadowrootmode", "open");
     host.appendChild(tpl);
-    // Force attachShadow to throw — simulate the void-element case
-    // without depending on the jsdom <input> shadow-host behavior, which
-    // varies between implementations.
+    // Force attachShadow to throw the same DOMException the platform
+    // would for an unsupported host. Plain Errors are deliberately NOT
+    // caught (a typo in the options object should surface, not silently
+    // drop content) — see the "rethrows non-DOMException errors" test
+    // below.
     const orig = host.attachShadow.bind(host);
     host.attachShadow = () => {
-      throw new Error("Operation is not supported");
+      throw new DOMException(
+        "Operation is not supported",
+        "NotSupportedError"
+      );
     };
 
     expect(() => handleShadowRootHydration(document.body)).not.toThrow();
@@ -993,6 +998,22 @@ describe("handleShadowRootHydration", () => {
 
     host.attachShadow = orig;
     input.remove();
+    host.remove();
+  });
+
+  it("rethrows non-DOMException errors so real bugs surface", () => {
+    document.body.innerHTML = `
+      <div id="host"><template shadowrootmode="open"><span>x</span></template></div>
+    `;
+    const host = document.getElementById("host")!;
+    host.attachShadow = () => {
+      throw new Error("typo in options or runtime bug");
+    };
+
+    // A bare catch would have hidden this; the narrow guard surfaces it.
+    expect(() => handleShadowRootHydration(document.body)).toThrow(
+      "typo in options or runtime bug"
+    );
   });
 
   it("idempotent re-run when no remaining templates is essentially free", () => {

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -995,11 +995,13 @@ describe("handleShadowRootHydration", () => {
     host.remove();
   });
 
-  it("skips templates with an unrecognised shadowrootmode (parser parity)", () => {
+  it("removes templates with an unrecognised shadowrootmode and warns", () => {
     // The HTML parser doesn't activate a `<template shadowrootmode>`
-    // with an unknown mode value — it leaves the template inert. The
-    // directive should match that behaviour rather than silently
-    // coercing "opne" / "openn" / typos to "open".
+    // with an unknown mode value. The directive removes the template
+    // outright (so the fast-path advertised in the docblock isn't
+    // defeated by a persistent typo that the qsa keeps re-finding) and
+    // logs a console.warn so authors actually see the mistake.
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
     document.body.innerHTML = `
       <div id="host">
         <template shadowrootmode="opne"><span>typo</span></template>
@@ -1008,9 +1010,12 @@ describe("handleShadowRootHydration", () => {
     const host = document.getElementById("host")!;
     handleShadowRootHydration(document.body);
     expect(host.shadowRoot).toBeNull();
-    // The template is left in place so the author can spot the typo on
-    // inspection rather than the content silently disappearing.
-    expect(host.querySelector("template")).not.toBeNull();
+    expect(host.querySelector("template")).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid shadowrootmode"),
+      expect.anything()
+    );
+    warn.mockRestore();
   });
 
   it("rethrows non-DOMException errors so real bugs surface", () => {

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1119,26 +1119,27 @@ describe("handleShadowRootHydration", () => {
     warn.mockRestore();
   });
 
-  it.skip("nested DSD across re-renders is left inert (qsa stops at shadow boundary)", () => {
-    // Outer shadow root hydrated. Server re-renders the outer host with
-    // a new inner `<template shadowrootmode>`. qsa from rootElement
-    // won't cross into the existing shadow root to find it.
+  it.skip("nested DSD inside another template is inert on first render", () => {
+    // A `<template shadowrootmode>` nested inside another `<template>`
+    // is in DocumentFragment land, which qsa doesn't descend into — the
+    // inner template is never in the first qsa result, so it stays
+    // inert from render zero. (The "on re-render" case is the same
+    // mechanism: after the outer shadow attaches, the inner template
+    // sits behind a shadow boundary, also out of qsa's reach.)
     document.body.innerHTML = `
       <div id="outer">
         <template shadowrootmode="open">
-          <div id="inner"></div>
+          <div id="inner">
+            <template shadowrootmode="open"><span>nested</span></template>
+          </div>
         </template>
       </div>
     `;
     handleShadowRootHydration(document.body);
     const outer = document.getElementById("outer")!;
-    // Simulate the server re-rendering the inner host with nested DSD.
-    outer.shadowRoot!.getElementById("inner")!.innerHTML = `
-      <template shadowrootmode="open"><span>nested</span></template>
-    `;
-    handleShadowRootHydration(document.body);
     const inner = outer.shadowRoot!.getElementById("inner")!;
     expect(inner.shadowRoot).toBeNull();
+    expect(inner.querySelector("template")).not.toBeNull();
   });
 
   it("defaults all extended options to false when attrs are absent", () => {

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1096,11 +1096,8 @@ describe("handleShadowRootHydration", () => {
   // Documented limitations — kept as it.skip so a future PR that
   // closes either gap can flip the skip and have an instant test.
 
-  it.skip("mode mismatch on re-render is silently ignored (one-shot attach)", () => {
-    // First render: shadowrootmode="open" → open root attached.
-    // Second render: shadowrootmode="closed" → ignored, root stays open.
-    // The docblock calls this a known limitation; this skipped test pins
-    // the contract so a future "fix" gets the right test coverage.
+  it("warns when shadowrootmode is changed on re-render (mode is one-shot)", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
     document.body.innerHTML = `
       <div id="host">
         <template shadowrootmode="open"><span>first</span></template>
@@ -1108,12 +1105,18 @@ describe("handleShadowRootHydration", () => {
     `;
     const host = document.getElementById("host")!;
     handleShadowRootHydration(document.body);
+    // Server flips the mode on the next render — surfacing the mismatch
+    // is the contract.
     host.innerHTML = `<template shadowrootmode="closed"><span>second</span></template>`;
     handleShadowRootHydration(document.body);
-    // Today: open root persists because attachShadow is only called on
-    // first attach. If this test ever passes, see the JSDoc — the new
-    // behaviour needs documenting.
-    expect(host.shadowRoot).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("shadowrootmode changed"),
+      host
+    );
+    // The pre-existing open root persists (attachShadow can't be re-
+    // called); content still updates inside it.
+    expect(host.shadowRoot?.querySelector("span")?.textContent).toBe("second");
+    warn.mockRestore();
   });
 
   it.skip("nested DSD across re-renders is left inert (qsa stops at shadow boundary)", () => {

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -3,6 +3,7 @@ import {
   handleHighlightDirectives,
   handleAnimateDirectives,
   handleAutoClickDirectives,
+  handleShadowRootHydration,
   setupFxDOMEventTriggers,
   teardownAutoClickTimers,
   __resetAnimatedElementsForTesting,
@@ -852,5 +853,136 @@ describe("handleAutoClickDirectives", () => {
     jest.advanceTimersByTime(500);
 
     expect(clickSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleShadowRootHydration", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("attaches an open shadow root and moves template content into it", () => {
+    document.body.innerHTML = `
+      <div id="host">
+        <template shadowrootmode="open"><span class="inner">hi</span></template>
+      </div>
+    `;
+    const host = document.getElementById("host")!;
+
+    handleShadowRootHydration(document.body);
+
+    expect(host.shadowRoot).not.toBeNull();
+    expect(host.shadowRoot!.querySelector(".inner")?.textContent).toBe("hi");
+    // Template should be gone — leaving it would re-trigger the hook
+    // on every subsequent render.
+    expect(host.querySelector("template")).toBeNull();
+  });
+
+  it("honors shadowrootmode='closed'", () => {
+    document.body.innerHTML = `
+      <div id="host">
+        <template shadowrootmode="closed"><span>x</span></template>
+      </div>
+    `;
+    const host = document.getElementById("host")!;
+
+    handleShadowRootHydration(document.body);
+
+    // Closed shadow root: parent.shadowRoot stays null per spec, but
+    // the template still gets consumed.
+    expect(host.shadowRoot).toBeNull();
+    expect(host.querySelector("template")).toBeNull();
+  });
+
+  it("is a no-op when there are no shadowroot templates", () => {
+    document.body.innerHTML = `<div><p>nothing here</p></div>`;
+    const before = document.body.innerHTML;
+
+    handleShadowRootHydration(document.body);
+
+    expect(document.body.innerHTML).toBe(before);
+  });
+
+  it("replaces existing shadow content on re-hydration (server re-render)", () => {
+    document.body.innerHTML = `
+      <div id="host">
+        <template shadowrootmode="open"><span>first</span></template>
+      </div>
+    `;
+    const host = document.getElementById("host")!;
+    handleShadowRootHydration(document.body);
+    expect(host.shadowRoot!.querySelector("span")?.textContent).toBe("first");
+
+    // Simulate the server emitting a new template into the same host
+    // after a morph (host kept, template re-inserted).
+    host.innerHTML = `<template shadowrootmode="open"><span>second</span></template>`;
+    handleShadowRootHydration(document.body);
+
+    expect(host.shadowRoot!.querySelector("span")?.textContent).toBe("second");
+    expect(host.querySelector("template")).toBeNull();
+  });
+
+  it("handles multiple sibling templates on one page", () => {
+    document.body.innerHTML = `
+      <div id="a"><template shadowrootmode="open"><i>A</i></template></div>
+      <div id="b"><template shadowrootmode="open"><i>B</i></template></div>
+      <div id="c"><template shadowrootmode="open"><i>C</i></template></div>
+    `;
+
+    handleShadowRootHydration(document.body);
+
+    for (const [id, want] of [["a", "A"], ["b", "B"], ["c", "C"]] as const) {
+      const host = document.getElementById(id)!;
+      expect(host.shadowRoot?.querySelector("i")?.textContent).toBe(want);
+    }
+  });
+
+  it("silently drops the template when the host can't accept a shadow root", () => {
+    // <input> can't host a shadow root. attachShadow throws; the hook
+    // must catch and remove the template instead of leaving a re-trigger
+    // ticking on every render.
+    document.body.innerHTML = `
+      <input id="bad" />
+    `;
+    const input = document.getElementById("bad")! as HTMLInputElement;
+    // Manually insert the template under <input>'s parent so the
+    // template's parentElement is the <input>'s container — but we want
+    // to test the actual fail-and-recover. Use a <div> we manually
+    // force to reject:
+    const host = document.createElement("div");
+    host.id = "host";
+    document.body.appendChild(host);
+    const tpl = document.createElement("template");
+    tpl.setAttribute("shadowrootmode", "open");
+    host.appendChild(tpl);
+    // Force attachShadow to throw — simulate the void-element case
+    // without depending on the jsdom <input> shadow-host behavior, which
+    // varies between implementations.
+    const orig = host.attachShadow.bind(host);
+    host.attachShadow = () => {
+      throw new Error("Operation is not supported");
+    };
+
+    expect(() => handleShadowRootHydration(document.body)).not.toThrow();
+    // Template must be removed even though attach failed.
+    expect(host.querySelector("template")).toBeNull();
+    expect(host.shadowRoot).toBeNull();
+
+    host.attachShadow = orig;
+    input.remove();
+  });
+
+  it("idempotent re-run when no remaining templates is essentially free", () => {
+    document.body.innerHTML = `<div id="host"></div>`;
+    // First run: nothing to do.
+    handleShadowRootHydration(document.body);
+    // Second run on a clean tree: still nothing.
+    handleShadowRootHydration(document.body);
+    const host = document.getElementById("host")!;
+    expect(host.shadowRoot).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Add `handleShadowRootHydration(root)` directive that walks for `<template shadowrootmode>` after morphdom completes, attaches a shadow root to the parent, moves the template's content via `replaceChildren`, and removes the template.
- Wire it into the post-morph FIRE-ON-CHANGE block alongside `handleScrollDirectives` / `handleAutoClickDirectives`.
- Fast path: one `querySelector` when no templates are present (sub-millisecond on hundreds-of-rows pages).

## Why

The HTML parser activates Declarative Shadow DOM only at initial document parse or via `setHTMLUnsafe`/`parseHTMLUnsafe`. The client uses `template.innerHTML = ...` for fragment parsing and morphdom for DOM updates — neither path triggers activation. Without this hook, a server-emitted `<template shadowrootmode="open">` parks as an inert template on every render.

Unblocks downstream consumers (e.g. prereview's HTML preview, livetemplate/prereview#15) that need style isolation for user-supplied HTML.

## Test plan

- [x] `npm test -- --testPathPatterns directives` — 59 pass (7 new for hydration)
- [x] Full client suite (607 tests) green
- [x] Verified end-to-end via prereview's HTML preview: shadow DOM isolates user CSS, SPA chrome unaffected
- [ ] CI

## Edge cases covered

- Open + closed `shadowrootmode`
- Re-hydration on re-render (server emits new template, content swaps)
- Multiple sibling templates on one page
- Host that rejects shadow roots (silent drop instead of crash)
- No templates → cheap no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)