### PR TITLE
feat: lvt-fx:url-hash — bidirectional location.hash ↔ state sync

### DIFF
--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1283,6 +1283,14 @@ export function teardownURLHashForRoot(rootElement: Element): void {
 // scroll) and gets replaceState. Updates entry.currentDataHash so a
 // subsequent render with the same data-attr no-ops.
 //
+// Initial-mirror special case: if the URL was empty when we're
+// mirroring (no prior hash to compare against), use replaceState even
+// though the path-component comparison would say "changed". An empty
+// URL → first server hash isn't a "navigation" — we're establishing
+// the initial state. Using pushState here would let Back land the
+// user on `url-without-hash`, which re-triggers the same arm and
+// pushes the same hash again. Loop.
+//
 // Empty-dataHash special case: if the server transitions FROM a
 // selected file TO no-selection (state.URLHash() returns ""), we
 // would otherwise wipe location.hash entirely — including hashes the
@@ -1305,7 +1313,12 @@ function mirrorDataAttrToLocation(entry: URLHashEntry, dataHash: string): void {
   const targetURL = dataHash ? `#${dataHash}` : window.location.pathname + window.location.search;
   const oldPath = currentLocation.split(":")[0];
   const newPath = dataHash.split(":")[0];
-  if (oldPath !== newPath) {
+  // Empty currentLocation means we're establishing the URL from a
+  // blank slate (initial render with no prior URL hash) — that's NOT
+  // a back-button-meaningful navigation, so always replaceState.
+  // Otherwise: a path change is a file switch (push), a target-only
+  // change is a line/anchor scroll (replace).
+  if (currentLocation !== "" && oldPath !== newPath) {
     window.history.pushState(null, "", targetURL);
   } else {
     window.history.replaceState(null, "", targetURL);
@@ -1364,6 +1377,15 @@ function attachURLHash(
       // would otherwise be dispatched here, prompt a server no-op,
       // then get clobbered by the mirror step when the server's
       // data-attr (unchanged) doesn't match.
+      //
+      // Empty hash (user cleared the URL bar) is also intentionally
+      // ignored. The directive treats the server as the source of
+      // truth for "what's selected"; an empty URL is "user navigated
+      // away from a hash" but not "deselect everything". If the user
+      // wants to deselect, they use the in-app affordance
+      // (clearSelection / Escape) which makes the server emit an
+      // empty data-attr — at which point the mirror step propagates
+      // the empty hash back to the URL.
       if (!looksLikeDeepLinkHash(hash)) return;
       // Iterate via Array.from in case a dispatched action triggers a
       // render that mutates the armed map (e.g. tears down this

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1319,20 +1319,45 @@ function mirrorDataAttrToLocation(entry: URLHashEntry, dataHash: string): void {
     entry.currentDataHash = dataHash;
     return;
   }
+  warnIfUnencodedHash(dataHash);
   const targetURL = dataHash ? `#${dataHash}` : window.location.pathname + window.location.search;
   const oldPath = currentLocation.split(":")[0];
   const newPath = dataHash.split(":")[0];
+  // Preserve existing history.state — passing `null` would clobber
+  // anything other SPA-like code on the page stores there (scroll
+  // position, modal flag, etc.). The state object is independent of
+  // the URL we're rewriting, so carrying it forward is the right
+  // default.
+  const currentState = window.history.state;
   // Empty currentLocation means we're establishing the URL from a
   // blank slate (initial render with no prior URL hash) — that's NOT
   // a back-button-meaningful navigation, so always replaceState.
   // Otherwise: a path change is a file switch (push), a target-only
   // change is a line/anchor scroll (replace).
   if (currentLocation !== "" && oldPath !== newPath) {
-    window.history.pushState(null, "", targetURL);
+    window.history.pushState(currentState, "", targetURL);
   } else {
-    window.history.replaceState(null, "", targetURL);
+    window.history.replaceState(currentState, "", targetURL);
   }
   entry.currentDataHash = dataHash;
+}
+
+// warnIfUnencodedHash flags `data-lvt-url-hash` values containing
+// characters that should be percent-encoded (raw space, `<`, `>`,
+// `"`, ``` ` ```, `#`). The directive writes the hash verbatim into
+// `pushState`/`replaceState`, so an unencoded value will silently
+// produce a malformed URL — `location.hash` reads back differently
+// from what was set. Cheap dev-time guard against a server-side
+// contract slip; dedupes by value to avoid log spam.
+const urlHashUnencodedWarned = new Set<string>();
+function warnIfUnencodedHash(hash: string): void {
+  if (!hash || urlHashUnencodedWarned.has(hash)) return;
+  if (/[ <>"`#]/.test(hash)) {
+    urlHashUnencodedWarned.add(hash);
+    console.warn(
+      `lvt-fx:url-hash: data-lvt-url-hash="${hash}" contains characters that should be percent-encoded. The directive writes it verbatim into history.pushState/replaceState; malformed URLs result. Server-side FormatHash (or equivalent) should percent-escape path segments and target ids before serialization.`
+    );
+  }
 }
 
 // looksLikeDeepLinkHash discriminates URL hashes the prereview deep-

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1072,6 +1072,15 @@ export function teardownAreaSelectForRoot(rootElement: Element): void {
 // sweep iterates to detect elements whose attribute was removed by a
 // server diff, and detached elements are cleaned up via the same
 // sweep (isConnected check).
+//
+// Module-level singleton: shared across all LiveTemplateClient
+// instances in the window. If two clients ever arm the same element
+// (rare — usually clients have disjoint roots), each gets its own
+// entry. On hashchange, the shared window listener iterates the map
+// and dispatches through every entry's own send — so a multi-client
+// page sees each client receive its hash event. Teardown is scoped
+// per root via teardownURLHashForRoot, so clients don't tear down
+// each other's listeners.
 const urlHashArmed = new Map<Element, URLHashEntry>();
 
 // urlHashWindowListener is the single window-level `hashchange`
@@ -1340,6 +1349,16 @@ function mirrorDataAttrToLocation(entry: URLHashEntry, dataHash: string): void {
 // file (prereview's SetURLHash does, via the loadDiffCached failure
 // path). The cost is one wasted roundtrip per false positive, which
 // is acceptable for the alternative of missing real deep links.
+//
+// False negatives: extension-less filenames at the repo root —
+// `#Makefile`, `#Dockerfile`, `#LICENSE` — don't match this
+// heuristic and won't be dispatched as path-only deep links. The
+// workaround is the line-form (`#Makefile:L1`), which always
+// dispatches. This trade-off is deliberate: a heuristic that
+// matched single-token hashes would also clobber every native
+// anchor / popover id, which is a much worse default. Consumers
+// that need extension-less file deep links can build a richer
+// directive on top.
 function looksLikeDeepLinkHash(hash: string): boolean {
   if (!hash) return false;
   return hash.includes(":") || hash.includes("/") || hash.includes(".");

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1067,6 +1067,226 @@ export function teardownAreaSelectForRoot(rootElement: Element): void {
   }
 }
 
+// urlHashArmed tracks `lvt-fx:url-hash` listeners and their last-
+// mirrored hash. Same Map-not-WeakMap reasoning as area-select: the
+// sweep iterates to detect elements whose attribute was removed by a
+// server diff, and detached elements are cleaned up via the same
+// sweep (isConnected check).
+const urlHashArmed = new Map<Element, URLHashEntry>();
+
+// urlHashWindowListener is the single window-level `hashchange`
+// listener shared across all armed elements. Registered on first arm,
+// removed when the armed map becomes empty. Per-element listeners
+// would multi-fire for the (rare) case of multiple armed elements;
+// one shared listener iterating the armed map keeps the dispatch
+// count deterministic.
+let urlHashWindowListener: ((e: HashChangeEvent) => void) | null = null;
+
+interface URLHashEntry {
+  action: string;
+  // send is stored on the entry so the shared window listener can
+  // dispatch each armed entry's action through its own transport. The
+  // idempotent re-arm path mutates this field directly (via
+  // updateSend), so a reconnect that rebuilt the transport is picked
+  // up on the next hashchange.
+  send: URLHashSendFn;
+  cleanup: () => void;
+  updateSend: (send: URLHashSendFn) => void;
+  // currentDataHash is the last `data-lvt-url-hash` value we mirrored
+  // into `location.hash` (or the value we observed on a user-initiated
+  // hashchange). Comparing against the next render's data-attr lets us
+  // no-op when the server re-rendered with the same hash — avoids
+  // extra history entries on every keystroke.
+  currentDataHash: string;
+}
+
+type URLHashSendFn = (
+  message: { action: string; data: Record<string, unknown> }
+) => void;
+
+/**
+ * Apply url-hash directives. `lvt-fx:url-hash="<actionName>"` plus a
+ * `data-lvt-url-hash="<hash>"` attribute on an element (typically the
+ * `<body>`) wires a two-way bridge between server state and
+ * `location.hash`:
+ *
+ *  - **State → URL** (every render): if `data-lvt-url-hash` differs
+ *    from `location.hash`, mirror the data-attr into the URL via
+ *    `history.pushState` when the path component changed (everything
+ *    before the first `:`) or `history.replaceState` when only the
+ *    target (line range / anchor) changed. Replace is the right
+ *    default for line scrolls so the back-button cycles between files,
+ *    not between every clicked line.
+ *  - **URL → State** (on `hashchange` AND initial arm): dispatch
+ *    `{action: <actionName>, data: {hash: <hash>}}` so the server can
+ *    parse the hash and update its state (which then renders back as
+ *    a matching data-attr — closing the loop).
+ *
+ * The directive uses `history.pushState`/`replaceState` (not
+ * `location.hash = ...`) for the state→URL direction precisely so
+ * those writes do NOT fire `hashchange` — only true user-initiated
+ * navigation (anchor click, address-bar edit, back-button) reaches
+ * the URL→state listener. This avoids the obvious infinite loop.
+ *
+ * Idempotent across renders: same action → keep listener + update
+ * send. Different action → cleanup + re-arm. Detached / attribute-
+ * removed elements are swept on every call (same pattern as
+ * area-select). The window listener is registered on first arm and
+ * removed when the armed map becomes empty.
+ *
+ * Coexistence with `setupHashLink`: prereview-style hashes
+ * (`README.md:L4`, `foo/bar.html:h-anchor`) never match a
+ * `document.getElementById(...)`, so the existing dialog/popover/
+ * details hash machinery silently no-ops. If a deep-link hash
+ * happens to collide with an element id, both handlers will fire —
+ * the server is expected to no-op on hashes that don't resolve to a
+ * known file.
+ */
+export function handleURLHashDirective(
+  rootElement: Element,
+  send: (message: { action: string; data: Record<string, unknown> }) => void
+): void {
+  // Sweep stale entries first — disconnected hosts AND hosts whose
+  // attribute was removed by a server diff. Iterate via Array.from so
+  // cleanup()'s delete() doesn't disturb the iterator.
+  for (const [element, entry] of Array.from(urlHashArmed)) {
+    if (
+      !element.isConnected ||
+      !element.hasAttribute("lvt-fx:url-hash")
+    ) {
+      entry.cleanup();
+    }
+  }
+
+  // Match the root itself AND descendants. The url-hash directive is
+  // typically placed on a wrapping element (body, the livetemplate
+  // wrapper div) and querySelectorAll only walks descendants — so
+  // without the root check, a directive on the wrapper itself would
+  // never arm.
+  const matches: HTMLElement[] = [];
+  if (
+    rootElement instanceof HTMLElement &&
+    rootElement.hasAttribute("lvt-fx:url-hash")
+  ) {
+    matches.push(rootElement);
+  }
+  rootElement
+    .querySelectorAll<HTMLElement>("[lvt-fx\\:url-hash]")
+    .forEach((el) => matches.push(el));
+  if (matches.length === 0) return;
+
+  for (const el of matches) {
+    const action = el.getAttribute("lvt-fx:url-hash");
+    if (!action) {
+      console.warn(
+        `lvt-fx:url-hash requires an action name, got: ${JSON.stringify(action)}`
+      );
+      continue;
+    }
+    const dataHash = el.getAttribute("data-lvt-url-hash") || "";
+    const existing = urlHashArmed.get(el);
+    if (existing && existing.action === action) {
+      existing.updateSend(send);
+      mirrorDataAttrToLocation(existing, dataHash);
+      continue;
+    }
+    if (existing) existing.cleanup();
+    const entry = attachURLHash(el, action, send);
+    urlHashArmed.set(el, entry);
+    // First-arm sync: if the server has a hash to mirror, write it
+    // before reacting to the existing location.hash. If location.hash
+    // is non-empty AND differs from the server's data-attr, dispatch
+    // (URL "wins" on initial load so deep-linked URLs work).
+    const initialLocation = window.location.hash.replace(/^#/, "");
+    if (initialLocation && initialLocation !== dataHash) {
+      entry.currentDataHash = initialLocation;
+      send({ action, data: { hash: initialLocation } });
+    } else {
+      mirrorDataAttrToLocation(entry, dataHash);
+    }
+  }
+}
+
+/**
+ * Cancel url-hash listeners for every armed element under root. Same
+ * lifecycle role as teardownAreaSelectForRoot.
+ */
+export function teardownURLHashForRoot(rootElement: Element): void {
+  for (const [element, entry] of Array.from(urlHashArmed)) {
+    if (rootElement.contains(element)) {
+      entry.cleanup();
+    }
+  }
+}
+
+// mirrorDataAttrToLocation pushes `dataHash` into `location.hash` if
+// it differs from what's already in the URL. Chooses push vs replace
+// by comparing the path component (everything before the first `:`)
+// against the current location.hash's path: a path change is a "file
+// switch" (user-meaningful back-button entry) and gets pushState;
+// any other change is a target-only update (line scroll / anchor
+// scroll) and gets replaceState. Updates entry.currentDataHash so a
+// subsequent render with the same data-attr no-ops.
+function mirrorDataAttrToLocation(entry: URLHashEntry, dataHash: string): void {
+  if (entry.currentDataHash === dataHash) return;
+  const currentLocation = window.location.hash.replace(/^#/, "");
+  if (currentLocation === dataHash) {
+    entry.currentDataHash = dataHash;
+    return;
+  }
+  const targetURL = dataHash ? `#${dataHash}` : window.location.pathname + window.location.search;
+  const oldPath = currentLocation.split(":")[0];
+  const newPath = dataHash.split(":")[0];
+  if (oldPath !== newPath) {
+    window.history.pushState(null, "", targetURL);
+  } else {
+    window.history.replaceState(null, "", targetURL);
+  }
+  entry.currentDataHash = dataHash;
+}
+
+function attachURLHash(
+  el: HTMLElement,
+  action: string,
+  initialSend: URLHashSendFn
+): URLHashEntry {
+  const entry: URLHashEntry = {
+    action,
+    send: initialSend,
+    cleanup: () => {
+      urlHashArmed.delete(el);
+      if (urlHashArmed.size === 0 && urlHashWindowListener) {
+        window.removeEventListener("hashchange", urlHashWindowListener);
+        urlHashWindowListener = null;
+      }
+    },
+    updateSend: (s) => {
+      entry.send = s;
+    },
+    currentDataHash: "",
+  };
+
+  if (!urlHashWindowListener) {
+    urlHashWindowListener = () => {
+      const hash = window.location.hash.replace(/^#/, "");
+      // Iterate via Array.from in case a dispatched action triggers a
+      // render that mutates the armed map (e.g. tears down this
+      // element). Each armed entry dispatches through its OWN send +
+      // action so multi-arm is deterministic — typically the body is
+      // the only armed element so this is one iteration.
+      for (const e of Array.from(urlHashArmed.values())) {
+        // Record the user-driven hash as the new baseline so the
+        // next render's mirror step doesn't immediately revert it.
+        e.currentDataHash = hash;
+        e.send({ action: e.action, data: { hash } });
+      }
+    };
+    window.addEventListener("hashchange", urlHashWindowListener);
+  }
+
+  return entry;
+}
+
 // attachAreaSelect captures `send` in a mutable local so the
 // idempotent re-arm path (same element, same action) can swap it via
 // the returned `updateSend` callback without tearing down + rebuilding

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1326,9 +1326,13 @@ function mirrorDataAttrToLocation(entry: URLHashEntry, dataHash: string): void {
     entry.currentDataHash = dataHash;
     return;
   }
-  if (dataHash === "" && !looksLikeDeepLinkHash(currentLocation)) {
-    // Server cleared the hash AND the URL is on something not ours
-    // (popover id, native anchor). Don't clobber.
+  if (currentLocation !== "" && !looksLikeDeepLinkHash(currentLocation)) {
+    // URL is on something not ours (popover id, native anchor) —
+    // don't clobber it, regardless of what the server's data-attr
+    // says. This covers BOTH the server-clears case (dataHash="")
+    // and the rarer server-changes-selection-while-popover-open
+    // case (dataHash transitions from one file to another while
+    // the URL is parked on a non-deep-link hash).
     entry.currentDataHash = dataHash;
     return;
   }

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1284,6 +1284,17 @@ export function teardownURLHashForRoot(rootElement: Element): void {
   // armed — the directive accepts body placement (see the matcher in
   // handleURLHashDirective), so teardown must symmetrically clean up
   // both directions.
+  //
+  // Multi-client caveat: a body-armed entry is shared across all
+  // LiveTemplateClient instances (Map key is the element, so only one
+  // entry per body). Tearing down client A's root will therefore also
+  // tear down a body listener that client B armed last — there's no
+  // "owner" tracked. Acceptable for the single-client case (the
+  // common deployment) and matches the same-element-multi-arm
+  // last-writer-wins behavior in attachURLHash. A "fix" that
+  // restricted the body-cleanup branch to client A would leak
+  // client A's own body listener — don't do that without also
+  // tracking entry ownership.
   const body = rootElement.ownerDocument?.body;
   for (const [element, entry] of Array.from(urlHashArmed)) {
     if (rootElement.contains(element)) {
@@ -1373,6 +1384,19 @@ function mirrorDataAttrToLocation(entry: URLHashEntry, dataHash: string): void {
 // (won't catch every malformed escape), but covers the common
 // "forgot to encode" cases.
 const urlHashUnencodedWarned = new Set<string>();
+
+/**
+ * Test-only: reset the per-page dedupe Set that suppresses repeated
+ * `warnIfUnencodedHash` calls for the same hash value. Production
+ * code shouldn't need this — the Set is bounded by the number of
+ * unique malformed hashes — but tests that re-use the same hash
+ * across cases need to clear it or the second test won't see the
+ * warning. Mirrors `__resetAnimatedElementsForTesting`.
+ */
+export function __resetURLHashUnencodedWarnedForTesting(): void {
+  urlHashUnencodedWarned.clear();
+}
+
 function warnIfUnencodedHash(hash: string): void {
   if (!hash || urlHashUnencodedWarned.has(hash)) return;
   if (/[ <>"`#\[\]]/.test(hash) || /%(?![0-9A-Fa-f]{2})/.test(hash)) {

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1158,11 +1158,14 @@ export function handleURLHashDirective(
     }
   }
 
-  // Match the root itself AND descendants. The url-hash directive is
-  // typically placed on a wrapping element (body, the livetemplate
-  // wrapper div) and querySelectorAll only walks descendants — so
-  // without the root check, a directive on the wrapper itself would
-  // never arm.
+  // Match the root itself, descendants, AND the document body. The
+  // url-hash directive is typically placed on `<body>`, but livetemplate
+  // auto-injects its `<div data-lvt-id>` INSIDE body, so the rootElement
+  // passed by the client is the wrapper div — a strict descendant of
+  // body. Without the body check, a directive on `<body>` would never
+  // arm. We accept body placement because URL hash is page-global
+  // anyway; the directive's lifecycle is still tied to the wrapper via
+  // teardownURLHashForRoot (called on disconnect of the wrapper).
   const matches: HTMLElement[] = [];
   if (
     rootElement instanceof HTMLElement &&
@@ -1170,9 +1173,20 @@ export function handleURLHashDirective(
   ) {
     matches.push(rootElement);
   }
+  const body = rootElement.ownerDocument?.body;
+  if (
+    body &&
+    body !== rootElement &&
+    body.hasAttribute("lvt-fx:url-hash") &&
+    !matches.includes(body)
+  ) {
+    matches.push(body);
+  }
   rootElement
     .querySelectorAll<HTMLElement>("[lvt-fx\\:url-hash]")
-    .forEach((el) => matches.push(el));
+    .forEach((el) => {
+      if (!matches.includes(el)) matches.push(el);
+    });
   if (matches.length === 0) return;
 
   for (const el of matches) {
@@ -1195,10 +1209,16 @@ export function handleURLHashDirective(
     urlHashArmed.set(el, entry);
     // First-arm sync: if the server has a hash to mirror, write it
     // before reacting to the existing location.hash. If location.hash
-    // is non-empty AND differs from the server's data-attr, dispatch
-    // (URL "wins" on initial load so deep-linked URLs work).
+    // is a deep-link-shaped hash AND differs from the server's
+    // data-attr, dispatch (URL "wins" on initial load so deep-linked
+    // URLs work). Non-deep-link hashes (e.g. an element-id anchor
+    // setupHashLink owns) are left to their owning machinery.
     const initialLocation = window.location.hash.replace(/^#/, "");
-    if (initialLocation && initialLocation !== dataHash) {
+    if (
+      initialLocation &&
+      initialLocation !== dataHash &&
+      looksLikeDeepLinkHash(initialLocation)
+    ) {
       entry.currentDataHash = initialLocation;
       send({ action, data: { hash: initialLocation } });
     } else {
@@ -1212,8 +1232,17 @@ export function handleURLHashDirective(
  * lifecycle role as teardownAreaSelectForRoot.
  */
 export function teardownURLHashForRoot(rootElement: Element): void {
+  // Includes body when body is an ancestor of rootElement and body is
+  // armed — the directive accepts body placement (see the matcher in
+  // handleURLHashDirective), so teardown must symmetrically clean up
+  // both directions.
+  const body = rootElement.ownerDocument?.body;
   for (const [element, entry] of Array.from(urlHashArmed)) {
     if (rootElement.contains(element)) {
+      entry.cleanup();
+      continue;
+    }
+    if (body && element === body && body.contains(rootElement)) {
       entry.cleanup();
     }
   }
@@ -1245,6 +1274,17 @@ function mirrorDataAttrToLocation(entry: URLHashEntry, dataHash: string): void {
   entry.currentDataHash = dataHash;
 }
 
+// looksLikeDeepLinkHash discriminates URL hashes the prereview deep-
+// link grammar can produce (file path with optional :L<n> or :h-id)
+// from hashes that belong to other native machinery (HTML element
+// anchors, dialog/popover/details ids, etc.). Deep-link hashes always
+// contain at least one of: `:` (target separator), `/` (nested path),
+// or `.` (file extension). Empty → false.
+function looksLikeDeepLinkHash(hash: string): boolean {
+  if (!hash) return false;
+  return hash.includes(":") || hash.includes("/") || hash.includes(".");
+}
+
 function attachURLHash(
   el: HTMLElement,
   action: string,
@@ -1269,6 +1309,15 @@ function attachURLHash(
   if (!urlHashWindowListener) {
     urlHashWindowListener = () => {
       const hash = window.location.hash.replace(/^#/, "");
+      // Only dispatch hashes that look like deep-link targets — they
+      // contain `:` (target separator), `/` (nested path), or `.`
+      // (file extension). Plain element-id hashes like `#hero` or
+      // `#confirm-delete-xyz` belong to the native anchor / dialog /
+      // popover / details machinery (setupHashLink handles those) and
+      // would otherwise be dispatched here, prompt a server no-op,
+      // then get clobbered by the mirror step when the server's
+      // data-attr (unchanged) doesn't match.
+      if (!looksLikeDeepLinkHash(hash)) return;
       // Iterate via Array.from in case a dispatched action triggers a
       // render that mutates the armed map (e.g. tears down this
       // element). Each armed entry dispatches through its OWN send +

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1141,6 +1141,23 @@ type URLHashSendFn = (
  * happens to collide with an element id, both handlers will fire —
  * the server is expected to no-op on hashes that don't resolve to a
  * known file.
+ *
+ * **Pre-encoding contract**: `data-lvt-url-hash` must hold the hash
+ * value already in URL-encoded form. The directive writes the
+ * attribute verbatim into `history.pushState`/`replaceState`, so a
+ * value containing spaces, `[`, `]`, `%`, or other reserved
+ * characters needs to be percent-encoded by the server. The hash
+ * sent to the action on `hashchange` is also passed through unmodified
+ * (no decoding) — both directions are byte-exact mirrors of what's
+ * in `location.hash`.
+ *
+ * **URL/state divergence after a non-deep-link initial load**: if
+ * the user lands with a native-anchor hash (`#hero`) AND the server
+ * has a selected file, the directive leaves the URL on `#hero` (case
+ * b) — URL and server state diverge until the user navigates. This
+ * is intentional: popovers/anchors aren't ours to overwrite. The
+ * next user action that triggers a server render will re-sync only
+ * once URL and state share a deep-link hash.
  */
 export function handleURLHashDirective(
   rootElement: Element,

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1074,13 +1074,18 @@ export function teardownAreaSelectForRoot(rootElement: Element): void {
 // sweep (isConnected check).
 //
 // Module-level singleton: shared across all LiveTemplateClient
-// instances in the window. If two clients ever arm the same element
-// (rare — usually clients have disjoint roots), each gets its own
-// entry. On hashchange, the shared window listener iterates the map
-// and dispatches through every entry's own send — so a multi-client
-// page sees each client receive its hash event. Teardown is scoped
-// per root via teardownURLHashForRoot, so clients don't tear down
-// each other's listeners.
+// instances in the window. Two clients arming DIFFERENT elements
+// each get their own entry; the shared window hashchange listener
+// iterates the map and dispatches through every armed entry's own
+// send, so a multi-client page sees each client receive its hash
+// event. Teardown is scoped per root via teardownURLHashForRoot, so
+// clients don't tear down each other's listeners.
+//
+// Same-element multi-arm is "last writer wins": the Map key is the
+// element, so a second client arming the same element runs the
+// existing entry's cleanup() and replaces it. The first client's
+// send is orphaned. This matches area-select's behavior and is fine
+// for the documented single-arm-per-element contract.
 const urlHashArmed = new Map<Element, URLHashEntry>();
 
 // urlHashWindowListener is the single window-level `hashchange`
@@ -1167,6 +1172,14 @@ type URLHashSendFn = (
  * is intentional: popovers/anchors aren't ours to overwrite. The
  * next user action that triggers a server render will re-sync only
  * once URL and state share a deep-link hash.
+ *
+ * **Path-only deep links require an extension**: the
+ * `looksLikeDeepLinkHash` heuristic dispatches only hashes
+ * containing `:`, `/`, or `.`. Extension-less root files
+ * (`#Makefile`, `#Dockerfile`, `#LICENSE`) won't dispatch as
+ * path-only deep links — use the line form (`#Makefile:L1`)
+ * instead. The trade-off favours not clobbering native-anchor
+ * machinery for single-token hashes.
  */
 export function handleURLHashDirective(
   rootElement: Element,
@@ -1344,15 +1357,21 @@ function mirrorDataAttrToLocation(entry: URLHashEntry, dataHash: string): void {
 
 // warnIfUnencodedHash flags `data-lvt-url-hash` values containing
 // characters that should be percent-encoded (raw space, `<`, `>`,
-// `"`, ``` ` ```, `#`). The directive writes the hash verbatim into
-// `pushState`/`replaceState`, so an unencoded value will silently
-// produce a malformed URL — `location.hash` reads back differently
-// from what was set. Cheap dev-time guard against a server-side
-// contract slip; dedupes by value to avoid log spam.
+// `"`, ``` ` ```, `#`, `[`, `]`, `%`). The directive writes the
+// hash verbatim into `pushState`/`replaceState`, so an unencoded
+// value will silently produce a malformed URL — `location.hash`
+// reads back differently from what was set. Cheap dev-time guard
+// against a server-side contract slip; dedupes by value to avoid
+// log spam.
+//
+// `%` is included because a raw `%` not followed by two hex digits
+// is itself a percent-encoding error. The check is a heuristic
+// (won't catch every malformed escape), but covers the common
+// "forgot to encode" cases.
 const urlHashUnencodedWarned = new Set<string>();
 function warnIfUnencodedHash(hash: string): void {
   if (!hash || urlHashUnencodedWarned.has(hash)) return;
-  if (/[ <>"`#]/.test(hash)) {
+  if (/[ <>"`#\[\]]/.test(hash) || /%(?![0-9A-Fa-f]{2})/.test(hash)) {
     urlHashUnencodedWarned.add(hash);
     console.warn(
       `lvt-fx:url-hash: data-lvt-url-hash="${hash}" contains characters that should be percent-encoded. The directive writes it verbatim into history.pushState/replaceState; malformed URLs result. Server-side FormatHash (or equivalent) should percent-escape path segments and target ids before serialization.`

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1207,21 +1207,30 @@ export function handleURLHashDirective(
     if (existing) existing.cleanup();
     const entry = attachURLHash(el, action, send);
     urlHashArmed.set(el, entry);
-    // First-arm sync: if the server has a hash to mirror, write it
-    // before reacting to the existing location.hash. If location.hash
-    // is a deep-link-shaped hash AND differs from the server's
-    // data-attr, dispatch (URL "wins" on initial load so deep-linked
-    // URLs work). Non-deep-link hashes (e.g. an element-id anchor
-    // setupHashLink owns) are left to their owning machinery.
+    // First-arm sync: three cases, in priority order.
     const initialLocation = window.location.hash.replace(/^#/, "");
     if (
       initialLocation &&
       initialLocation !== dataHash &&
       looksLikeDeepLinkHash(initialLocation)
     ) {
+      // (a) URL has a deep-link hash that differs from server state.
+      // URL "wins" on initial load — dispatch so the server can
+      // reconcile, and seed currentDataHash so the converging render
+      // doesn't try to mirror over the user's URL.
       entry.currentDataHash = initialLocation;
       send({ action, data: { hash: initialLocation } });
+    } else if (initialLocation && !looksLikeDeepLinkHash(initialLocation)) {
+      // (b) URL has a non-deep-link hash (e.g. `#hero` opening a
+      // popover, or a native heading anchor). Leave it alone — it
+      // belongs to other machinery (setupHashLink, native scroll).
+      // Seed currentDataHash so a later mirror sees the data-attr
+      // as the baseline to compare against, and only writes when
+      // the user navigates away from the popover/anchor.
+      entry.currentDataHash = dataHash;
     } else {
+      // (c) URL is empty (or already matches the server). Mirror the
+      // server's hash into the URL if any.
       mirrorDataAttrToLocation(entry, dataHash);
     }
   }
@@ -1256,10 +1265,23 @@ export function teardownURLHashForRoot(rootElement: Element): void {
 // any other change is a target-only update (line scroll / anchor
 // scroll) and gets replaceState. Updates entry.currentDataHash so a
 // subsequent render with the same data-attr no-ops.
+//
+// Empty-dataHash special case: if the server transitions FROM a
+// selected file TO no-selection (state.URLHash() returns ""), we
+// would otherwise wipe location.hash entirely — including hashes the
+// directive doesn't own (a popover #hero the user opened during the
+// session). To stay safe, only clear when the URL currently holds a
+// deep-link-shaped hash; non-deep-link hashes are left alone.
 function mirrorDataAttrToLocation(entry: URLHashEntry, dataHash: string): void {
   if (entry.currentDataHash === dataHash) return;
   const currentLocation = window.location.hash.replace(/^#/, "");
   if (currentLocation === dataHash) {
+    entry.currentDataHash = dataHash;
+    return;
+  }
+  if (dataHash === "" && !looksLikeDeepLinkHash(currentLocation)) {
+    // Server cleared the hash AND the URL is on something not ours
+    // (popover id, native anchor). Don't clobber.
     entry.currentDataHash = dataHash;
     return;
   }
@@ -1280,6 +1302,14 @@ function mirrorDataAttrToLocation(entry: URLHashEntry, dataHash: string): void {
 // anchors, dialog/popover/details ids, etc.). Deep-link hashes always
 // contain at least one of: `:` (target separator), `/` (nested path),
 // or `.` (file extension). Empty → false.
+//
+// False positives are possible but cheap. A heading id like
+// `#v1.0.0`, `#menu/item`, or `#key:value` matches this heuristic
+// and will dispatch the action — but the consuming server is
+// expected to no-op on hashes whose path doesn't resolve to a known
+// file (prereview's SetURLHash does, via the loadDiffCached failure
+// path). The cost is one wasted roundtrip per false positive, which
+// is acceptable for the alternative of missing real deep links.
 function looksLikeDeepLinkHash(hash: string): boolean {
   if (!hash) return false;
   return hash.includes(":") || hash.includes("/") || hash.includes(".");

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -15,7 +15,9 @@ import {
   handleScrollDirectives,
   handleShadowRootHydration,
   handleToastDirectives,
+  handleURLHashDirective,
   teardownAreaSelectForRoot,
+  teardownURLHashForRoot,
   teardownAutoClickTimers,
   setupToastClickOutside,
   setupFxDOMEventTriggers,
@@ -628,6 +630,7 @@ export class LiveTemplateClient {
       teardownScrollAway(this.wrapperElement);
       teardownSpy(this.wrapperElement);
       teardownAreaSelectForRoot(this.wrapperElement);
+      teardownURLHashForRoot(this.wrapperElement);
     }
     this.resetSessionState();
   }
@@ -1841,6 +1844,12 @@ export class LiveTemplateClient {
     // send the event delegator uses so the WS/HTTP routing is
     // identical to a normal action.
     handleAreaSelectDirectives(element, (message) => this.send(message));
+    // url-hash bridges server state ↔ location.hash. Same send-callback
+    // wiring as area-select: the directive needs to dispatch a server
+    // action on user-driven hashchange events (anchor click, address-bar
+    // edit, back-button) and read the latest server-rendered hash from
+    // `data-lvt-url-hash` on every render.
+    handleURLHashDirective(element, (message) => this.send(message));
     // Hydrate any server-emitted Declarative Shadow DOM templates that
     // morphdom inserted via DOM APIs (which don't auto-activate them).
     // Cheap when no templates are present (one querySelectorAll).

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -597,6 +597,16 @@ export class LiveTemplateClient {
     setupInvokerPolyfill();
     setupHashLink();
 
+    // url-hash directive needs an initial-load arm here (not just in
+    // updateDOM's FIRE-ON-CHANGE block) because page load → no
+    // updateDOM call → directive never arms → a `#path:L4` URL never
+    // dispatches setURLHash. Subsequent state changes route through
+    // the FIRE-ON-CHANGE block's call site, which keeps the data-attr
+    // mirror in sync after server re-renders.
+    if (this.wrapperElement) {
+      handleURLHashDirective(this.wrapperElement, (message) => this.send(message));
+    }
+
     // Set up lifecycle listeners for lvt-fx:*:on:{lifecycle} attributes
     setupFxLifecycleListeners(this.wrapperElement);
 

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -603,6 +603,13 @@ export class LiveTemplateClient {
     // dispatches setURLHash. Subsequent state changes route through
     // the FIRE-ON-CHANGE block's call site, which keeps the data-attr
     // mirror in sync after server re-renders.
+    //
+    // Transport is reliable at this point: `connect()` above was
+    // awaited, so either the WebSocket is OPEN (`useHTTP=false`,
+    // readyState=1) or the HTTP fallback is wired (`useHTTP=true`).
+    // `this.send` covers both paths plus a `readyState!==1 && WS
+    // available` fallback that posts via HTTP, so the initial-arm
+    // dispatch always reaches the server — no "best-effort" caveat.
     if (this.wrapperElement) {
       handleURLHashDirective(this.wrapperElement, (message) => this.send(message));
     }

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -2214,6 +2214,25 @@ describe("handleURLHashDirective", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it("teardown via a descendant root cleans up a body-armed entry", () => {
+    // Pin the body-ancestor branch of teardownURLHashForRoot: in
+    // production, livetemplate calls teardown with the wrapper div
+    // (inside body) as the root, but the directive lives on body.
+    // The teardown must clean up the body entry too — otherwise
+    // disconnect/reconnect cycles leak listeners.
+    mountBody("README.md:L4");
+    const wrapper = document.createElement("div");
+    document.body.appendChild(wrapper);
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+
+    teardownURLHashForRoot(wrapper);
+
+    window.history.replaceState(null, "", "#OTHER.md:L1");
+    window.dispatchEvent(new Event("hashchange"));
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it("sweep cleans up entries whose attribute was removed by a server diff", () => {
     mountBody("README.md:L4");
     const send = jest.fn();
@@ -2250,6 +2269,42 @@ describe("handleURLHashDirective", () => {
     const send = jest.fn();
     handleURLHashDirective(document.body, send);
     expect(send).not.toHaveBeenCalled();
+    expect(window.location.hash).toBe("#hero");
+  });
+
+  it("on initial load with non-deep-link hash AND non-empty server data-attr, leaves the URL alone", () => {
+    // The browser navigated to `#hero` (a popover id, say). The
+    // server happens to have selected a default file, so the data-
+    // attr is non-empty. Before the fix, the else-branch mirrored
+    // the server's hash into the URL and silently closed the
+    // popover. After the fix, the URL is left alone — popover
+    // wins.
+    window.history.replaceState(null, "", "#hero");
+    mountBody("README.md");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(send).not.toHaveBeenCalled();
+    expect(window.location.hash).toBe("#hero");
+  });
+
+  it("server clearing the data-attr does NOT wipe a non-deep-link URL hash", () => {
+    // Server first has README.md selected → URL becomes
+    // `#README.md`. Then the user opens a popover whose id is
+    // `#hero` (URL is now `#hero`). Then the server transitions to
+    // no-selection (e.g. ClearSelection) and renders data-attr="".
+    // The directive must not clobber the popover hash.
+    mountBody("README.md");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#README.md");
+
+    // User navigates to a popover-shaped hash (simulated).
+    window.history.replaceState(null, "", "#hero");
+
+    // Server clears state → empty data-attr.
+    document.body.setAttribute("data-lvt-url-hash", "");
+    handleURLHashDirective(document.body, send);
+
     expect(window.location.hash).toBe("#hero");
   });
 

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -2302,6 +2302,43 @@ describe("handleURLHashDirective", () => {
     expect(window.location.hash).toBe("#hero");
   });
 
+  it("server changing selection while a non-deep-link URL hash is open does NOT clobber", () => {
+    // Round-8 bot edge case: case (b) leaves the URL on #hero and
+    // seeds currentDataHash = dataHash. If the server then pushes a
+    // DIFFERENT selection (rare in prereview — server state changes
+    // only on user action — but possible via cross-tab sync or a
+    // server-driven update), the mirror's path-comparison would
+    // have written the new file's hash and clobbered #hero. Fixed
+    // by generalising the non-deep-link-URL guard to cover any
+    // dataHash, not just empty.
+    window.history.replaceState(null, "", "#hero");
+    mountBody("README.md");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#hero");
+
+    // Server pushes a different selection — URL must NOT change.
+    document.body.setAttribute("data-lvt-url-hash", "OTHER.md");
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#hero");
+  });
+
+  it("server clearing the data-attr DOES clear a deep-link URL hash (deliberate, symmetric)", () => {
+    // Symmetric to "non-deep-link is never clobbered": if the URL
+    // is a deep-link we own AND the server transitions to
+    // no-selection, the URL should clear. Pin this as deliberate
+    // so a future refactor doesn't accidentally make all
+    // empty-dataHash mirrors no-op.
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#README.md:L4");
+
+    document.body.setAttribute("data-lvt-url-hash", "");
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("");
+  });
+
   it("server clearing the data-attr does NOT wipe a non-deep-link URL hash", () => {
     // Server first has README.md selected → URL becomes
     // `#README.md`. Then the user opens a popover whose id is

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -2417,6 +2417,31 @@ describe("handleURLHashDirective", () => {
     );
   });
 
+  it.each([
+    ["bracket [", "path[v1].md"],
+    ["bracket ]", "list]item.md"],
+    ["raw percent", "50%off.md"],
+    ["raw quote", `name".md`],
+    ["raw less-than", "x<y.md"],
+  ])("warns on %s", (_label, hash) => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    mountBody(hash);
+    handleURLHashDirective(document.body, jest.fn());
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("should be percent-encoded")
+    );
+  });
+
+  it("valid percent-encoded sequence does NOT warn", () => {
+    // `%20` is a properly percent-encoded space — no warn.
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    mountBody("path%20with%20space.md");
+    handleURLHashDirective(document.body, jest.fn());
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("should be percent-encoded")
+    );
+  });
+
   it("data-attr update unchanged from last mirror is a no-op (no history pollution)", () => {
     mountBody("README.md:L4");
     const send = jest.fn();

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -2090,6 +2090,21 @@ describe("handleURLHashDirective", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it("on first arm with empty URL, uses replaceState (not pushState) — Back must not loop", () => {
+    // Bug pinned: when initial URL is empty AND server has a hash,
+    // the mirror step uses pushState by the path-comparison rule
+    // ("" → "README.md" is a path change). That leaves a history
+    // entry where Back lands the user on `url-without-hash`, which
+    // re-arms the directive, which pushes the same hash again. Loop.
+    // Fix: empty currentLocation → always replaceState.
+    const lengthBefore = window.history.length;
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#README.md:L4");
+    expect(window.history.length).toBe(lengthBefore);
+  });
+
   it("on first arm with non-empty location.hash differing from data-attr, dispatches the action with the URL hash", () => {
     window.history.replaceState(null, "", "#README.md:L4");
     mountBody(""); // server hasn't seen the hash yet
@@ -2306,6 +2321,24 @@ describe("handleURLHashDirective", () => {
     handleURLHashDirective(document.body, send);
 
     expect(window.location.hash).toBe("#hero");
+  });
+
+  it("user clearing the URL hash (hashchange to empty) does NOT dispatch — server stays source of truth", () => {
+    // The directive treats the server as source of truth for
+    // "what's selected". An empty location.hash is "user navigated
+    // away from the hash" but not "deselect". Deselect happens via
+    // in-app affordances that flow through the server, which then
+    // emits an empty data-attr.
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    send.mockClear();
+
+    // User clears the URL bar.
+    window.history.replaceState(null, "", window.location.pathname);
+    window.dispatchEvent(new Event("hashchange"));
+
+    expect(send).not.toHaveBeenCalled();
   });
 
   it("ignores plain element-id hashes on hashchange", () => {

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -11,6 +11,7 @@ import {
   teardownURLHashForRoot,
   teardownAutoClickTimers,
   __resetAnimatedElementsForTesting,
+  __resetURLHashUnencodedWarnedForTesting,
 } from "../dom/directives";
 
 describe("handleScrollDirectives", () => {
@@ -2070,6 +2071,10 @@ describe("handleURLHashDirective", () => {
     // Reset URL hash without touching history (the directive uses
     // pushState/replaceState; jsdom keeps them isolated per test).
     window.history.replaceState(null, "", window.location.pathname);
+    // The unencoded-hash warning dedupe Set is module-level and
+    // outlives a single test; reset so a hash value reused across
+    // tests still warns.
+    __resetURLHashUnencodedWarnedForTesting();
     jest.restoreAllMocks();
   });
 

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -2323,6 +2323,39 @@ describe("handleURLHashDirective", () => {
     expect(window.location.hash).toBe("#hero");
   });
 
+  it("case-(b) + user clears URL: URL stays empty while server keeps its selection (deliberate divergence)", () => {
+    // Load with a popover-shaped hash, server has a file selected.
+    // Case (b) seeds entry.currentDataHash with the server's value.
+    window.history.replaceState(null, "", "#hero");
+    mountBody("README.md");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#hero");
+
+    // User clears the URL bar.
+    window.history.replaceState(null, "", window.location.pathname);
+    window.dispatchEvent(new Event("hashchange"));
+    expect(send).not.toHaveBeenCalled();
+
+    // Server re-renders with the SAME selection (data-attr unchanged).
+    // The early-exit guard (currentDataHash === dataHash) means we
+    // never mirror — URL stays empty, server stays on README.md.
+    // This divergence is intentional: case (b) said "the URL isn't
+    // ours, leave it alone", and a user clearing the URL doesn't
+    // change that — they're still navigating outside our turf.
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("");
+    expect(send).not.toHaveBeenCalled();
+
+    // Convergence only happens when the user takes an in-app action
+    // that changes server state (e.g. SelectFile to OTHER.md): the
+    // data-attr now differs from currentDataHash and the mirror
+    // step writes the new hash.
+    document.body.setAttribute("data-lvt-url-hash", "OTHER.md");
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#OTHER.md");
+  });
+
   it("user clearing the URL hash (hashchange to empty) does NOT dispatch — server stays source of truth", () => {
     // The directive treats the server as source of truth for
     // "what's selected". An empty location.hash is "user navigated

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -2241,6 +2241,31 @@ describe("handleURLHashDirective", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it("ignores plain element-id hashes on initial load (no dispatch, no URL clobber)", () => {
+    // Anchors like `#hero` (no `:`, no `/`, no `.`) belong to native
+    // anchor / dialog / popover machinery — the directive must NOT
+    // dispatch for them or it would race against setupHashLink.
+    window.history.replaceState(null, "", "#hero");
+    mountBody("");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(send).not.toHaveBeenCalled();
+    expect(window.location.hash).toBe("#hero");
+  });
+
+  it("ignores plain element-id hashes on hashchange", () => {
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    send.mockClear();
+
+    // User clicks an HTML anchor link (e.g. inside the TOC overlay).
+    window.history.replaceState(null, "", "#some-section");
+    window.dispatchEvent(new Event("hashchange"));
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it("data-attr update unchanged from last mirror is a no-op (no history pollution)", () => {
     mountBody("README.md:L4");
     const send = jest.fn();

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -5,8 +5,10 @@ import {
   handleAreaSelectDirectives,
   handleAutoClickDirectives,
   handleShadowRootHydration,
+  handleURLHashDirective,
   setupFxDOMEventTriggers,
   teardownAreaSelectForRoot,
+  teardownURLHashForRoot,
   teardownAutoClickTimers,
   __resetAnimatedElementsForTesting,
 } from "../dom/directives";
@@ -2051,5 +2053,213 @@ describe("handleAreaSelectDirectives", () => {
     // Exactly one overlay at most over the whole sequence (the second
     // drag's) — never two.
     expect(document.querySelectorAll(".lvt-area-select-overlay").length).toBe(0);
+  });
+});
+
+describe("handleURLHashDirective", () => {
+  // The directive is a module-level singleton (a Map of armed elements
+  // plus a single window-level hashchange listener), so every test
+  // must tear down to avoid bleed between cases.
+  afterEach(() => {
+    teardownURLHashForRoot(document.body);
+    document.body.innerHTML = "";
+    // Body persists across tests (innerHTML only resets descendants);
+    // wipe attributes the previous test set on body itself.
+    document.body.removeAttribute("lvt-fx:url-hash");
+    document.body.removeAttribute("data-lvt-url-hash");
+    // Reset URL hash without touching history (the directive uses
+    // pushState/replaceState; jsdom keeps them isolated per test).
+    window.history.replaceState(null, "", window.location.pathname);
+    jest.restoreAllMocks();
+  });
+
+  function mountBody(dataHash: string, action = "setURLHash"): HTMLElement {
+    const body = document.body;
+    body.setAttribute("lvt-fx:url-hash", action);
+    body.setAttribute("data-lvt-url-hash", dataHash);
+    return body;
+  }
+
+  it("on first arm with empty location.hash and non-empty data-attr, mirrors data-attr into location.hash", () => {
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#README.md:L4");
+    // No dispatch because the URL didn't drive the change — the server
+    // already knew the state (the data-attr came FROM the server).
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("on first arm with non-empty location.hash differing from data-attr, dispatches the action with the URL hash", () => {
+    window.history.replaceState(null, "", "#README.md:L4");
+    mountBody(""); // server hasn't seen the hash yet
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0]).toEqual({
+      action: "setURLHash",
+      data: { hash: "README.md:L4" },
+    });
+    // The URL is not rewritten — the server's next render will produce
+    // the canonical data-attr, and we'll converge then.
+    expect(window.location.hash).toBe("#README.md:L4");
+  });
+
+  it("on first arm with empty location.hash and empty data-attr, no-op (no dispatch, no URL write)", () => {
+    mountBody("");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(send).not.toHaveBeenCalled();
+    expect(window.location.hash).toBe("");
+  });
+
+  it("mirrors data-attr change to location.hash via replaceState when path component is unchanged", () => {
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#README.md:L4");
+    const lengthBefore = window.history.length;
+
+    // Server re-render: same file, different line.
+    document.body.setAttribute("data-lvt-url-hash", "README.md:L8");
+    handleURLHashDirective(document.body, send);
+
+    expect(window.location.hash).toBe("#README.md:L8");
+    // replaceState keeps history depth flat: jsdom's history.length
+    // increments only on pushState, not replaceState.
+    expect(window.history.length).toBe(lengthBefore);
+  });
+
+  it("mirrors data-attr change to location.hash via pushState when path component changes", () => {
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    const lengthBefore = window.history.length;
+
+    // Server re-render: different file.
+    document.body.setAttribute("data-lvt-url-hash", "OTHER.md:L1");
+    handleURLHashDirective(document.body, send);
+
+    expect(window.location.hash).toBe("#OTHER.md:L1");
+    expect(window.history.length).toBe(lengthBefore + 1);
+  });
+
+  it("on hashchange (user clicks a permalink), dispatches the action with the new hash", () => {
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    send.mockClear();
+
+    // Simulate a user-driven hash change: set location.hash AND
+    // synchronously fire the hashchange event. (jsdom queues
+    // hashchange asynchronously when you assign location.hash, so we
+    // dispatch manually to keep the test deterministic — same pattern
+    // as area-select's synthetic pointer events.)
+    window.history.replaceState(null, "", "#OTHER.md:L2");
+    window.dispatchEvent(new Event("hashchange"));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0]).toEqual({
+      action: "setURLHash",
+      data: { hash: "OTHER.md:L2" },
+    });
+  });
+
+  it("idempotent re-arm with the same action does NOT add history entries", () => {
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    const lengthAfterArm = window.history.length;
+
+    // Re-call with no data-attr change.
+    handleURLHashDirective(document.body, send);
+    handleURLHashDirective(document.body, send);
+    handleURLHashDirective(document.body, send);
+
+    expect(window.history.length).toBe(lengthAfterArm);
+    expect(window.location.hash).toBe("#README.md:L4");
+  });
+
+  it("updateSend swaps the captured transport so a reconnect rebuilds dispatching", () => {
+    mountBody("README.md:L4");
+    const firstSend = jest.fn();
+    handleURLHashDirective(document.body, firstSend);
+    firstSend.mockClear();
+
+    // Re-arm with a NEW send (simulating a reconnect that rebuilt the
+    // transport).
+    const secondSend = jest.fn();
+    handleURLHashDirective(document.body, secondSend);
+
+    // hashchange now should route through the second send only.
+    window.history.replaceState(null, "", "#OTHER.md:L1");
+    window.dispatchEvent(new Event("hashchange"));
+    expect(firstSend).not.toHaveBeenCalled();
+    expect(secondSend).toHaveBeenCalledTimes(1);
+    expect(secondSend.mock.calls[0][0].data).toEqual({ hash: "OTHER.md:L1" });
+  });
+
+  it("teardown removes the armed element AND its hashchange listener", () => {
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#README.md:L4");
+
+    teardownURLHashForRoot(document.body);
+
+    // After teardown, a hashchange does NOT dispatch — the window
+    // listener was removed when the armed map emptied.
+    window.history.replaceState(null, "", "#OTHER.md:L1");
+    window.dispatchEvent(new Event("hashchange"));
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("sweep cleans up entries whose attribute was removed by a server diff", () => {
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+
+    // Server diff removed the directive.
+    document.body.removeAttribute("lvt-fx:url-hash");
+    document.body.removeAttribute("data-lvt-url-hash");
+    handleURLHashDirective(document.body, send);
+
+    // The window listener should be gone now too — no dispatch.
+    window.history.replaceState(null, "", "#OTHER.md:L1");
+    window.dispatchEvent(new Event("hashchange"));
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("warns and skips when lvt-fx:url-hash is present but empty", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    document.body.setAttribute("lvt-fx:url-hash", "");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("lvt-fx:url-hash requires an action name")
+    );
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("data-attr update unchanged from last mirror is a no-op (no history pollution)", () => {
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+
+    // User clicks a permalink anchor → location.hash changes to the
+    // same value the data-attr already had. The hashchange dispatch
+    // updates currentDataHash to the same value; subsequent renders
+    // with the same data-attr should still no-op (no extra history
+    // entries when the server echoes back the same hash).
+    window.history.replaceState(null, "", "#OTHER.md:L9");
+    window.dispatchEvent(new Event("hashchange"));
+    const lengthBefore = window.history.length;
+
+    send.mockClear();
+    document.body.setAttribute("data-lvt-url-hash", "OTHER.md:L9");
+    handleURLHashDirective(document.body, send);
+
+    expect(window.history.length).toBe(lengthBefore);
+    expect(window.location.hash).toBe("#OTHER.md:L9");
   });
 });

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -2387,6 +2387,36 @@ describe("handleURLHashDirective", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it("preserves history.state across the mirror write (doesn't clobber co-tenant SPA state)", () => {
+    // Co-tenant code stores something in history.state — e.g. scroll
+    // position or modal flag. Our directive's push/replaceState must
+    // pass that state through, not overwrite with null.
+    window.history.replaceState({ scroll: 42, modal: "open" }, "", window.location.pathname);
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#README.md:L4");
+    expect(window.history.state).toEqual({ scroll: 42, modal: "open" });
+
+    // Same on a path-change pushState path.
+    document.body.setAttribute("data-lvt-url-hash", "OTHER.md");
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#OTHER.md");
+    expect(window.history.state).toEqual({ scroll: 42, modal: "open" });
+  });
+
+  it("warns when data-lvt-url-hash contains characters that should be percent-encoded", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    // Note: jsdom's location.hash setter percent-encodes spaces, so
+    // we mount the directive with a value containing a literal space
+    // and expect a warn before the directive writes the URL.
+    mountBody("path with space.md");
+    handleURLHashDirective(document.body, jest.fn());
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("should be percent-encoded")
+    );
+  });
+
   it("data-attr update unchanged from last mirror is a no-op (no history pollution)", () => {
     mountBody("README.md:L4");
     const send = jest.fn();

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -2344,6 +2344,26 @@ describe("handleURLHashDirective", () => {
     expect(window.location.hash).toBe("");
   });
 
+  it("deselection (deep-link → empty) uses pushState — Back returns to the selection (deliberate)", () => {
+    // Pin the path-comparison branch's behavior for the deselect
+    // case: server transitions `data-lvt-url-hash` from a selected
+    // file to "", path comparison says oldPath !== newPath (one is
+    // empty), the mirror uses pushState. That leaves a history
+    // entry so Back returns the user to their prior selection.
+    // Intentional — matches the file-switch UX.
+    mountBody("README.md:L4");
+    const send = jest.fn();
+    handleURLHashDirective(document.body, send);
+    expect(window.location.hash).toBe("#README.md:L4");
+    const lengthBeforeDeselect = window.history.length;
+
+    document.body.setAttribute("data-lvt-url-hash", "");
+    handleURLHashDirective(document.body, send);
+
+    expect(window.location.hash).toBe("");
+    expect(window.history.length).toBe(lengthBeforeDeselect + 1);
+  });
+
   it("server clearing the data-attr does NOT wipe a non-deep-link URL hash", () => {
     // Server first has README.md selected → URL becomes
     // `#README.md`. Then the user opens a popover whose id is


### PR DESCRIPTION
## Summary

Adds the `lvt-fx:url-hash=\"<actionName>\"` + `data-lvt-url-hash=\"<hash>\"` directive pair that mirrors a server-rendered hash into `location.hash` (pushState on file change, replaceState on line/anchor change) and dispatches the action on user-driven hashchange / initial load.

Built for prereview's deep-link issue ([livetemplate/prereview#7](https://github.com/livetemplate/prereview/issues/7)) — first cross-repo PR. The companion prereview PR will follow once this lands and gets released.

Design highlights:
- One shared window-level `hashchange` listener (registered on first arm, removed when the armed map empties); each entry stores its own `send` so multi-arm dispatch is deterministic
- Uses `pushState`/`replaceState` for state→URL — those don't fire `hashchange`, avoiding the obvious infinite loop
- Accepts placement on `<body>` (where livetemplate-go's `<div data-lvt-id>` wrapper sits below body, so `querySelector(rootElement, …)` would otherwise miss it)
- Initial-arm dispatch runs from `setup()` so a page loaded with a hash converges before the first `updateDOM` would
- Discriminates deep-link hashes (`:`, `/`, or `.` present) from native anchor / dialog / popover ids — leaves those to `setupHashLink`'s existing machinery

## Test plan

- [x] Unit tests (`npm test -- --testPathPatterns directives`): 109 new + existing, all pass
- [x] Full client suite: 657 tests pass
- [ ] Cross-repo verification in the prereview PR (deep links, link rewriting, back-button, native-anchor escape hatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)