### PR TITLE
feat: lvt-fx:area-select — drag-rectangle pointer directive with final-coords dispatch

### DIFF
--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -984,6 +984,12 @@ const MIN_AREA_FRACTION = 0.02;
  *    so click handlers still receive the gesture; that means the
  *    browser's default text-selection-on-drag behaviour also fires
  *    unless the host opts out via CSS).
+ *  - The overlay uses `z-index: var(--lvt-area-select-z-index, 9999)`.
+ *    9999 is high enough for most use cases but can collide with
+ *    portals / modals / drawers that also sit at a high z-index.
+ *    Set `--lvt-area-select-z-index` on the host (or any ancestor)
+ *    to override. Color + fill follow the same pattern via
+ *    `--lvt-area-select-color` and `--lvt-area-select-fill`.
  *  - **No keyboard equivalent.** Pointer-only by design (a keyboard-
  *    selected rectangle requires a different UX — focus + arrow keys
  *    to position + arrow keys to size). Consumers needing a11y for
@@ -1092,6 +1098,14 @@ function attachAreaSelect(
   // stays a child of the parent we appended it to (overlay removal
   // uses overlay.parentElement, which is independent).
   let dragParent: HTMLElement | null = null;
+  // Cache the host's rect at pointerdown — startClientX/Y are captured
+  // in the SAME frame, so the start corner is meaningful only against
+  // the rect that existed then. If a server diff repositions the host
+  // mid-drag, finalize would otherwise clamp the (old-coord-system)
+  // startClientX against the new rect and silently produce wrong
+  // fractions. Anchoring to the start-rect keeps the dispatched
+  // rectangle pinned to the visual region the user actually dragged.
+  let startRect: DOMRect | null = null;
 
   const removeOverlay = () => {
     if (overlay) {
@@ -1116,11 +1130,14 @@ function attachAreaSelect(
     el.removeEventListener("pointerleave", onPointerLeaveCancel);
     pointerId = -1;
     dragParent = null;
-    if (!dispatch || !e) {
+    // Snapshot + clear startRect before any early return so a future
+    // gesture starts with a fresh capture.
+    const rect = startRect;
+    startRect = null;
+    if (!dispatch || !e || !rect) {
       removeOverlay();
       return;
     }
-    const rect = el.getBoundingClientRect();
     if (rect.width <= 0 || rect.height <= 0) {
       removeOverlay();
       return;
@@ -1224,6 +1241,7 @@ function attachAreaSelect(
     startClientY = e.clientY;
     pointerId = e.pointerId;
     dragParent = parent;
+    startRect = el.getBoundingClientRect();
     let captureOk = false;
     try {
       el.setPointerCapture(pointerId);

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -915,6 +915,13 @@ const areaSelectArmed = new Map<Element, AreaSelectEntry>();
 // so a user who repeatedly drags on a mis-configured element gets a
 // single console message instead of one per pointerdown. WeakSet so
 // detached parents don't leak.
+//
+// Known limitation: once a parent is in the set, the warn never fires
+// again on that DOM node — even if the developer subsequently adds
+// `position: relative` to fix the issue. The WeakSet is per-object
+// (different DOM node = different entry), so re-mounting the parent
+// resets the dedupe; in-place CSS fixes do not. Fine in practice
+// (the user already saw the warn once, on the broken render).
 const areaSelectWarnedParents = new WeakSet<Element>();
 
 interface AreaSelectEntry {
@@ -1155,11 +1162,14 @@ function attachAreaSelect(
     send({ action, data: { x, y, w, h } });
   };
 
-  const onPointerLeaveCancel = () => {
+  const onPointerLeaveCancel = (e: PointerEvent) => {
     // Fallback for the rare case where setPointerCapture failed: without
     // capture, pointermove + pointerup stop arriving once the pointer
     // leaves the host, freezing the overlay. Treating pointerleave as
     // a cancel keeps the overlay from getting stuck on screen.
+    // Guard on pointerId — in multi-touch, a SECONDARY pointer's
+    // leave shouldn't cancel the primary drag.
+    if (e.pointerId !== pointerId) return;
     finalize(null, false);
   };
 

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -911,6 +911,12 @@ export function handleShadowRootHydration(rootElement: Element): void {
 // the same sweep (isConnected check).
 const areaSelectArmed = new Map<Element, AreaSelectEntry>();
 
+// areaSelectWarnedParents dedupes the "parent not positioned" dev-warn
+// so a user who repeatedly drags on a mis-configured element gets a
+// single console message instead of one per pointerdown. WeakSet so
+// detached parents don't leak.
+const areaSelectWarnedParents = new WeakSet<Element>();
+
 interface AreaSelectEntry {
   action: string;
   cleanup: () => void;
@@ -1182,19 +1188,24 @@ function attachAreaSelect(
     // the wrong place with no error, just a confusing visual.
     // Check against the positive list of positioned values; the
     // default "static" and an unset/empty value both fail it (jsdom
-    // returns "" for unset position).
-    const parentPos = window.getComputedStyle(parent).position;
-    if (
-      parentPos !== "relative" &&
-      parentPos !== "absolute" &&
-      parentPos !== "fixed" &&
-      parentPos !== "sticky"
-    ) {
-      console.warn(
-        "lvt-fx:area-select: parentElement has no positioning context; the drag overlay will be mis-positioned. " +
-          "Add position:relative (or absolute/fixed/sticky) to the parent.",
-        parent
-      );
+    // returns "" for unset position). Dedupe via WeakSet so a user
+    // dragging repeatedly on the same mis-configured parent gets ONE
+    // console message, not one per pointerdown.
+    if (!areaSelectWarnedParents.has(parent)) {
+      const parentPos = window.getComputedStyle(parent).position;
+      if (
+        parentPos !== "relative" &&
+        parentPos !== "absolute" &&
+        parentPos !== "fixed" &&
+        parentPos !== "sticky"
+      ) {
+        console.warn(
+          "lvt-fx:area-select: parentElement has no positioning context; the drag overlay will be mis-positioned. " +
+            "Add position:relative (or absolute/fixed/sticky) to the parent.",
+          parent
+        );
+        areaSelectWarnedParents.add(parent);
+      }
     }
     startClientX = e.clientX;
     startClientY = e.clientY;

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1087,8 +1087,11 @@ function attachAreaSelect(
   let dragParent: HTMLElement | null = null;
 
   const removeOverlay = () => {
-    if (overlay && overlay.parentElement) {
-      overlay.parentElement.removeChild(overlay);
+    if (overlay) {
+      // Element.remove() is a no-op if the node isn't in the DOM,
+      // so we don't need the parent-null guard the older two-step
+      // pattern needed.
+      overlay.remove();
     }
     overlay = null;
   };

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -961,12 +961,6 @@ const MIN_AREA_FRACTION = 0.02;
  *    (`position: relative` / `absolute` / `fixed`). The overlay is
  *    `position: absolute` inside that parent so it follows the host
  *    on scroll / reflow.
- *  - The parent should NOT use `overflow: hidden` — the in-progress
- *    overlay can briefly extend outside the host's rect while the
- *    drag is in flight (before the clamp settles on a frame), and
- *    overflow:hidden would clip it. The saved area persisted by
- *    the consumer will fit inside the host's rect; only the live
- *    drag-paint can briefly overshoot.
  *  - Consumers usually pair this with `touch-action: none` on the
  *    host so iOS Safari doesn't interpret the drag as a pinch/scroll.
  *  - `<img>` and other natively-draggable hosts work automatically:
@@ -1119,8 +1113,23 @@ function attachAreaSelect(
 
   const finalize = (e: PointerEvent | null, dispatch: boolean) => {
     if (pointerId === -1) return;
+    // CRITICAL ORDER: reset pointerId + dragParent + startRect BEFORE
+    // calling releasePointerCapture. Chromium fires lostpointercapture
+    // SYNCHRONOUSLY during releasePointerCapture, which lands in
+    // onLostCapture → finalize(null, false). Without the early reset,
+    // the nested finalize sees pointerId still matching and runs to
+    // completion (clearing startRect), then the outer finalize
+    // resumes with startRect == null and silently drops the
+    // dispatched action. Resetting first makes the nested call
+    // return at the `pointerId === -1` guard, leaving outer state
+    // intact.
+    const capturedPointerId = pointerId;
+    const rect = startRect;
+    pointerId = -1;
+    dragParent = null;
+    startRect = null;
     try {
-      el.releasePointerCapture(pointerId);
+      el.releasePointerCapture(capturedPointerId);
     } catch {
       // Capture may already be gone (e.g. pointercancel) — ignore.
     }
@@ -1128,12 +1137,6 @@ function attachAreaSelect(
     // doesn't inherit a stale listener from this one. {once: true}
     // only auto-removes if it fires; a stuck drag never fired it.
     el.removeEventListener("pointerleave", onPointerLeaveCancel);
-    pointerId = -1;
-    dragParent = null;
-    // Snapshot + clear startRect before any early return so a future
-    // gesture starts with a fresh capture.
-    const rect = startRect;
-    startRect = null;
     if (!dispatch || !e || !rect) {
       removeOverlay();
       return;

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1258,22 +1258,34 @@ function attachAreaSelect(
     if (!parent) return;
     const elRect = el.getBoundingClientRect();
     const parentRect = parent.getBoundingClientRect();
-    // position:absolute offsets from the parent's PADDING box, not its
-    // border box. getBoundingClientRect returns the border box, so a
-    // parent with a non-zero CSS border would shift the overlay by the
-    // border width. Subtract clientLeft / clientTop to convert from
-    // border-box to padding-box offset.
+    // Convert viewport coords (clientX/Y) to position:absolute CSS
+    // offsets inside the parent. Three corrections, all subtracted
+    // from / added to the same way for every value we compute:
+    //
+    //   1. parentRect.left/top — getBoundingClientRect is in viewport
+    //      coords; CSS offsets are relative to the parent's box.
+    //   2. parent.clientLeft/Top — position:absolute is measured from
+    //      the padding box; getBoundingClientRect returns the border
+    //      box. A parent with a CSS border would otherwise shift the
+    //      overlay by the border width.
+    //   3. parent.scrollLeft/Top — when the parent is scrolled, an
+    //      element at viewport_x = parentRect.left has CSS_left =
+    //      parent.scrollLeft (not 0). Without adding scroll back in,
+    //      the overlay paints offset by the scroll amount.
     const borderL = parent.clientLeft;
     const borderT = parent.clientTop;
-    const left = Math.min(startClientX, e.clientX) - parentRect.left - borderL;
-    const top = Math.min(startClientY, e.clientY) - parentRect.top - borderT;
+    const scrollL = parent.scrollLeft;
+    const scrollT = parent.scrollTop;
+    const toCSSLeft = (vx: number) => vx - parentRect.left - borderL + scrollL;
+    const toCSSTop = (vy: number) => vy - parentRect.top - borderT + scrollT;
+    const left = toCSSLeft(Math.min(startClientX, e.clientX));
+    const top = toCSSTop(Math.min(startClientY, e.clientY));
     const width = Math.abs(e.clientX - startClientX);
     const height = Math.abs(e.clientY - startClientY);
-    // Clamp to the host's rendered rect so a drag that runs off the
-    // edge doesn't paint outside the image. Same border-box-to-
-    // padding-box conversion as above.
-    const minLeft = elRect.left - parentRect.left - borderL;
-    const minTop = elRect.top - parentRect.top - borderT;
+    // Clamp to the host's rendered rect (in the same CSS coord space)
+    // so a drag that runs off the edge doesn't paint outside the host.
+    const minLeft = toCSSLeft(elRect.left);
+    const minTop = toCSSTop(elRect.top);
     const maxRight = minLeft + elRect.width;
     const maxBottom = minTop + elRect.height;
     const clampedLeft = Math.max(minLeft, Math.min(left, maxRight));

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -989,6 +989,23 @@ const MIN_AREA_FRACTION = 0.02;
  * and the first client's send() is orphaned. Single-client use is
  * unaffected.
  */
+/**
+ * Cancel area-select listeners for every armed element under root.
+ * Mirrors teardownAutoClickTimers: meant for the client's disconnect /
+ * destroy lifecycle so the module-level singleton doesn't outlive a
+ * client that was torn down without a subsequent
+ * handleAreaSelectDirectives call (e.g. network error closed the
+ * socket while an element was armed). Without this, a SPA that mounts
+ * + tears down livetemplate trees would leak listeners across mounts.
+ */
+export function teardownAreaSelectForRoot(rootElement: Element): void {
+  for (const [element, entry] of Array.from(areaSelectArmed)) {
+    if (rootElement === element || rootElement.contains(element)) {
+      entry.cleanup();
+    }
+  }
+}
+
 export function handleAreaSelectDirectives(
   rootElement: Element,
   send: (message: { action: string; data: Record<string, unknown> }) => void
@@ -1097,6 +1114,13 @@ function attachAreaSelect(
     const w = (x1 - x0) / rect.width;
     const h = (y1 - y0) / rect.height;
     removeOverlay();
+    // Reject zero-area rectangles outright. The MIN_AREA_FRACTION
+    // check below uses `&&` (drop only when BOTH dims are small) so
+    // a wide-but-thin selection is preserved — but a literal
+    // 60%×0 (or 0×60%) collapses to no region, can't be rendered
+    // sensibly, and would divide by zero in any pixel-space
+    // conversion downstream. Drop independently of the threshold.
+    if (w <= 0 || h <= 0) return;
     // Drop when BOTH dimensions are below the threshold (intentional
     // `&&` — NOT `||`). A wide-but-thin drag (e.g. an underline across
     // an annotated row) or a tall-but-thin drag (e.g. a vertical
@@ -1236,14 +1260,18 @@ function attachAreaSelect(
     if (e.pointerId !== pointerId) return;
     finalize(e, false);
   };
+  // lostpointercapture handles the rare case where the platform yanks
+  // capture (OS gesture, another setPointerCapture call). Don't go
+  // through onPointerCancel — that variant reads e.pointerId, which
+  // for a lost-capture event may not match our tracked pointerId
+  // (e.g. capture was lost between gestures). Just always cancel.
+  const onLostCapture = () => finalize(null, false);
 
   el.addEventListener("pointerdown", onPointerDown);
   el.addEventListener("pointermove", onPointerMove);
   el.addEventListener("pointerup", onPointerUp);
   el.addEventListener("pointercancel", onPointerCancel);
-  // lostpointercapture handles the rare case where the platform yanks
-  // capture (e.g. another element calls setPointerCapture, OS gesture).
-  el.addEventListener("lostpointercapture", onPointerCancel);
+  el.addEventListener("lostpointercapture", onLostCapture);
   el.addEventListener("dragstart", onDragStart);
 
   const cleanup = () => {
@@ -1251,7 +1279,7 @@ function attachAreaSelect(
     el.removeEventListener("pointermove", onPointerMove);
     el.removeEventListener("pointerup", onPointerUp);
     el.removeEventListener("pointercancel", onPointerCancel);
-    el.removeEventListener("lostpointercapture", onPointerCancel);
+    el.removeEventListener("lostpointercapture", onLostCapture);
     el.removeEventListener("pointerleave", onPointerLeaveCancel);
     el.removeEventListener("dragstart", onDragStart);
     finalize(null, false);

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -901,3 +901,235 @@ export function handleShadowRootHydration(rootElement: Element): void {
     tpl.remove();
   }
 }
+
+// areaSelectArmed tracks the cleanup callback for every element that
+// currently has a `lvt-fx:area-select` handler attached. WeakMap keys
+// are garbage-collected with their elements, so detached elements
+// don't leak; the cleanup callback removes listeners + the on-screen
+// overlay if a drag is mid-flight.
+const areaSelectArmed = new WeakMap<Element, AreaSelectEntry>();
+
+interface AreaSelectEntry {
+  action: string;
+  cleanup: () => void;
+}
+
+// MIN_AREA_FRACTION filters accidental click-style gestures where the
+// user meant to click, not drag. 2% of the element's rendered size is
+// big enough to be intentional on touch + mouse but small enough that
+// anyone seriously trying to annotate a tiny region can still do it.
+const MIN_AREA_FRACTION = 0.02;
+
+/**
+ * Apply area-select directives. `lvt-fx:area-select="<actionName>"` on
+ * an element (typically an `<img>` inside a positioned parent) lets
+ * the user drag a rectangle locally — a `<div>` overlay tracks the
+ * gesture in real time without a server round-trip — and on
+ * `pointerup` dispatches a single livetemplate action with the final
+ * `{x, y, w, h}` as 0..1 fractions of the element's rendered bounding
+ * rect. The image's intrinsic dimensions don't matter for the
+ * fractions: any uniform scale (zoom, responsive layout) preserves
+ * the fraction. The consumer scales to pixels using the natural size
+ * if it needs them.
+ *
+ * Contract:
+ *  - Host's `parentElement` must establish a positioning context
+ *    (`position: relative` / `absolute` / `fixed`). The overlay is
+ *    `position: absolute` inside that parent so it follows the host
+ *    on scroll / reflow.
+ *  - Consumers usually pair this with `touch-action: none` on the
+ *    host so iOS Safari doesn't interpret the drag as a pinch/scroll.
+ *  - On pointer-cancel (e.g. system gesture, app switch), the overlay
+ *    is removed and no action is dispatched — same effect as cancelling
+ *    a click on `mouseleave`.
+ *  - Drags smaller than `MIN_AREA_FRACTION` in BOTH dimensions are
+ *    dropped — a click on the image still bubbles for normal handlers.
+ *
+ * Idempotent across renders: an element re-armed with the same action
+ * keeps its existing listeners. A different action causes a tear-down
+ * and re-arm. Disconnected elements have their listeners cleaned up
+ * implicitly via WeakMap GC + pointerup happening only while the
+ * element is still in the DOM.
+ */
+export function handleAreaSelectDirectives(
+  rootElement: Element,
+  send: (message: { action: string; data: Record<string, unknown> }) => void
+): void {
+  const matches = rootElement.querySelectorAll<HTMLElement>(
+    "[lvt-fx\\:area-select]"
+  );
+  if (matches.length === 0) return;
+
+  for (const el of matches) {
+    const action = el.getAttribute("lvt-fx:area-select");
+    // Empty attribute → consumer almost certainly typoed; warn and
+    // skip rather than dispatching to a blank action name.
+    if (!action) {
+      console.warn(
+        `lvt-fx:area-select requires an action name, got: ${JSON.stringify(action)}`
+      );
+      continue;
+    }
+    const existing = areaSelectArmed.get(el);
+    if (existing && existing.action === action) continue;
+    if (existing) existing.cleanup();
+    areaSelectArmed.set(el, attachAreaSelect(el, action, send));
+  }
+}
+
+function attachAreaSelect(
+  el: HTMLElement,
+  action: string,
+  send: (message: { action: string; data: Record<string, unknown> }) => void
+): AreaSelectEntry {
+  let overlay: HTMLDivElement | null = null;
+  let startClientX = 0;
+  let startClientY = 0;
+  let pointerId = -1;
+
+  const removeOverlay = () => {
+    if (overlay && overlay.parentElement) {
+      overlay.parentElement.removeChild(overlay);
+    }
+    overlay = null;
+  };
+
+  const finalize = (e: PointerEvent | null, dispatch: boolean) => {
+    if (pointerId === -1) return;
+    try {
+      el.releasePointerCapture(pointerId);
+    } catch {
+      // Capture may already be gone (e.g. pointercancel) — ignore.
+    }
+    pointerId = -1;
+    if (!dispatch || !e) {
+      removeOverlay();
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      removeOverlay();
+      return;
+    }
+    // Clamp the two corners to the rect BEFORE computing fractions so
+    // a drag that escapes the element still yields a rectangle inside
+    // it (x ∈ [0,1], w ∈ [0,1-x]). Otherwise a far-off-rect endpoint
+    // would push w past 1 even with x already > 0.
+    const rectRight = rect.left + rect.width;
+    const rectBottom = rect.top + rect.height;
+    const x0 = clampRange(Math.min(startClientX, e.clientX), rect.left, rectRight);
+    const y0 = clampRange(Math.min(startClientY, e.clientY), rect.top, rectBottom);
+    const x1 = clampRange(Math.max(startClientX, e.clientX), rect.left, rectRight);
+    const y1 = clampRange(Math.max(startClientY, e.clientY), rect.top, rectBottom);
+    const x = (x0 - rect.left) / rect.width;
+    const y = (y0 - rect.top) / rect.height;
+    const w = (x1 - x0) / rect.width;
+    const h = (y1 - y0) / rect.height;
+    removeOverlay();
+    if (w < MIN_AREA_FRACTION && h < MIN_AREA_FRACTION) {
+      // Treat as a click, not a drag. Don't dispatch; let normal click
+      // handlers (if any) run via the platform.
+      return;
+    }
+    send({ action, data: { x, y, w, h } });
+  };
+
+  const onPointerDown = (e: PointerEvent) => {
+    // Only primary button (left mouse / single touch / pen tip). Modifier
+    // keys passed through so the server-side handler can decide what to
+    // do with them via subsequent renders.
+    if (!e.isPrimary || e.button !== 0) return;
+    const parent = el.parentElement;
+    if (!parent) return; // overlay needs a positioned container
+    startClientX = e.clientX;
+    startClientY = e.clientY;
+    pointerId = e.pointerId;
+    try {
+      el.setPointerCapture(pointerId);
+    } catch {
+      // Capture failure is non-fatal — without it, leaving the element
+      // mid-drag will lose pointermove. Better to attempt and continue.
+    }
+    overlay = document.createElement("div");
+    overlay.className = "lvt-area-select-overlay";
+    overlay.setAttribute("aria-hidden", "true");
+    // Inline styles so the directive doesn't depend on a CSS class
+    // shipped by the consumer. Consumers can override via the class
+    // selector if they want a different look.
+    overlay.style.cssText =
+      "position:absolute;pointer-events:none;border:2px solid var(--lvt-area-select-color,#4cc2ff);" +
+      "background:var(--lvt-area-select-fill,rgba(76,194,255,0.18));box-sizing:border-box;z-index:9999;";
+    parent.appendChild(overlay);
+    updateOverlay(e);
+    e.preventDefault();
+  };
+
+  const updateOverlay = (e: PointerEvent) => {
+    if (!overlay) return;
+    const parent = el.parentElement;
+    if (!parent) return;
+    const elRect = el.getBoundingClientRect();
+    const parentRect = parent.getBoundingClientRect();
+    // Position the overlay relative to the parent's content box so it
+    // tracks with `position: absolute` correctly.
+    const left = Math.min(startClientX, e.clientX) - parentRect.left;
+    const top = Math.min(startClientY, e.clientY) - parentRect.top;
+    const width = Math.abs(e.clientX - startClientX);
+    const height = Math.abs(e.clientY - startClientY);
+    // Clamp to the host's rendered rect so a drag that runs off the
+    // edge doesn't paint outside the image.
+    const minLeft = elRect.left - parentRect.left;
+    const minTop = elRect.top - parentRect.top;
+    const maxRight = minLeft + elRect.width;
+    const maxBottom = minTop + elRect.height;
+    const clampedLeft = Math.max(minLeft, Math.min(left, maxRight));
+    const clampedTop = Math.max(minTop, Math.min(top, maxBottom));
+    const clampedRight = Math.max(minLeft, Math.min(left + width, maxRight));
+    const clampedBottom = Math.max(minTop, Math.min(top + height, maxBottom));
+    overlay.style.left = `${clampedLeft}px`;
+    overlay.style.top = `${clampedTop}px`;
+    overlay.style.width = `${Math.max(0, clampedRight - clampedLeft)}px`;
+    overlay.style.height = `${Math.max(0, clampedBottom - clampedTop)}px`;
+  };
+
+  const onPointerMove = (e: PointerEvent) => {
+    if (e.pointerId !== pointerId) return;
+    updateOverlay(e);
+  };
+
+  const onPointerUp = (e: PointerEvent) => {
+    if (e.pointerId !== pointerId) return;
+    finalize(e, true);
+  };
+
+  const onPointerCancel = (e: PointerEvent) => {
+    if (e.pointerId !== pointerId) return;
+    finalize(e, false);
+  };
+
+  el.addEventListener("pointerdown", onPointerDown);
+  el.addEventListener("pointermove", onPointerMove);
+  el.addEventListener("pointerup", onPointerUp);
+  el.addEventListener("pointercancel", onPointerCancel);
+  // lostpointercapture handles the rare case where the platform yanks
+  // capture (e.g. another element calls setPointerCapture, OS gesture).
+  el.addEventListener("lostpointercapture", onPointerCancel);
+
+  const cleanup = () => {
+    el.removeEventListener("pointerdown", onPointerDown);
+    el.removeEventListener("pointermove", onPointerMove);
+    el.removeEventListener("pointerup", onPointerUp);
+    el.removeEventListener("pointercancel", onPointerCancel);
+    el.removeEventListener("lostpointercapture", onPointerCancel);
+    finalize(null, false);
+    areaSelectArmed.delete(el);
+  };
+
+  return { action, cleanup };
+}
+
+function clampRange(n: number, lo: number, hi: number): number {
+  if (!Number.isFinite(n) || n < lo) return lo;
+  if (n > hi) return hi;
+  return n;
+}

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -999,6 +999,17 @@ export function handleAreaSelectDirectives(
   }
 }
 
+// attachAreaSelect captures `send` in a closure for the lifetime of
+// the armed listeners. When the same element is re-encountered with
+// the same action (the idempotent path), the existing entry is reused
+// and the new `send` argument is NOT applied — drags will dispatch
+// through the FIRST call's `send`. Today's call site
+// (handleAreaSelectDirectives in livetemplate-client.ts) always passes
+// a fresh arrow over the same `this.send` method, so the captured
+// behaviour is equivalent; if a future caller passes a fundamentally
+// different send (e.g. a different LiveTemplateClient instance arming
+// the same element), the attribute-change re-arm path is the only way
+// to update the captured send.
 function attachAreaSelect(
   el: HTMLElement,
   action: string,
@@ -1086,9 +1097,9 @@ function attachAreaSelect(
     if (!e.isPrimary || e.button !== 0) return;
     // Re-entrancy guard: if a prior drag never finished (e.g. capture
     // failed silently, then pointer left the element with no pointerup
-    // ever delivered), the WeakMap entry would still hold pointerId.
-    // Cancel the prior drag — removing its overlay and listeners —
-    // before starting a fresh one.
+    // ever delivered), the closed-over pointerId variable would still
+    // hold the stale id. Cancel the prior drag — removing its overlay
+    // and listeners — before starting a fresh one.
     if (pointerId !== -1) finalize(null, false);
     const parent = el.parentElement;
     if (!parent) return; // overlay needs a positioned container

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1034,21 +1034,41 @@ function attachAreaSelect(
     send({ action, data: { x, y, w, h } });
   };
 
+  const onPointerLeaveCancel = () => {
+    // Fallback for the rare case where setPointerCapture failed: without
+    // capture, pointermove + pointerup stop arriving once the pointer
+    // leaves the host, freezing the overlay. Treating pointerleave as
+    // a cancel keeps the overlay from getting stuck on screen.
+    finalize(null, false);
+  };
+
   const onPointerDown = (e: PointerEvent) => {
     // Only primary button (left mouse / single touch / pen tip). Modifier
     // keys passed through so the server-side handler can decide what to
     // do with them via subsequent renders.
     if (!e.isPrimary || e.button !== 0) return;
+    // Re-entrancy guard: if a prior drag never finished (e.g. capture
+    // failed silently, then pointer left the element with no pointerup
+    // ever delivered), the WeakMap entry would still hold pointerId.
+    // Cancel the prior drag — removing its overlay and listeners —
+    // before starting a fresh one.
+    if (pointerId !== -1) finalize(null, false);
     const parent = el.parentElement;
     if (!parent) return; // overlay needs a positioned container
     startClientX = e.clientX;
     startClientY = e.clientY;
     pointerId = e.pointerId;
+    let captureOk = false;
     try {
       el.setPointerCapture(pointerId);
+      captureOk = true;
     } catch {
       // Capture failure is non-fatal — without it, leaving the element
-      // mid-drag will lose pointermove. Better to attempt and continue.
+      // mid-drag will lose pointermove. Fall back to pointerleave as
+      // the cancel signal so the overlay can't get stuck.
+    }
+    if (!captureOk) {
+      el.addEventListener("pointerleave", onPointerLeaveCancel, { once: true });
     }
     overlay = document.createElement("div");
     overlay.className = "lvt-area-select-overlay";
@@ -1058,7 +1078,8 @@ function attachAreaSelect(
     // selector if they want a different look.
     overlay.style.cssText =
       "position:absolute;pointer-events:none;border:2px solid var(--lvt-area-select-color,#4cc2ff);" +
-      "background:var(--lvt-area-select-fill,rgba(76,194,255,0.18));box-sizing:border-box;z-index:9999;";
+      "background:var(--lvt-area-select-fill,rgba(76,194,255,0.18));box-sizing:border-box;" +
+      "z-index:var(--lvt-area-select-z-index,9999);";
     parent.appendChild(overlay);
     updateOverlay(e);
     e.preventDefault();
@@ -1094,11 +1115,22 @@ function attachAreaSelect(
 
   const onPointerMove = (e: PointerEvent) => {
     if (e.pointerId !== pointerId) return;
+    // Host removed from the DOM mid-drag (e.g. server diff replaced it).
+    // Without this, the overlay would be left orphaned under the parent
+    // because the host's cleanup never runs.
+    if (!el.isConnected) {
+      finalize(null, false);
+      return;
+    }
     updateOverlay(e);
   };
 
   const onPointerUp = (e: PointerEvent) => {
     if (e.pointerId !== pointerId) return;
+    if (!el.isConnected) {
+      finalize(null, false);
+      return;
+    }
     finalize(e, true);
   };
 
@@ -1121,6 +1153,7 @@ function attachAreaSelect(
     el.removeEventListener("pointerup", onPointerUp);
     el.removeEventListener("pointercancel", onPointerCancel);
     el.removeEventListener("lostpointercapture", onPointerCancel);
+    el.removeEventListener("pointerleave", onPointerLeaveCancel);
     finalize(null, false);
     areaSelectArmed.delete(el);
   };

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -949,9 +949,16 @@ const MIN_AREA_FRACTION = 0.02;
  *
  * Idempotent across renders: an element re-armed with the same action
  * keeps its existing listeners. A different action causes a tear-down
- * and re-arm. Disconnected elements have their listeners cleaned up
- * implicitly via WeakMap GC + pointerup happening only while the
- * element is still in the DOM.
+ * and re-arm. Disconnected elements (and elements whose attribute was
+ * cleared by a server diff) get their listeners cleaned up by the
+ * sweep at the top of every call — we use a regular Map (not WeakMap)
+ * specifically so the sweep can iterate.
+ *
+ * Module-level singleton: `areaSelectArmed` is shared across all
+ * LiveTemplateClient instances in the same window. If two clients
+ * ever arm the same element with different actions, the second wins
+ * and the first client's send() is orphaned. Single-client use is
+ * unaffected.
  */
 export function handleAreaSelectDirectives(
   rootElement: Element,
@@ -1064,6 +1071,14 @@ function attachAreaSelect(
     finalize(null, false);
   };
 
+  // Chromium fires `dragstart` on an <img> after the first mousemove
+  // following mousedown, yanking the gesture away from pointer events
+  // before pointerup arrives — the overlay flashes and capture is
+  // lost. preventDefault on dragstart suppresses the native image
+  // drag without breaking pointer events. Cheap to attach on every
+  // element type (non-img hosts simply never fire dragstart).
+  const onDragStart = (e: DragEvent) => e.preventDefault();
+
   const onPointerDown = (e: PointerEvent) => {
     // Only primary button (left mouse / single touch / pen tip). Modifier
     // keys passed through so the server-side handler can decide what to
@@ -1174,6 +1189,7 @@ function attachAreaSelect(
   // lostpointercapture handles the rare case where the platform yanks
   // capture (e.g. another element calls setPointerCapture, OS gesture).
   el.addEventListener("lostpointercapture", onPointerCancel);
+  el.addEventListener("dragstart", onDragStart);
 
   const cleanup = () => {
     el.removeEventListener("pointerdown", onPointerDown);
@@ -1182,6 +1198,7 @@ function attachAreaSelect(
     el.removeEventListener("pointercancel", onPointerCancel);
     el.removeEventListener("lostpointercapture", onPointerCancel);
     el.removeEventListener("pointerleave", onPointerLeaveCancel);
+    el.removeEventListener("dragstart", onDragStart);
     finalize(null, false);
     areaSelectArmed.delete(el);
   };

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -914,7 +914,16 @@ const areaSelectArmed = new Map<Element, AreaSelectEntry>();
 interface AreaSelectEntry {
   action: string;
   cleanup: () => void;
+  // updateSend lets the idempotent re-arm path swap the captured
+  // send callback without tearing down + rebuilding listeners. The
+  // listeners close over a mutable `send` variable inside
+  // attachAreaSelect; updateSend reassigns it.
+  updateSend: (send: AreaSelectSendFn) => void;
 }
+
+type AreaSelectSendFn = (
+  message: { action: string; data: Record<string, unknown> }
+) => void;
 
 // MIN_AREA_FRACTION filters accidental click-style gestures where the
 // user meant to click, not drag. 2% of the element's rendered size is
@@ -939,13 +948,27 @@ const MIN_AREA_FRACTION = 0.02;
  *    (`position: relative` / `absolute` / `fixed`). The overlay is
  *    `position: absolute` inside that parent so it follows the host
  *    on scroll / reflow.
+ *  - The parent should NOT use `overflow: hidden` — the in-progress
+ *    overlay can briefly extend outside the host's rect while the
+ *    drag is in flight (before the clamp settles on a frame), and
+ *    overflow:hidden would clip it. The saved area persisted by
+ *    the consumer will fit inside the host's rect; only the live
+ *    drag-paint can briefly overshoot.
  *  - Consumers usually pair this with `touch-action: none` on the
  *    host so iOS Safari doesn't interpret the drag as a pinch/scroll.
+ *  - `<img>` and other natively-draggable hosts work automatically:
+ *    the directive calls `preventDefault()` on `dragstart` so the
+ *    browser's native drag (which would otherwise steal the gesture)
+ *    is suppressed.
  *  - On pointer-cancel (e.g. system gesture, app switch), the overlay
  *    is removed and no action is dispatched — same effect as cancelling
  *    a click on `mouseleave`.
  *  - Drags smaller than `MIN_AREA_FRACTION` in BOTH dimensions are
  *    dropped — a click on the image still bubbles for normal handlers.
+ *  - **No keyboard equivalent.** Pointer-only by design (a keyboard-
+ *    selected rectangle requires a different UX — focus + arrow keys
+ *    to position + arrow keys to size). Consumers needing a11y for
+ *    area selection should provide a parallel form-based affordance.
  *
  * Idempotent across renders: an element re-armed with the same action
  * keeps its existing listeners. A different action causes a tear-down
@@ -993,28 +1016,33 @@ export function handleAreaSelectDirectives(
       continue;
     }
     const existing = areaSelectArmed.get(el);
-    if (existing && existing.action === action) continue;
+    if (existing && existing.action === action) {
+      // Idempotent re-arm: keep the listeners + WeakMap entry, but
+      // update the captured send so a subsequent drag dispatches
+      // through the latest callback (e.g. after a WebSocket
+      // reconnect rebuilt the transport).
+      existing.updateSend(send);
+      continue;
+    }
     if (existing) existing.cleanup();
     areaSelectArmed.set(el, attachAreaSelect(el, action, send));
   }
 }
 
-// attachAreaSelect captures `send` in a closure for the lifetime of
-// the armed listeners. When the same element is re-encountered with
-// the same action (the idempotent path), the existing entry is reused
-// and the new `send` argument is NOT applied — drags will dispatch
-// through the FIRST call's `send`. Today's call site
-// (handleAreaSelectDirectives in livetemplate-client.ts) always passes
-// a fresh arrow over the same `this.send` method, so the captured
-// behaviour is equivalent; if a future caller passes a fundamentally
-// different send (e.g. a different LiveTemplateClient instance arming
-// the same element), the attribute-change re-arm path is the only way
-// to update the captured send.
+// attachAreaSelect captures `send` in a mutable local so the
+// idempotent re-arm path (same element, same action) can swap it via
+// the returned `updateSend` callback without tearing down + rebuilding
+// listeners. Listeners reference the closure-captured `send` variable
+// directly, so reassigning it propagates instantly. This guards
+// against the stale-closure trap a caller would hit if their `send`
+// reference changed across renders — e.g. a reconnect rebuilt the
+// transport.
 function attachAreaSelect(
   el: HTMLElement,
   action: string,
-  send: (message: { action: string; data: Record<string, unknown> }) => void
+  initialSend: AreaSelectSendFn
 ): AreaSelectEntry {
+  let send = initialSend;
   let overlay: HTMLDivElement | null = null;
   let startClientX = 0;
   let startClientY = 0;
@@ -1214,7 +1242,13 @@ function attachAreaSelect(
     areaSelectArmed.delete(el);
   };
 
-  return { action, cleanup };
+  return {
+    action,
+    cleanup,
+    updateSend: (s) => {
+      send = s;
+    },
+  };
 }
 
 function clampRange(n: number, lo: number, hi: number): number {

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -964,7 +964,13 @@ const MIN_AREA_FRACTION = 0.02;
  *    is removed and no action is dispatched — same effect as cancelling
  *    a click on `mouseleave`.
  *  - Drags smaller than `MIN_AREA_FRACTION` in BOTH dimensions are
- *    dropped — a click on the image still bubbles for normal handlers.
+ *    dropped — a click on the host still fires normal `click`
+ *    handlers via the compatibility mouse events.
+ *  - For text-bearing hosts, set `user-select: none` (the directive
+ *    deliberately does NOT call `preventDefault()` on `pointerdown`
+ *    so click handlers still receive the gesture; that means the
+ *    browser's default text-selection-on-drag behaviour also fires
+ *    unless the host opts out via CSS).
  *  - **No keyboard equivalent.** Pointer-only by design (a keyboard-
  *    selected rectangle requires a different UX — focus + arrow keys
  *    to position + arrow keys to size). Consumers needing a11y for
@@ -1062,6 +1068,10 @@ function attachAreaSelect(
     } catch {
       // Capture may already be gone (e.g. pointercancel) — ignore.
     }
+    // Remove the per-gesture pointerleave fallback so a NEXT drag
+    // doesn't inherit a stale listener from this one. {once: true}
+    // only auto-removes if it fires; a stuck drag never fired it.
+    el.removeEventListener("pointerleave", onPointerLeaveCancel);
     pointerId = -1;
     if (!dispatch || !e) {
       removeOverlay();
@@ -1158,7 +1168,13 @@ function attachAreaSelect(
       "z-index:var(--lvt-area-select-z-index,9999);";
     parent.appendChild(overlay);
     updateOverlay(e);
-    e.preventDefault();
+    // NOT calling e.preventDefault() here: doing so on pointerdown
+    // suppresses the compatibility mouse events (mousedown → mouseup
+    // → click), so a small-rect drag (which finalize() treats as a
+    // click) would never reach the host's click handlers. The
+    // directive's contract promises clicks still bubble. Text-
+    // selection during drag is the consumer's responsibility — set
+    // `user-select: none` on the host (the contract docs this).
   };
 
   const updateOverlay = (e: PointerEvent) => {

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -903,11 +903,13 @@ export function handleShadowRootHydration(rootElement: Element): void {
 }
 
 // areaSelectArmed tracks the cleanup callback for every element that
-// currently has a `lvt-fx:area-select` handler attached. WeakMap keys
-// are garbage-collected with their elements, so detached elements
-// don't leak; the cleanup callback removes listeners + the on-screen
-// overlay if a drag is mid-flight.
-const areaSelectArmed = new WeakMap<Element, AreaSelectEntry>();
+// currently has a `lvt-fx:area-select` handler attached. Map (not
+// WeakMap) because the sweep needs to iterate to detect elements whose
+// attribute was removed by a server diff — without iteration those
+// elements would keep their listeners and silently dispatch the old
+// action on subsequent drags. Detached elements are cleaned up via
+// the same sweep (isConnected check).
+const areaSelectArmed = new Map<Element, AreaSelectEntry>();
 
 interface AreaSelectEntry {
   action: string;
@@ -955,6 +957,19 @@ export function handleAreaSelectDirectives(
   rootElement: Element,
   send: (message: { action: string; data: Record<string, unknown> }) => void
 ): void {
+  // Sweep stale entries before processing the current match set:
+  // disconnected elements AND elements where the attribute was
+  // removed by a server diff. Without this, a previously-armed
+  // element whose lvt-fx:area-select was cleared would keep its
+  // listeners and silently dispatch the old action on subsequent
+  // drags. Iterate via Array.from so cleanup()'s delete() doesn't
+  // disturb the iterator.
+  for (const [element, entry] of Array.from(areaSelectArmed)) {
+    if (!element.isConnected || !element.hasAttribute("lvt-fx:area-select")) {
+      entry.cleanup();
+    }
+  }
+
   const matches = rootElement.querySelectorAll<HTMLElement>(
     "[lvt-fx\\:area-select]"
   );
@@ -1026,6 +1041,13 @@ function attachAreaSelect(
     const w = (x1 - x0) / rect.width;
     const h = (y1 - y0) / rect.height;
     removeOverlay();
+    // Drop when BOTH dimensions are below the threshold (intentional
+    // `&&` — NOT `||`). A wide-but-thin drag (e.g. an underline across
+    // an annotated row) or a tall-but-thin drag (e.g. a vertical
+    // highlight) is a real selection in this directive's contract,
+    // not an accidental click. `||` would drop those legitimate
+    // gestures. The click-vs-drag boundary lives in "the rect has
+    // basically no area" — that's both dims below the threshold.
     if (w < MIN_AREA_FRACTION && h < MIN_AREA_FRACTION) {
       // Treat as a click, not a drag. Don't dispatch; let normal click
       // handlers (if any) run via the platform.
@@ -1091,16 +1113,22 @@ function attachAreaSelect(
     if (!parent) return;
     const elRect = el.getBoundingClientRect();
     const parentRect = parent.getBoundingClientRect();
-    // Position the overlay relative to the parent's content box so it
-    // tracks with `position: absolute` correctly.
-    const left = Math.min(startClientX, e.clientX) - parentRect.left;
-    const top = Math.min(startClientY, e.clientY) - parentRect.top;
+    // position:absolute offsets from the parent's PADDING box, not its
+    // border box. getBoundingClientRect returns the border box, so a
+    // parent with a non-zero CSS border would shift the overlay by the
+    // border width. Subtract clientLeft / clientTop to convert from
+    // border-box to padding-box offset.
+    const borderL = parent.clientLeft;
+    const borderT = parent.clientTop;
+    const left = Math.min(startClientX, e.clientX) - parentRect.left - borderL;
+    const top = Math.min(startClientY, e.clientY) - parentRect.top - borderT;
     const width = Math.abs(e.clientX - startClientX);
     const height = Math.abs(e.clientY - startClientY);
     // Clamp to the host's rendered rect so a drag that runs off the
-    // edge doesn't paint outside the image.
-    const minLeft = elRect.left - parentRect.left;
-    const minTop = elRect.top - parentRect.top;
+    // edge doesn't paint outside the image. Same border-box-to-
+    // padding-box conversion as above.
+    const minLeft = elRect.left - parentRect.left - borderL;
+    const minTop = elRect.top - parentRect.top - borderT;
     const maxRight = minLeft + elRect.width;
     const maxBottom = minTop + elRect.height;
     const clampedLeft = Math.max(minLeft, Math.min(left, maxRight));

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -989,25 +989,6 @@ const MIN_AREA_FRACTION = 0.02;
  * and the first client's send() is orphaned. Single-client use is
  * unaffected.
  */
-/**
- * Cancel area-select listeners for every armed element under root.
- * Mirrors teardownAutoClickTimers: meant for the client's disconnect /
- * destroy lifecycle so the module-level singleton doesn't outlive a
- * client that was torn down without a subsequent
- * handleAreaSelectDirectives call (e.g. network error closed the
- * socket while an element was armed). Without this, a SPA that mounts
- * + tears down livetemplate trees would leak listeners across mounts.
- */
-export function teardownAreaSelectForRoot(rootElement: Element): void {
-  // `contains` returns true for the node itself, so this also handles
-  // the (today-impossible) case of rootElement being armed directly.
-  for (const [element, entry] of Array.from(areaSelectArmed)) {
-    if (rootElement.contains(element)) {
-      entry.cleanup();
-    }
-  }
-}
-
 export function handleAreaSelectDirectives(
   rootElement: Element,
   send: (message: { action: string; data: Record<string, unknown> }) => void
@@ -1054,6 +1035,25 @@ export function handleAreaSelectDirectives(
   }
 }
 
+/**
+ * Cancel area-select listeners for every armed element under root.
+ * Mirrors teardownAutoClickTimers: meant for the client's disconnect /
+ * destroy lifecycle so the module-level singleton doesn't outlive a
+ * client that was torn down without a subsequent
+ * handleAreaSelectDirectives call (e.g. network error closed the
+ * socket while an element was armed). Without this, a SPA that mounts
+ * + tears down livetemplate trees would leak listeners across mounts.
+ */
+export function teardownAreaSelectForRoot(rootElement: Element): void {
+  // `contains` returns true for the node itself, so this also handles
+  // the (today-impossible) case of rootElement being armed directly.
+  for (const [element, entry] of Array.from(areaSelectArmed)) {
+    if (rootElement.contains(element)) {
+      entry.cleanup();
+    }
+  }
+}
+
 // attachAreaSelect captures `send` in a mutable local so the
 // idempotent re-arm path (same element, same action) can swap it via
 // the returned `updateSend` callback without tearing down + rebuilding
@@ -1072,6 +1072,13 @@ function attachAreaSelect(
   let startClientX = 0;
   let startClientY = 0;
   let pointerId = -1;
+  // Capture the parent at pointerdown time so a server diff that moves
+  // the host to a NEW parent mid-drag doesn't split the drag across
+  // two positioning contexts. updateOverlay positions against this
+  // cached parent for the lifetime of the gesture; the overlay itself
+  // stays a child of the parent we appended it to (overlay removal
+  // uses overlay.parentElement, which is independent).
+  let dragParent: HTMLElement | null = null;
 
   const removeOverlay = () => {
     if (overlay && overlay.parentElement) {
@@ -1092,6 +1099,7 @@ function attachAreaSelect(
     // only auto-removes if it fires; a stuck drag never fired it.
     el.removeEventListener("pointerleave", onPointerLeaveCancel);
     pointerId = -1;
+    dragParent = null;
     if (!dispatch || !e) {
       removeOverlay();
       return;
@@ -1191,6 +1199,7 @@ function attachAreaSelect(
     startClientX = e.clientX;
     startClientY = e.clientY;
     pointerId = e.pointerId;
+    dragParent = parent;
     let captureOk = false;
     try {
       el.setPointerCapture(pointerId);
@@ -1226,7 +1235,12 @@ function attachAreaSelect(
 
   const updateOverlay = (e: PointerEvent) => {
     if (!overlay) return;
-    const parent = el.parentElement;
+    // Use the parent captured at pointerdown — if a server diff
+    // moved `el` to a new parent mid-drag, re-fetching el.parentElement
+    // here would compute against the new container while the overlay
+    // lives in the old, paint at the wrong place for the rest of the
+    // gesture.
+    const parent = dragParent;
     if (!parent) return;
     const elRect = el.getBoundingClientRect();
     const parentRect = parent.getBoundingClientRect();
@@ -1284,11 +1298,13 @@ function attachAreaSelect(
     finalize(e, false);
   };
   // lostpointercapture handles the rare case where the platform yanks
-  // capture (OS gesture, another setPointerCapture call). Don't go
-  // through onPointerCancel — that variant reads e.pointerId, which
-  // for a lost-capture event may not match our tracked pointerId
-  // (e.g. capture was lost between gestures). Just always cancel.
-  const onLostCapture = () => finalize(null, false);
+  // capture (OS gesture, another setPointerCapture call). Guard on
+  // pointerId — another code path could call setPointerCapture for a
+  // DIFFERENT pointer on the same element, and we mustn't cancel
+  // our in-progress drag because of an unrelated release.
+  const onLostCapture = (e: PointerEvent) => {
+    if (e.pointerId === pointerId) finalize(null, false);
+  };
 
   el.addEventListener("pointerdown", onPointerDown);
   el.addEventListener("pointermove", onPointerMove);

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -999,8 +999,10 @@ const MIN_AREA_FRACTION = 0.02;
  * + tears down livetemplate trees would leak listeners across mounts.
  */
 export function teardownAreaSelectForRoot(rootElement: Element): void {
+  // `contains` returns true for the node itself, so this also handles
+  // the (today-impossible) case of rootElement being armed directly.
   for (const [element, entry] of Array.from(areaSelectArmed)) {
-    if (rootElement === element || rootElement.contains(element)) {
+    if (rootElement.contains(element)) {
       entry.cleanup();
     }
   }
@@ -1165,6 +1167,27 @@ function attachAreaSelect(
     if (pointerId !== -1) finalize(null, false);
     const parent = el.parentElement;
     if (!parent) return; // overlay needs a positioned container
+    // Dev-time check: if the parent doesn't establish a positioning
+    // context, the overlay's `position: absolute` will resolve against
+    // the nearest positioned ANCESTOR — a distant element with no
+    // visible relationship to the host. Result: overlay paints in
+    // the wrong place with no error, just a confusing visual.
+    // Check against the positive list of positioned values; the
+    // default "static" and an unset/empty value both fail it (jsdom
+    // returns "" for unset position).
+    const parentPos = window.getComputedStyle(parent).position;
+    if (
+      parentPos !== "relative" &&
+      parentPos !== "absolute" &&
+      parentPos !== "fixed" &&
+      parentPos !== "sticky"
+    ) {
+      console.warn(
+        "lvt-fx:area-select: parentElement has no positioning context; the drag overlay will be mis-positioned. " +
+          "Add position:relative (or absolute/fixed/sticky) to the parent.",
+        parent
+      );
+    }
     startClientX = e.clientX;
     startClientY = e.clientY;
     pointerId = e.pointerId;

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -9,6 +9,7 @@ import morphdom from "morphdom";
 import { FocusManager } from "./dom/focus-manager";
 import {
   handleAnimateDirectives,
+  handleAreaSelectDirectives,
   handleAutoClickDirectives,
   handleHighlightDirectives,
   handleScrollDirectives,
@@ -1832,6 +1833,12 @@ export class LiveTemplateClient {
     handleAnimateDirectives(element);
     handleToastDirectives(element);
     handleAutoClickDirectives(element);
+    // Area-select needs the send() callback to dispatch the final-
+    // coords action on pointerup, unlike the other directives in this
+    // block (which are visual-only or click-through). Reuse the same
+    // send the event delegator uses so the WS/HTTP routing is
+    // identical to a normal action.
+    handleAreaSelectDirectives(element, (message) => this.send(message));
     // Hydrate any server-emitted Declarative Shadow DOM templates that
     // morphdom inserted via DOM APIs (which don't auto-activate them).
     // Cheap when no templates are present (one querySelectorAll).

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -15,6 +15,7 @@ import {
   handleScrollDirectives,
   handleShadowRootHydration,
   handleToastDirectives,
+  teardownAreaSelectForRoot,
   teardownAutoClickTimers,
   setupToastClickOutside,
   setupFxDOMEventTriggers,
@@ -626,6 +627,7 @@ export class LiveTemplateClient {
       teardownFxLifecycleListeners(this.wrapperElement);
       teardownScrollAway(this.wrapperElement);
       teardownSpy(this.wrapperElement);
+      teardownAreaSelectForRoot(this.wrapperElement);
     }
     this.resetSessionState();
   }

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1426,6 +1426,58 @@ describe("handleAreaSelectDirectives", () => {
     expect(parent.querySelector(".lvt-area-select-overlay")).toBeNull();
   });
 
+  it("suppresses native <img> drag via dragstart preventDefault", () => {
+    const [target] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    handleAreaSelectDirectives(document.body, jest.fn());
+
+    // Without the dragstart listener, Chromium would call default-
+    // action (start a native image drag) and steal the gesture from
+    // pointer events. The directive must call preventDefault on
+    // dragstart so pointermove + pointerup keep arriving.
+    const drag = new Event("dragstart", { bubbles: true, cancelable: true });
+    target.dispatchEvent(drag);
+    expect(drag.defaultPrevented).toBe(true);
+  });
+
+  it("positions overlay correctly when target is offset inside its parent", () => {
+    // Parent at (0,0), target at (50, 25) — exercises the
+    // border-box-to-padding-box offset math with a real gap.
+    document.body.innerHTML = `
+      <div id="parent" style="position:relative;">
+        <img id="target" lvt-fx:area-select="selectImageArea">
+      </div>
+    `;
+    const target = document.getElementById("target") as HTMLImageElement;
+    const parent = document.getElementById("parent") as HTMLDivElement;
+    target.getBoundingClientRect = jest.fn(() => ({
+      x: 50, y: 25, left: 50, top: 25, right: 150, bottom: 125,
+      width: 100, height: 100, toJSON: () => ({}),
+    } as DOMRect));
+    parent.getBoundingClientRect = jest.fn(() => ({
+      x: 0, y: 0, left: 0, top: 0, right: 200, bottom: 200,
+      width: 200, height: 200, toJSON: () => ({}),
+    } as DOMRect));
+    (target as any).setPointerCapture = jest.fn();
+    (target as any).releasePointerCapture = jest.fn();
+    handleAreaSelectDirectives(document.body, jest.fn());
+
+    // Drag from (80, 50) → (120, 90) — inside the target's 100×100 rect.
+    // Relative to the parent (and after subtracting clientLeft/clientTop=0
+    // for a borderless parent), the overlay should sit at left=80, top=50.
+    dispatchPointer(target, "pointerdown", 80, 50);
+    dispatchPointer(target, "pointermove", 120, 90);
+    const overlay = parent.querySelector(".lvt-area-select-overlay") as HTMLDivElement;
+    expect(overlay).not.toBeNull();
+    expect(overlay.style.left).toBe("80px");
+    expect(overlay.style.top).toBe("50px");
+    expect(overlay.style.width).toBe("40px");
+    expect(overlay.style.height).toBe("40px");
+  });
+
   it("cleans up armed elements whose attribute was removed by a server diff", () => {
     const [target] = mountTarget(
       "img",

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1546,6 +1546,41 @@ describe("handleAreaSelectDirectives", () => {
     expect(send).toHaveBeenCalledTimes(1);
   });
 
+  it("releasePointerCapture firing lostpointercapture synchronously does not drop the dispatch", () => {
+    // Chromium fires lostpointercapture SYNCHRONOUSLY during
+    // releasePointerCapture. Without the early state-reset in
+    // finalize, the nested lostpointercapture handler would see
+    // pointerId still matching, run a nested finalize that clears
+    // startRect, then the outer finalize would resume with rect=null
+    // and silently drop the dispatched action.
+    const [, parent] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const target = parent.querySelector("img")! as HTMLElement;
+    // Make releasePointerCapture fire lostpointercapture synchronously
+    // — the real Chromium behaviour that wasn't covered by jest.fn().
+    (target as any).releasePointerCapture = jest.fn((pid: number) => {
+      target.dispatchEvent(
+        Object.assign(new MouseEvent("lostpointercapture", { bubbles: false }), {
+          pointerId: pid,
+        })
+      );
+    });
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    dispatchPointer(target, "pointerdown", 20, 20);
+    dispatchPointer(target, "pointermove", 80, 80);
+    dispatchPointer(target, "pointerup", 80, 80);
+
+    // The action must still dispatch — the early state-reset prevents
+    // the nested lostpointercapture from re-entering finalize and
+    // clearing the rect mid-call.
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
   it("uses pointerdown-time rect for fractions even if host moves between mousemoves", () => {
     // If a server diff repositions the host mid-drag, the rect
     // captured AT POINTERUP would clamp startClientX (which was

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -2,6 +2,7 @@ import {
   handleScrollDirectives,
   handleHighlightDirectives,
   handleAnimateDirectives,
+  handleAreaSelectDirectives,
   handleAutoClickDirectives,
   handleShadowRootHydration,
   setupFxDOMEventTriggers,
@@ -1159,5 +1160,247 @@ describe("handleShadowRootHydration", () => {
       clonable: false,
       serializable: false,
     });
+  });
+});
+
+describe("handleAreaSelectDirectives", () => {
+  // jsdom-friendly helper: configure the target element so it has a
+  // non-trivial bounding rect (jsdom returns zeros by default) and a
+  // positioned parent so the overlay has somewhere to land. Returns
+  // [target, parent] for the assertions.
+  function mountTarget(
+    targetTag: "img" | "div",
+    attrs: Record<string, string>,
+    rect: { left: number; top: number; width: number; height: number }
+  ): [HTMLElement, HTMLElement] {
+    document.body.innerHTML = `
+      <div id="parent" style="position:relative;">
+        <${targetTag} id="target"></${targetTag}>
+      </div>
+    `;
+    const target = document.getElementById("target") as HTMLElement;
+    const parent = document.getElementById("parent") as HTMLElement;
+    for (const [k, v] of Object.entries(attrs)) target.setAttribute(k, v);
+    target.getBoundingClientRect = jest.fn(() => ({
+      x: rect.left,
+      y: rect.top,
+      left: rect.left,
+      top: rect.top,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      width: rect.width,
+      height: rect.height,
+      toJSON: () => ({}),
+    }));
+    parent.getBoundingClientRect = jest.fn(() => ({
+      x: rect.left,
+      y: rect.top,
+      left: rect.left,
+      top: rect.top,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      width: rect.width,
+      height: rect.height,
+      toJSON: () => ({}),
+    }));
+    // jsdom doesn't implement pointer-capture; stub so the directive's
+    // try/catch around it doesn't matter, but the test still asserts
+    // the contract.
+    (target as any).setPointerCapture = jest.fn();
+    (target as any).releasePointerCapture = jest.fn();
+    return [target, parent];
+  }
+
+  function dispatchPointer(
+    el: HTMLElement,
+    type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel",
+    clientX: number,
+    clientY: number,
+    pointerId = 1
+  ): void {
+    const e = new MouseEvent(type, { clientX, clientY, button: 0, bubbles: true });
+    // PointerEvent isn't fully supported in jsdom but the directive
+    // only reads pointerId / isPrimary / button / clientX / clientY.
+    Object.defineProperty(e, "pointerId", { value: pointerId });
+    Object.defineProperty(e, "isPrimary", { value: true });
+    el.dispatchEvent(e);
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("dispatches the action with 0..1 fraction coords on pointerup", () => {
+    const [target] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 100, top: 50, width: 200, height: 200 }
+    );
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    // Drag from (120, 80) → (220, 150) inside the rect.
+    // x = (120 - 100) / 200 = 0.10
+    // y = (80 - 50)   / 200 = 0.15
+    // w = (220 - 120) / 200 = 0.50
+    // h = (150 - 80)  / 200 = 0.35
+    dispatchPointer(target, "pointerdown", 120, 80);
+    dispatchPointer(target, "pointermove", 220, 150);
+    dispatchPointer(target, "pointerup", 220, 150);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const msg = send.mock.calls[0][0];
+    expect(msg.action).toBe("selectImageArea");
+    expect(msg.data.x).toBeCloseTo(0.10, 5);
+    expect(msg.data.y).toBeCloseTo(0.15, 5);
+    expect(msg.data.w).toBeCloseTo(0.50, 5);
+    expect(msg.data.h).toBeCloseTo(0.35, 5);
+  });
+
+  it("filters drags smaller than the min-fraction threshold", () => {
+    const [target] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 1000, height: 1000 }
+    );
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    // Drag is 10×10 px on a 1000×1000 rect → 1% fraction in both dims.
+    // 1% < MIN_AREA_FRACTION (2%) → must drop.
+    dispatchPointer(target, "pointerdown", 100, 100);
+    dispatchPointer(target, "pointermove", 110, 110);
+    dispatchPointer(target, "pointerup", 110, 110);
+
+    expect(send).not.toHaveBeenCalled();
+    // Overlay should have been cleaned up after the failed drag.
+    expect(document.querySelectorAll(".lvt-area-select-overlay").length).toBe(0);
+  });
+
+  it("paints an overlay during the drag and removes it on release", () => {
+    const [, parent] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const target = parent.querySelector("img")! as HTMLElement;
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    dispatchPointer(target, "pointerdown", 10, 10);
+    expect(parent.querySelector(".lvt-area-select-overlay")).not.toBeNull();
+
+    dispatchPointer(target, "pointermove", 60, 70);
+    const overlay = parent.querySelector(".lvt-area-select-overlay") as HTMLDivElement;
+    expect(overlay.style.width).toBe("50px");
+    expect(overlay.style.height).toBe("60px");
+
+    dispatchPointer(target, "pointerup", 60, 70);
+    expect(parent.querySelector(".lvt-area-select-overlay")).toBeNull();
+  });
+
+  it("pointercancel removes the overlay and does NOT dispatch", () => {
+    const [, parent] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const target = parent.querySelector("img")! as HTMLElement;
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    dispatchPointer(target, "pointerdown", 10, 10);
+    dispatchPointer(target, "pointermove", 60, 60);
+    dispatchPointer(target, "pointercancel", 60, 60);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(parent.querySelector(".lvt-area-select-overlay")).toBeNull();
+  });
+
+  it("is idempotent across renders for the same action", () => {
+    const [target] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const send = jest.fn();
+
+    handleAreaSelectDirectives(document.body, send);
+    handleAreaSelectDirectives(document.body, send);
+    handleAreaSelectDirectives(document.body, send);
+
+    dispatchPointer(target, "pointerdown", 10, 10);
+    dispatchPointer(target, "pointermove", 100, 100);
+    dispatchPointer(target, "pointerup", 100, 100);
+
+    // Listeners must NOT have been duplicated by repeated calls.
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-arms with new action when the attribute value changes", () => {
+    const [target] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "first" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+    target.setAttribute("lvt-fx:area-select", "second");
+    handleAreaSelectDirectives(document.body, send);
+
+    dispatchPointer(target, "pointerdown", 10, 10);
+    dispatchPointer(target, "pointermove", 100, 100);
+    dispatchPointer(target, "pointerup", 100, 100);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0].action).toBe("second");
+  });
+
+  it("warns and skips when the attribute value is empty", () => {
+    const warn = console.warn as jest.Mock;
+    mountTarget(
+      "img",
+      { "lvt-fx:area-select": "" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("requires an action name")
+    );
+  });
+
+  it("clamps coords to 0..1 when the drag escapes the element rect", () => {
+    const [target] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 100, top: 100, width: 200, height: 200 }
+    );
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    // Drag starts inside but ends far below-right of the rect.
+    dispatchPointer(target, "pointerdown", 150, 150);
+    dispatchPointer(target, "pointerup", 10000, 10000);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const data = send.mock.calls[0][0].data as Record<string, number>;
+    expect(data.x).toBeGreaterThanOrEqual(0);
+    expect(data.x).toBeLessThanOrEqual(1);
+    expect(data.x + data.w).toBeLessThanOrEqual(1);
+    expect(data.y + data.h).toBeLessThanOrEqual(1);
+  });
+
+  it("fast-path returns when no matching elements", () => {
+    document.body.innerHTML = `<div><p>nothing here</p></div>`;
+    const send = jest.fn();
+    // Should not throw, should not dispatch.
+    expect(() => handleAreaSelectDirectives(document.body, send)).not.toThrow();
+    expect(send).not.toHaveBeenCalled();
   });
 });

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1403,4 +1403,61 @@ describe("handleAreaSelectDirectives", () => {
     expect(() => handleAreaSelectDirectives(document.body, send)).not.toThrow();
     expect(send).not.toHaveBeenCalled();
   });
+
+  it("removes the overlay when the host is detached mid-drag", () => {
+    const [target, parent] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    dispatchPointer(target, "pointerdown", 10, 10);
+    expect(parent.querySelector(".lvt-area-select-overlay")).not.toBeNull();
+
+    // Simulate a server diff replacing the host element.
+    target.remove();
+
+    // A late pointermove (jsdom dispatches to the detached element)
+    // must clean up the overlay rather than leave it orphaned under
+    // the parent.
+    dispatchPointer(target, "pointermove", 60, 70);
+    expect(parent.querySelector(".lvt-area-select-overlay")).toBeNull();
+  });
+
+  it("recovers from a stuck drag on the next pointerdown (re-entrancy guard)", () => {
+    const [target] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    // First drag: pointerdown but no pointerup (simulates a captured
+    // pointer that never released — what happens when capture silently
+    // fails and pointer leaves the element).
+    dispatchPointer(target, "pointerdown", 10, 10);
+    dispatchPointer(target, "pointermove", 60, 60);
+    // No pointerup. The drag is "stuck".
+
+    // Second drag starts. Without the re-entrancy guard, the first
+    // overlay would be orphaned. With the guard, the directive cancels
+    // the stuck drag before starting the new one, and the new drag
+    // completes normally.
+    dispatchPointer(target, "pointerdown", 100, 100);
+    dispatchPointer(target, "pointermove", 150, 150);
+    dispatchPointer(target, "pointerup", 150, 150);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    // The dispatched coords must come from the SECOND drag, not the
+    // first. (Start=100, End=150 → x=0.5, w=0.25 on the 200-wide rect.)
+    const data = send.mock.calls[0][0].data as Record<string, number>;
+    expect(data.x).toBeCloseTo(0.50, 5);
+    expect(data.w).toBeCloseTo(0.25, 5);
+    // Exactly one overlay at most over the whole sequence (the second
+    // drag's) — never two.
+    expect(document.querySelectorAll(".lvt-area-select-overlay").length).toBe(0);
+  });
 });

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1479,6 +1479,55 @@ describe("handleAreaSelectDirectives", () => {
     expect(overlay.style.height).toBe("40px");
   });
 
+  it("warns when the parent's computed position is `static`", () => {
+    // Forgetting position:relative on the parent silently mis-paints
+    // the overlay against the nearest positioned ancestor. A
+    // dev-time warn gives the author a chance to spot the mistake.
+    const warn = console.warn as jest.Mock;
+    document.body.innerHTML = `
+      <div id="static-parent">
+        <img id="target" lvt-fx:area-select="selectImageArea">
+      </div>
+    `;
+    const target = document.getElementById("target") as HTMLImageElement;
+    target.getBoundingClientRect = jest.fn(() => ({
+      x: 0, y: 0, left: 0, top: 0, right: 200, bottom: 200,
+      width: 200, height: 200, toJSON: () => ({}),
+    } as DOMRect));
+    (target as any).setPointerCapture = jest.fn();
+    (target as any).releasePointerCapture = jest.fn();
+    handleAreaSelectDirectives(document.body, jest.fn());
+
+    dispatchPointer(target, "pointerdown", 10, 10);
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("parentElement has no positioning context"),
+      expect.anything()
+    );
+  });
+
+  it("pointercancel cancels the drag without dispatching", () => {
+    // pointercancel fires on system gestures (OS-level swipe, app
+    // switch). Like lostpointercapture / pointerleave, it must remove
+    // the overlay and NOT dispatch — same contract from the user's
+    // perspective.
+    const [, parent] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const target = parent.querySelector("img")! as HTMLElement;
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    dispatchPointer(target, "pointerdown", 10, 10);
+    dispatchPointer(target, "pointermove", 80, 80);
+    dispatchPointer(target, "pointercancel", 80, 80);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(parent.querySelector(".lvt-area-select-overlay")).toBeNull();
+  });
+
   it("rejects zero-area rectangles even if the threshold check would pass", () => {
     // The MIN_AREA_FRACTION check uses && so a wide-but-thin drag is
     // a legit selection — but a literal 60% × 0% drag has no area,

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1478,6 +1478,30 @@ describe("handleAreaSelectDirectives", () => {
     expect(overlay.style.height).toBe("40px");
   });
 
+  it("idempotent re-arm picks up the latest send callback (no stale closure)", () => {
+    const [target] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const firstSend = jest.fn();
+    const secondSend = jest.fn();
+
+    handleAreaSelectDirectives(document.body, firstSend);
+    // A subsequent render passes a different send (e.g. after a WS
+    // reconnect rebuilt the transport). The idempotent path keeps
+    // the listeners but MUST swap the captured send so the next
+    // drag dispatches through the latest callback.
+    handleAreaSelectDirectives(document.body, secondSend);
+
+    dispatchPointer(target, "pointerdown", 10, 10);
+    dispatchPointer(target, "pointermove", 100, 100);
+    dispatchPointer(target, "pointerup", 100, 100);
+
+    expect(firstSend).not.toHaveBeenCalled();
+    expect(secondSend).toHaveBeenCalledTimes(1);
+  });
+
   it("lostpointercapture cancels the drag without dispatching", () => {
     const [, parent] = mountTarget(
       "img",

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1478,6 +1478,79 @@ describe("handleAreaSelectDirectives", () => {
     expect(overlay.style.height).toBe("40px");
   });
 
+  it("does not preventDefault on pointerdown — clicks still bubble", () => {
+    // The contract promises a small-rect drag (treated as a click)
+    // still reaches the host's click handlers. Calling
+    // preventDefault on pointerdown would suppress the compatibility
+    // mouse events that fire click — so the directive must NOT do
+    // that.
+    const [target] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    handleAreaSelectDirectives(document.body, jest.fn());
+
+    const down = new MouseEvent("pointerdown", {
+      clientX: 50, clientY: 50, button: 0, bubbles: true, cancelable: true,
+    });
+    Object.defineProperty(down, "pointerId", { value: 1 });
+    Object.defineProperty(down, "isPrimary", { value: true });
+    target.dispatchEvent(down);
+
+    expect(down.defaultPrevented).toBe(false);
+  });
+
+  it("stale pointerleave listener does not survive into the next gesture", () => {
+    // The bug Claude flagged: when setPointerCapture fails on drag N,
+    // the directive registers a pointerleave fallback. If drag N
+    // gets stuck (pointer never leaves so the fallback never fires
+    // and no pointerup arrives), and the user starts drag N+1, the
+    // re-entrancy guard finalizes drag N but the STALE pointerleave
+    // listener from N would still be attached. If capture SUCCEEDS
+    // on drag N+1 (no new pointerleave registered), the stale one
+    // from N would still fire if the pointer ever leaves — and
+    // incorrectly cancel drag N+1. finalize() must remove the
+    // pointerleave listener so it can't outlive its own gesture.
+    const [target] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    // Capture FAILS only on the first call (drag N), succeeds after.
+    let captureCalls = 0;
+    (target as any).setPointerCapture = jest.fn(() => {
+      captureCalls++;
+      if (captureCalls === 1) {
+        throw new DOMException("no capture", "InvalidStateError");
+      }
+    });
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    // Drag N: pointerdown attaches the pointerleave fallback, but
+    // user starts drag and never releases (simulates a "stuck"
+    // drag). Do NOT pointerup.
+    dispatchPointer(target, "pointerdown", 10, 10);
+    dispatchPointer(target, "pointermove", 80, 80);
+
+    // Drag N+1 starts. Re-entrancy guard finalizes drag N. WITHOUT
+    // the fix, drag N's pointerleave listener stays attached.
+    // Capture succeeds this time so no NEW pointerleave is attached.
+    dispatchPointer(target, "pointerdown", 20, 20);
+    dispatchPointer(target, "pointermove", 100, 100);
+
+    // Fire pointerleave. With the fix, no pointerleave handler is
+    // attached → no-op, drag N+1 continues. WITHOUT the fix, the
+    // stale listener from N would call finalize and cancel.
+    target.dispatchEvent(new MouseEvent("pointerleave", { bubbles: false }));
+    dispatchPointer(target, "pointerup", 100, 100);
+
+    // Drag N+1 should have dispatched normally — the stale listener
+    // must NOT have cancelled it.
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
   it("idempotent re-arm picks up the latest send callback (no stale closure)", () => {
     const [target] = mountTarget(
       "img",

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1546,6 +1546,58 @@ describe("handleAreaSelectDirectives", () => {
     expect(send).toHaveBeenCalledTimes(1);
   });
 
+  it("uses pointerdown-time rect for fractions even if host moves between mousemoves", () => {
+    // If a server diff repositions the host mid-drag, the rect
+    // captured AT POINTERUP would clamp startClientX (which was
+    // captured against the OLD position) into the wrong place.
+    // The dispatched fractions must reflect the original drag,
+    // measured against the rect that existed at pointerdown.
+    document.body.innerHTML = `
+      <div id="parent" style="position:relative;"><img id="target" lvt-fx:area-select="selectImageArea"></div>
+    `;
+    const parent = document.getElementById("parent") as HTMLDivElement;
+    const target = document.getElementById("target") as HTMLImageElement;
+    // Rect call counter: first call (pointerdown) returns the OLD
+    // rect, subsequent calls return a NEW rect 500px away.
+    let rectCalls = 0;
+    target.getBoundingClientRect = jest.fn(() => {
+      rectCalls++;
+      if (rectCalls === 1) {
+        return {
+          x: 0, y: 0, left: 0, top: 0, right: 200, bottom: 200,
+          width: 200, height: 200, toJSON: () => ({}),
+        } as DOMRect;
+      }
+      return {
+        x: 500, y: 500, left: 500, top: 500, right: 700, bottom: 700,
+        width: 200, height: 200, toJSON: () => ({}),
+      } as DOMRect;
+    });
+    parent.getBoundingClientRect = jest.fn(() => ({
+      x: 0, y: 0, left: 0, top: 0, right: 1000, bottom: 1000,
+      width: 1000, height: 1000, toJSON: () => ({}),
+    } as DOMRect));
+    (target as any).setPointerCapture = jest.fn();
+    (target as any).releasePointerCapture = jest.fn();
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    // Drag from (40, 60) → (140, 160) inside the OLD rect at (0..200).
+    // OLD-rect fractions: x=40/200=0.2, y=60/200=0.3, w=100/200=0.5,
+    // h=100/200=0.5. With the new (500..700) rect at finalize time,
+    // clamping (40,60) into that rect would silently shift the start.
+    dispatchPointer(target, "pointerdown", 40, 60);
+    dispatchPointer(target, "pointermove", 90, 110);
+    dispatchPointer(target, "pointerup", 140, 160);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const data = send.mock.calls[0][0].data as Record<string, number>;
+    expect(data.x).toBeCloseTo(0.2, 5);
+    expect(data.y).toBeCloseTo(0.3, 5);
+    expect(data.w).toBeCloseTo(0.5, 5);
+    expect(data.h).toBeCloseTo(0.5, 5);
+  });
+
   it("uses the pointerdown-time parent even if host moves between mousemoves", () => {
     // Two positioned parents at known offsets. The host starts under
     // the first; we begin a drag, then synthetically re-parent the

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1165,6 +1165,15 @@ describe("handleShadowRootHydration", () => {
 });
 
 describe("handleAreaSelectDirectives", () => {
+  // The module-level areaSelectArmed map is cleared lazily — the sweep
+  // only fires when handleAreaSelectDirectives runs. Without an explicit
+  // afterEach, tests that don't call it would inherit armed elements
+  // from prior tests. teardownAreaSelectForRoot(document.body) wipes
+  // every entry so each test gets a fresh slate.
+  afterEach(() => {
+    teardownAreaSelectForRoot(document.body);
+  });
+
   // jsdom-friendly helper: configure the target element so it has a
   // non-trivial bounding rect (jsdom returns zeros by default) and a
   // positioned parent so the overlay has somewhere to land. Returns
@@ -1477,6 +1486,82 @@ describe("handleAreaSelectDirectives", () => {
     expect(overlay.style.top).toBe("50px");
     expect(overlay.style.width).toBe("40px");
     expect(overlay.style.height).toBe("40px");
+  });
+
+  it("lostpointercapture for a different pointerId does NOT cancel our drag", () => {
+    // Another code path could call setPointerCapture on the same
+    // element with a different pointerId and later release it,
+    // firing lostpointercapture on the host. Our handler must not
+    // mistake that for OUR drag being canceled.
+    const [, parent] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const target = parent.querySelector("img")! as HTMLElement;
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    // Our drag starts with pointerId=1.
+    dispatchPointer(target, "pointerdown", 10, 10, 1);
+    dispatchPointer(target, "pointermove", 80, 80, 1);
+
+    // Unrelated lostpointercapture for pointerId=42 — must be ignored.
+    dispatchPointer(target, "lostpointercapture", 80, 80, 42);
+
+    // Our drag is still alive — pointerup dispatches normally.
+    dispatchPointer(target, "pointerup", 100, 100, 1);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the pointerdown-time parent even if host moves between mousemoves", () => {
+    // Two positioned parents at known offsets. The host starts under
+    // the first; we begin a drag, then synthetically re-parent the
+    // host into the second container mid-drag. Without the parent-
+    // capture fix, updateOverlay would refetch el.parentElement and
+    // compute against the SECOND parent while the overlay still
+    // lives in the FIRST — visual mis-positioning for the rest of
+    // the drag. With the fix, the overlay tracks the FIRST parent.
+    document.body.innerHTML = `
+      <div id="p1" style="position:relative;"></div>
+      <div id="p2" style="position:relative;"></div>
+    `;
+    const p1 = document.getElementById("p1") as HTMLDivElement;
+    const p2 = document.getElementById("p2") as HTMLDivElement;
+    const target = document.createElement("img");
+    target.setAttribute("lvt-fx:area-select", "selectImageArea");
+    p1.appendChild(target);
+    target.getBoundingClientRect = jest.fn(() => ({
+      x: 10, y: 10, left: 10, top: 10, right: 110, bottom: 110,
+      width: 100, height: 100, toJSON: () => ({}),
+    } as DOMRect));
+    p1.getBoundingClientRect = jest.fn(() => ({
+      x: 0, y: 0, left: 0, top: 0, right: 200, bottom: 200,
+      width: 200, height: 200, toJSON: () => ({}),
+    } as DOMRect));
+    p2.getBoundingClientRect = jest.fn(() => ({
+      x: 500, y: 500, left: 500, top: 500, right: 700, bottom: 700,
+      width: 200, height: 200, toJSON: () => ({}),
+    } as DOMRect));
+    (target as any).setPointerCapture = jest.fn();
+    (target as any).releasePointerCapture = jest.fn();
+    handleAreaSelectDirectives(document.body, jest.fn());
+
+    dispatchPointer(target, "pointerdown", 30, 30);
+    // Server diff moves the host to p2.
+    p2.appendChild(target);
+    dispatchPointer(target, "pointermove", 80, 60);
+
+    // Overlay stays in p1 (where pointerdown attached it). Position is
+    // computed against p1's rect (cached at pointerdown), not p2's.
+    const overlayInP1 = p1.querySelector(".lvt-area-select-overlay") as HTMLDivElement;
+    const overlayInP2 = p2.querySelector(".lvt-area-select-overlay");
+    expect(overlayInP1).not.toBeNull();
+    expect(overlayInP2).toBeNull();
+    // pointerdown at (30,30), move to (80,60) → 50×30 against p1
+    // at (0,0). If updateOverlay had re-fetched el.parentElement
+    // and used p2 (at 500,500), left would be -470 instead of 30.
+    expect(overlayInP1.style.left).toBe("30px");
   });
 
   it("warns when the parent's computed position is `static`", () => {

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1585,10 +1585,43 @@ describe("handleAreaSelectDirectives", () => {
 
     dispatchPointer(target, "pointerdown", 10, 10);
 
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("parentElement has no positioning context"),
-      expect.anything()
+    const warnings = warn.mock.calls.filter(
+      (args) => typeof args[0] === "string" && args[0].includes("parentElement has no positioning context")
     );
+    expect(warnings.length).toBe(1);
+  });
+
+  it("dedupes the static-parent warn across repeated drags", () => {
+    // Without the WeakSet dedupe, a user repeatedly dragging on the
+    // same mis-configured element would spam console.warn (and
+    // re-run getComputedStyle, a style-recalc trigger) once per
+    // pointerdown.
+    const warn = console.warn as jest.Mock;
+    document.body.innerHTML = `
+      <div id="static-parent">
+        <img id="target" lvt-fx:area-select="selectImageArea">
+      </div>
+    `;
+    const target = document.getElementById("target") as HTMLImageElement;
+    target.getBoundingClientRect = jest.fn(() => ({
+      x: 0, y: 0, left: 0, top: 0, right: 200, bottom: 200,
+      width: 200, height: 200, toJSON: () => ({}),
+    } as DOMRect));
+    (target as any).setPointerCapture = jest.fn();
+    (target as any).releasePointerCapture = jest.fn();
+    handleAreaSelectDirectives(document.body, jest.fn());
+
+    // Three drags on the same mis-configured parent — only the FIRST
+    // should warn.
+    for (let i = 0; i < 3; i++) {
+      dispatchPointer(target, "pointerdown", 10, 10);
+      dispatchPointer(target, "pointerup", 60, 60);
+    }
+
+    const warnings = warn.mock.calls.filter(
+      (args) => typeof args[0] === "string" && args[0].includes("parentElement has no positioning context")
+    );
+    expect(warnings.length).toBe(1);
   });
 
   it("pointercancel cancels the drag without dispatching", () => {

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1213,7 +1213,7 @@ describe("handleAreaSelectDirectives", () => {
 
   function dispatchPointer(
     el: HTMLElement,
-    type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel",
+    type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel" | "lostpointercapture",
     clientX: number,
     clientY: number,
     pointerId = 1
@@ -1476,6 +1476,27 @@ describe("handleAreaSelectDirectives", () => {
     expect(overlay.style.top).toBe("50px");
     expect(overlay.style.width).toBe("40px");
     expect(overlay.style.height).toBe("40px");
+  });
+
+  it("lostpointercapture cancels the drag without dispatching", () => {
+    const [, parent] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const target = parent.querySelector("img")! as HTMLElement;
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    dispatchPointer(target, "pointerdown", 10, 10);
+    dispatchPointer(target, "pointermove", 80, 80);
+    // Platform yanks capture (OS gesture, another setPointerCapture
+    // call elsewhere). lostpointercapture should cancel like
+    // pointercancel — overlay removed, no action dispatched.
+    dispatchPointer(target, "lostpointercapture", 80, 80);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(parent.querySelector(".lvt-area-select-overlay")).toBeNull();
   });
 
   it("cleans up armed elements whose attribute was removed by a server diff", () => {

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1564,6 +1564,47 @@ describe("handleAreaSelectDirectives", () => {
     expect(overlayInP1.style.left).toBe("30px");
   });
 
+  it("positions overlay correctly when parent is scrolled", () => {
+    // For a scrolled positioned parent: an element at viewport_x =
+    // parentRect.left actually has CSS_left = parent.scrollLeft (the
+    // browser is scrolled, so what's at viewport-x-0 is parent-x-100
+    // for scrollLeft=100). Without adding scrollLeft/scrollTop back
+    // into the CSS coords, the overlay paints displaced by the scroll
+    // amount.
+    document.body.innerHTML = `
+      <div id="parent" style="position:relative;"><img id="target" lvt-fx:area-select="selectImageArea"></div>
+    `;
+    const parent = document.getElementById("parent") as HTMLDivElement;
+    const target = document.getElementById("target") as HTMLImageElement;
+    target.getBoundingClientRect = jest.fn(() => ({
+      x: 0, y: 0, left: 0, top: 0, right: 200, bottom: 200,
+      width: 200, height: 200, toJSON: () => ({}),
+    } as DOMRect));
+    parent.getBoundingClientRect = jest.fn(() => ({
+      x: 0, y: 0, left: 0, top: 0, right: 200, bottom: 200,
+      width: 200, height: 200, toJSON: () => ({}),
+    } as DOMRect));
+    // jsdom: scrollLeft/Top are mutable properties; just assign.
+    Object.defineProperty(parent, "scrollLeft", { value: 100, configurable: true });
+    Object.defineProperty(parent, "scrollTop", { value: 50, configurable: true });
+    (target as any).setPointerCapture = jest.fn();
+    (target as any).releasePointerCapture = jest.fn();
+    handleAreaSelectDirectives(document.body, jest.fn());
+
+    // Drag from viewport (30, 40) to (90, 100). With the scroll
+    // correction the overlay's CSS left should be
+    // 30 - 0 - 0 + 100 = 130 and CSS top should be
+    // 40 - 0 - 0 + 50 = 90. Without it, left=30 / top=40 (the bug).
+    dispatchPointer(target, "pointerdown", 30, 40);
+    dispatchPointer(target, "pointermove", 90, 100);
+    const overlay = parent.querySelector(".lvt-area-select-overlay") as HTMLDivElement;
+    expect(overlay).not.toBeNull();
+    expect(overlay.style.left).toBe("130px");
+    expect(overlay.style.top).toBe("90px");
+    expect(overlay.style.width).toBe("60px");
+    expect(overlay.style.height).toBe("60px");
+  });
+
   it("warns when the parent's computed position is `static`", () => {
     // Forgetting position:relative on the parent silently mis-paints
     // the overlay against the nearest positioned ancestor. A

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1223,7 +1223,7 @@ describe("handleAreaSelectDirectives", () => {
 
   function dispatchPointer(
     el: HTMLElement,
-    type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel" | "lostpointercapture",
+    type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel" | "lostpointercapture" | "pointerleave",
     clientX: number,
     clientY: number,
     pointerId = 1
@@ -1486,6 +1486,38 @@ describe("handleAreaSelectDirectives", () => {
     expect(overlay.style.top).toBe("50px");
     expect(overlay.style.width).toBe("40px");
     expect(overlay.style.height).toBe("40px");
+  });
+
+  it("pointerleave for a different pointerId does NOT cancel our capture-fallback drag", () => {
+    // When setPointerCapture fails the directive attaches a
+    // pointerleave fallback so the drag can clean up. In a multi-
+    // touch scenario, a SECONDARY pointer leaving the element fires
+    // pointerleave too — must not be mistaken for our pointer
+    // leaving.
+    const [, parent] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const target = parent.querySelector("img")! as HTMLElement;
+    // Force capture failure so the pointerleave fallback is attached.
+    (target as any).setPointerCapture = jest.fn(() => {
+      throw new DOMException("no capture", "InvalidStateError");
+    });
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    // Primary drag with pointerId=1.
+    dispatchPointer(target, "pointerdown", 10, 10, 1);
+    dispatchPointer(target, "pointermove", 80, 80, 1);
+
+    // Secondary pointer (id=42) leaves the host. Must NOT cancel
+    // our id=1 drag.
+    dispatchPointer(target, "pointerleave", 80, 80, 42);
+
+    // Primary drag still alive — pointerup completes it normally.
+    dispatchPointer(target, "pointerup", 100, 100, 1);
+    expect(send).toHaveBeenCalledTimes(1);
   });
 
   it("lostpointercapture for a different pointerId does NOT cancel our drag", () => {

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -1426,6 +1426,29 @@ describe("handleAreaSelectDirectives", () => {
     expect(parent.querySelector(".lvt-area-select-overlay")).toBeNull();
   });
 
+  it("cleans up armed elements whose attribute was removed by a server diff", () => {
+    const [target] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    // Server diff removes the attribute. The element stays in the DOM
+    // (host alive, but no longer wants area-select). The next
+    // handleAreaSelectDirectives pass MUST cancel the listeners — a
+    // subsequent drag must not dispatch the old action.
+    target.removeAttribute("lvt-fx:area-select");
+    handleAreaSelectDirectives(document.body, send);
+
+    dispatchPointer(target, "pointerdown", 10, 10);
+    dispatchPointer(target, "pointermove", 100, 100);
+    dispatchPointer(target, "pointerup", 100, 100);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it("recovers from a stuck drag on the next pointerdown (re-entrancy guard)", () => {
     const [target] = mountTarget(
       "img",

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -6,6 +6,7 @@ import {
   handleAutoClickDirectives,
   handleShadowRootHydration,
   setupFxDOMEventTriggers,
+  teardownAreaSelectForRoot,
   teardownAutoClickTimers,
   __resetAnimatedElementsForTesting,
 } from "../dom/directives";
@@ -1476,6 +1477,77 @@ describe("handleAreaSelectDirectives", () => {
     expect(overlay.style.top).toBe("50px");
     expect(overlay.style.width).toBe("40px");
     expect(overlay.style.height).toBe("40px");
+  });
+
+  it("rejects zero-area rectangles even if the threshold check would pass", () => {
+    // The MIN_AREA_FRACTION check uses && so a wide-but-thin drag is
+    // a legit selection — but a literal 60% × 0% drag has no area,
+    // can't render sensibly, and would divide by zero downstream.
+    // Drop it independently of the threshold.
+    const [target] = mountTarget(
+      "img",
+      { "lvt-fx:area-select": "selectImageArea" },
+      { left: 0, top: 0, width: 200, height: 200 }
+    );
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    // Drag from (40,100) to (160,100) — w=60% of 200, h=0%.
+    dispatchPointer(target, "pointerdown", 40, 100);
+    dispatchPointer(target, "pointermove", 160, 100);
+    dispatchPointer(target, "pointerup", 160, 100);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("teardownAreaSelectForRoot cancels armed elements under root", () => {
+    // For the disconnect / destroy lifecycle: if a client tears down
+    // without a subsequent handleAreaSelectDirectives call, the
+    // module-level singleton would otherwise leak listeners.
+    document.body.innerHTML = `
+      <div id="root">
+        <div id="parent" style="position:relative;">
+          <img id="target" lvt-fx:area-select="selectImageArea">
+        </div>
+      </div>
+      <div id="outside-parent" style="position:relative;">
+        <img id="outside-target" lvt-fx:area-select="otherAction">
+      </div>
+    `;
+    const root = document.getElementById("root")!;
+    const target = document.getElementById("target")! as HTMLImageElement;
+    const outside = document.getElementById("outside-target")! as HTMLImageElement;
+    for (const el of [target, outside]) {
+      el.getBoundingClientRect = jest.fn(() => ({
+        x: 0, y: 0, left: 0, top: 0, right: 200, bottom: 200,
+        width: 200, height: 200, toJSON: () => ({}),
+      } as DOMRect));
+      el.parentElement!.getBoundingClientRect = jest.fn(() => ({
+        x: 0, y: 0, left: 0, top: 0, right: 200, bottom: 200,
+        width: 200, height: 200, toJSON: () => ({}),
+      } as DOMRect));
+      (el as any).setPointerCapture = jest.fn();
+      (el as any).releasePointerCapture = jest.fn();
+    }
+    const send = jest.fn();
+    handleAreaSelectDirectives(document.body, send);
+
+    teardownAreaSelectForRoot(root);
+
+    // The target inside root must NOT dispatch after teardown.
+    dispatchPointer(target, "pointerdown", 10, 10);
+    dispatchPointer(target, "pointermove", 100, 100);
+    dispatchPointer(target, "pointerup", 100, 100);
+    expect(send).not.toHaveBeenCalled();
+
+    // The target outside root must still work.
+    dispatchPointer(outside, "pointerdown", 10, 10);
+    dispatchPointer(outside, "pointermove", 100, 100);
+    dispatchPointer(outside, "pointerup", 100, 100);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0].action).toBe("otherAction");
+
+    teardownAreaSelectForRoot(document.body); // clean up for next test
   });
 
   it("does not preventDefault on pointerdown — clicks still bubble", () => {


### PR DESCRIPTION
## Summary

Adds `lvt-fx:area-select="<actionName>"` — a new directive that handles a pointer drag locally and dispatches a single action with the final `{x, y, w, h}` (0..1 fractions of the host's bounding rect) on pointerup. Mirrors the `handleAutoClickDirectives` pattern: Map of armed elements (sweep-based cleanup, not WeakMap GC), idempotent across renders, fast path on empty match.

Unblocks `livetemplate/prereview#16 phase 2` (image-area annotations).

## What's in this PR

- **`dom/directives.ts`** — new `handleAreaSelectDirectives(root, send)`. Pointer Events API (unified mouse + touch + stylus). `setPointerCapture` so a drag that leaves the host still finishes; `pointerleave`-cancel fallback if capture fails. `pointercancel` + `lostpointercapture` both clean up without dispatching, with `pointerId` guards so secondary-pointer leaves don't cancel the primary drag. Re-entrancy guard on `pointerdown` cancels a prior stuck drag. `dragstart` `preventDefault()` so `<img>` and other natively-draggable hosts don't have the gesture stolen by the browser's native drag. 2%-of-rect minimum filter for accidental clicks (AND across dims — a wide-but-thin selection is intentional). Both corners clamped to the host rect BEFORE the fraction divides so a drag that escapes still yields `x+w ≤ 1` / `y+h ≤ 1`. Border-box-to-padding-box offset (`clientLeft`/`clientTop`) AND scroll correction (`scrollLeft`/`scrollTop`) so the overlay positions correctly under a scrolled, bordered, positioned parent. The host's rect AND parent are cached at pointerdown so a server diff that repositions or re-parents the host mid-drag doesn't skew the dispatched fractions. State is reset BEFORE `releasePointerCapture` so Chromium's synchronous `lostpointercapture` re-entrancy doesn't drop the dispatch. Sweep on every call cleans up disconnected hosts AND elements whose attribute was removed by a server diff. Idempotent re-arm updates the captured `send` so a fresh callback (e.g. after a WS reconnect rebuilt the transport) reaches the next drag. Static-parent warn is deduped via WeakSet so repeated drags don't spam the console.
- **`livetemplate-client.ts`** — wired in the FIRE-ON-CHANGE block right after `handleAutoClickDirectives`. Reuses `this.send()` so WS / HTTP routing is identical to a normal action. Calls `teardownAreaSelectForRoot(this.wrapperElement)` in the disconnect path so the module-level singleton doesn't leak listeners after a client tears down.
- **`tests/directives.test.ts`** — 22 area-select tests covering: happy-path dispatch with fraction coords, min-size filter, overlay paint + removal, pointercancel cleanup, idempotent re-run, attribute-value-change re-arm, empty-attribute warn, escape-rect clamp, host-detach mid-drag, attribute-removal sweep, re-entrancy recovery from a stuck drag, `dragstart` suppression on `<img>`, offset-parent positioning, scrolled-parent positioning, `lostpointercapture` cancel + pointerId guard, `pointerleave` pointerId guard for multi-touch, idempotent re-arm picking up a fresh `send`, `pointerdown.preventDefault` NOT firing (clicks still bubble), stale `pointerleave` listener removed between gestures, zero-area rectangle rejection, `teardownAreaSelectForRoot` scoped to root, static-parent warn + dedupe, host re-parented mid-drag uses cached parent, host repositioned mid-drag uses cached rect, synchronous `lostpointercapture` from `releasePointerCapture` doesn't drop the dispatch.

## Why Pointer Events instead of mouse + touch

Pointer Events unify mouse / touch / stylus into one event family with `setPointerCapture`. Modern Chromium / Firefox / Safari all ship it. Touch consumers should pair the directive with `touch-action: none` on the host so iOS Safari doesn't interpret the drag as a pinch / scroll — the prereview consumer does exactly this on the `<img>`.

## Test plan

- [x] `npm test -- --testPathPatterns directives` — 95 pass + 1 skipped pre-existing.
- [x] Full client suite (`npm test`) — 627 pass.
- [x] Verified end-to-end via prereview's image-area annotation flow: synthetic drag via Chrome `Input.dispatchMouseEvent` fires the directive's pointerdown/move/up handlers, action dispatches with the correct fraction coords, server renders the saved overlay at the right CSS percentages.
- [ ] CI

## Consumer contract

- Host's `parentElement` must establish a positioning context (`position: relative` / `absolute` / `fixed`). The overlay `<div>` is `position: absolute` inside that parent so it tracks on scroll / reflow. The directive logs a dev-time `console.warn` (deduped per-parent via WeakSet) if the parent's computed position isn't one of the positioned values.
- Pair with `touch-action: none` on the host so iOS Safari doesn't interpret the drag as a pinch / scroll.
- `<img>` and other natively-draggable hosts work automatically: the directive calls `preventDefault()` on `dragstart` so the browser's native drag (which would otherwise steal the gesture) is suppressed.
- For text-bearing hosts, set `user-select: none` — the directive deliberately does NOT call `preventDefault()` on `pointerdown` so click handlers still receive the gesture, which means the browser's default text-selection-on-drag also fires unless the host opts out via CSS.
- Drags smaller than 2% of the host's rect in both dimensions are dropped — a click still bubbles for normal handlers. (`&&`, not `||` — a wide-but-thin or tall-but-thin drag is a real selection in this contract.)
- Zero-area rectangles (`w == 0 || h == 0`) are rejected outright independent of the threshold so a downstream pixel-space conversion can't divide by zero.
- Pointer-cancel / lost-capture / pointerleave (after capture failure): overlay removed, no action dispatched (same effect as cancelling a click on `mouseleave`). All three handlers guard on `pointerId` so a secondary pointer leaving doesn't cancel the primary drag.
- The overlay uses `z-index: var(--lvt-area-select-z-index, 9999)`. Color + fill follow the same pattern via `--lvt-area-select-color` and `--lvt-area-select-fill`. Override on the host (or any ancestor) to stack against portals / modals / drawers.
- **Module-level singleton.** `areaSelectArmed` is shared across all `LiveTemplateClient` instances in the same window. If two clients ever arm the same element with different actions, the second wins and the first client's `send` is orphaned silently. Single-client use (the only case today) is unaffected.
- **Pointer-only by design.** No keyboard equivalent — a keyboard-selected rectangle requires a different UX (focus + arrow keys to position + arrow keys to size). Consumers needing a11y for area selection should provide a parallel form-based affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)