### PR TITLE
feat: data-lvt-redact — Preview-mode field redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emits. Substitution is scoped to the attribute, never a free text scan, so
   user-posted content can't trigger it. Purely additive.
 
+  Known follow-ups (tracked, not blocking): no `clearRedactedValues` teardown yet
+  (a consuming app is expected to clear its preview-scope keys on session end —
+  e.g. checklistkit clears on preview-save); the `resolveScope` fallback to
+  `"lvt-unknown"` can collide across two wrapper-less pages on one origin
+  (livetemplate pages always carry `data-lvt-id` in practice).
+
 ## [v0.11.7] - 2026-05-30
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changes
+### Added
 
-- feat: data-lvt-redact — Preview-mode field redaction. Inputs tagged
+- feat: data-lvt-redact — Preview-mode field redaction. Elements tagged
   `data-lvt-redact="<field>"` keep their value in browser localStorage and send a
-  `{redacted:true,field}` sentinel instead; `[[field]]` placeholder tokens (emitted
-  by the Go `lvt.Redact` helper) are substituted back from localStorage before each
-  DOM patch. Purely additive — apps without the attribute behave identically.
+  `{redacted:true,field}` sentinel instead (both the JSON and multipart send paths);
+  on render the client fills `[data-lvt-redact]` elements from localStorage —
+  `.value` for inputs, `textContent` for the `<span>` the Go `lvt.Redact` helper
+  emits. Substitution is scoped to the attribute, never a free text scan, so
+  user-posted content can't trigger it. Purely additive.
 
 ## [v0.11.7] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to @livetemplate/client will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changes
+
+- feat: data-lvt-redact — Preview-mode field redaction. Inputs tagged
+  `data-lvt-redact="<field>"` keep their value in browser localStorage and send a
+  `{redacted:true,field}` sentinel instead; `[[field]]` placeholder tokens (emitted
+  by the Go `lvt.Redact` helper) are substituted back from localStorage before each
+  DOM patch. Purely additive — apps without the attribute behave identically.
+
 ## [v0.11.7] - 2026-05-30
 
 ### Changes

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -1,4 +1,5 @@
 import { debounce, throttle } from "../utils/rate-limit";
+import { redactActionData, redactFormData } from "./redact";
 import { lvtSelector } from "../utils/lvt-selector";
 import { executeAction, resolveTarget, processElementInteraction, isDOMEventTrigger, type ReactiveAction } from "./reactive-attributes";
 import type { Logger } from "../utils/logger";
@@ -584,6 +585,11 @@ export class EventDelegator {
               // tier1FormData is only set when targetElement is a form.
               if (tier1FormData !== null) {
                 this.logger.debug("Tier 1 file upload detected, using HTTP fetch");
+                // Preview-mode redaction on the multipart path: a redacted field
+                // in a form that also has a file input would otherwise POST its
+                // raw value as a multipart field, bypassing the JSON redaction
+                // below. Redact the FormData before it leaves the browser.
+                redactFormData(targetElement, tier1FormData);
                 this.context.sendHTTPMultipart(
                   targetElement as HTMLFormElement,
                   action,
@@ -591,6 +597,12 @@ export class EventDelegator {
                 );
                 return;
               }
+
+              // Preview-mode redaction: persist any data-lvt-redact values to
+              // localStorage and replace them in the payload with a sentinel so
+              // the raw value never reaches the server. No-op when no element is
+              // tagged. Runs last so it sees the fully-built message.data.
+              redactActionData(targetElement, message.data);
 
               this.context.send(message);
               this.logger.debug("send() called");

--- a/dom/redact.ts
+++ b/dom/redact.ts
@@ -17,28 +17,17 @@
  *      transports: `redactActionData` for the JSON payload (WebSocket / HTTP-JSON)
  *      and `redactFormData` for the multipart file-upload path.
  *
- *   2. Incoming (hydrateRedactedTokens): before each DOM patch is applied, real
- *      values are substituted back in from localStorage — both into
- *      `input[data-lvt-redact]` element values and into `[[field]]` placeholder
- *      tokens in text content (the token the Go `lvt.Redact` helper emits).
+ *   2. Incoming (hydrateRedactedTokens): after each DOM patch, real values are
+ *      filled back into `[data-lvt-redact]` elements from localStorage — `.value`
+ *      for inputs, `textContent` for the <span> the Go `lvt.Redact` helper emits.
+ *      Substitution is scoped to the attribute, never a free text scan, so
+ *      user-posted content cannot trigger it.
  *
  * Values are namespaced by the page's `data-lvt-id` scope so two LiveTemplate
  * pages in the same origin don't collide.
  */
 
 const STORAGE_PREFIX = "lvt-redact";
-
-// Matches the placeholder token emitted by the Go `lvt.Redact(name)` helper.
-// Field names are word chars plus dot/hyphen (e.g. "tax_id", "address.line1").
-// The grammar is bracket-based, not angle-based: "<<name>>" is mangled by both
-// html/template's escaper and the browser's innerHTML parser (it reads "<name>"
-// as a tag), whereas "[[name]]" survives every context intact.
-//
-// The `g` flag carries `lastIndex` state, but it is only ever used with
-// String.prototype.replace (which resets lastIndex on each call), so the shared
-// module-level instance is safe. Do not switch to `.exec()` in a loop without
-// reconsidering this.
-const TOKEN_RE = /\[\[([\w.-]+)\]\]/g;
 
 export interface RedactOptions {
   /** Storage backend; defaults to window.localStorage. Injectable for tests. */
@@ -186,15 +175,11 @@ export function redactFormData(
 }
 
 /**
- * Substitute real values back into the rendered DOM. Call on the LIVE element
- * after the patch commits (redacted content tokens are static, so they only
- * exist on the committed DOM, never in an update patch).
- *
- * Handles two surfaces:
- *   - `input[data-lvt-redact]` (and textarea/select): sets `.value`.
- *   - `[[field]]` tokens in text nodes: replaces with the stored value.
- *
- * Reads are cached per call so repeated tokens cost one storage hit each.
+ * Fill every `[data-lvt-redact]` element from localStorage. Call on the LIVE
+ * element after the patch commits. Substitution is scoped to elements carrying
+ * the attribute — never a free text scan — so user-posted content can't trigger
+ * it. Value elements (input/textarea/select) get `.value`; others (the <span>
+ * the Go lvt.Redact helper emits) get `textContent`. Reads are cached per call.
  */
 export function hydrateRedactedTokens(root: Element, opts?: RedactOptions): void {
   const storage = getStorage(opts);
@@ -214,36 +199,20 @@ export function hydrateRedactedTokens(root: Element, opts?: RedactOptions): void
     return v;
   };
 
-  // 1. Tagged value elements. Skip the element the user is currently editing —
-  // overwriting .value mid-keystroke would clobber in-progress input (and the
-  // stored value may lag what they've typed since the last dispatch).
+  // Skip the element the user is currently editing — overwriting .value
+  // mid-keystroke would clobber in-progress input (and the stored value may lag
+  // what they've typed since the last dispatch).
   const active = root.ownerDocument?.activeElement ?? null;
   root.querySelectorAll?.("[data-lvt-redact]").forEach((el) => {
     if (el === active) return;
     const field = el.getAttribute("data-lvt-redact");
-    if (!field || !hasValue(el)) return;
+    if (!field) return;
     const v = read(field);
-    if (v !== null) el.value = v;
+    if (v === null) return;
+    if (hasValue(el)) {
+      el.value = v;
+    } else {
+      el.textContent = v;
+    }
   });
-
-  // 2. `[[field]]` tokens in text nodes. Walk only text nodes; never touches
-  // attributes or element structure, so morphdom still diffs normally.
-  const ownerDoc = root.ownerDocument;
-  if (!ownerDoc) return;
-  const walker = ownerDoc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-  const pending: Text[] = [];
-  for (let n = walker.nextNode(); n; n = walker.nextNode()) {
-    if (n.nodeValue && n.nodeValue.includes("[[")) {
-      pending.push(n as Text);
-    }
-  }
-  for (const textNode of pending) {
-    const replaced = textNode.nodeValue!.replace(TOKEN_RE, (whole, field: string) => {
-      const v = read(field);
-      return v !== null ? v : whole;
-    });
-    if (replaced !== textNode.nodeValue) {
-      textNode.nodeValue = replaced;
-    }
-  }
 }

--- a/dom/redact.ts
+++ b/dom/redact.ts
@@ -1,0 +1,236 @@
+/**
+ * Preview-mode field redaction.
+ *
+ * Some apps (e.g. a "try it before you sign up" preview) need sensitive field
+ * values — passport numbers, tax IDs, draft answers — to stay in the visitor's
+ * browser and never reach the server. An element opts in with the
+ * `data-lvt-redact="<field>"` attribute:
+ *
+ *   <input name="passport" data-lvt-redact="passport">
+ *
+ * Two halves make the round-trip work:
+ *
+ *   1. Outgoing: before an action payload is sent, the raw value is written to
+ *      localStorage and replaced with a redact sentinel `{ redacted: true, field }`.
+ *      The server learns the field was provided (so it can keep structural state /
+ *      validate presence) but never sees the value. Two sinks cover the two send
+ *      transports: `redactActionData` for the JSON payload (WebSocket / HTTP-JSON)
+ *      and `redactFormData` for the multipart file-upload path.
+ *
+ *   2. Incoming (hydrateRedactedTokens): before each DOM patch is applied, real
+ *      values are substituted back in from localStorage — both into
+ *      `input[data-lvt-redact]` element values and into `[[field]]` placeholder
+ *      tokens in text content (the token the Go `lvt.Redact` helper emits).
+ *
+ * Values are namespaced by the page's `data-lvt-id` scope so two LiveTemplate
+ * pages in the same origin don't collide.
+ */
+
+const STORAGE_PREFIX = "lvt-redact";
+
+// Matches the placeholder token emitted by the Go `lvt.Redact(name)` helper.
+// Field names are word chars plus dot/hyphen (e.g. "tax_id", "address.line1").
+// The grammar is bracket-based, not angle-based: "<<name>>" is mangled by both
+// html/template's escaper and the browser's innerHTML parser (it reads "<name>"
+// as a tag), whereas "[[name]]" survives every context intact.
+const TOKEN_RE = /\[\[([\w.-]+)\]\]/g;
+
+export interface RedactOptions {
+  /** Storage backend; defaults to window.localStorage. Injectable for tests. */
+  storage?: Storage;
+  /** Namespace for stored values; defaults to the page's data-lvt-id. */
+  scope?: string;
+}
+
+/** The sentinel that replaces a redacted value in an outgoing action payload. */
+export interface RedactSentinel {
+  redacted: true;
+  field: string;
+}
+
+function storageKey(scope: string, field: string): string {
+  return `${STORAGE_PREFIX}:${scope}:${field}`;
+}
+
+/**
+ * Resolve the redaction namespace from the live DOM. Uses the wrapper's
+ * `data-lvt-id` so values are scoped per page. Falls back to "lvt-unknown"
+ * before the wrapper is wired (no value collides with a real scope).
+ */
+function resolveScope(ownerDocument: Document | null | undefined): string {
+  const doc = ownerDocument ?? (typeof document !== "undefined" ? document : null);
+  const wrapper = doc?.querySelector?.("[data-lvt-id]");
+  return wrapper?.getAttribute("data-lvt-id") || "lvt-unknown";
+}
+
+function getStorage(opts?: RedactOptions): Storage | null {
+  if (opts?.storage) return opts.storage;
+  try {
+    return typeof localStorage !== "undefined" ? localStorage : null;
+  } catch {
+    // localStorage can throw (disabled cookies, sandboxed iframe). Treat as
+    // absent — redaction degrades to a no-op rather than breaking the app.
+    return null;
+  }
+}
+
+/** Elements that carry a redactable value: <input>, <textarea>, <select>. */
+function hasValue(el: Element): el is HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement {
+  return (
+    el instanceof HTMLInputElement ||
+    el instanceof HTMLTextAreaElement ||
+    el instanceof HTMLSelectElement
+  );
+}
+
+/**
+ * Collect every redact-tagged value element at or under `actionElement`.
+ * `actionElement` itself is included when it is the tagged element (the
+ * single-input change/input event path), as well as any descendants (the
+ * form-submit path).
+ */
+function collectRedactInputs(actionElement: Element): Element[] {
+  const found: Element[] = [];
+  if (actionElement.hasAttribute("data-lvt-redact")) {
+    found.push(actionElement);
+  }
+  actionElement
+    .querySelectorAll?.("[data-lvt-redact]")
+    .forEach((el) => found.push(el));
+  return found;
+}
+
+/**
+ * Shared outgoing-redaction core. For every redact-tagged element at/under
+ * `actionElement`: persist its value to localStorage and hand the sink the
+ * payload key + sentinel to write. The sink differs per transport (a JSON
+ * payload object vs. a multipart FormData). No-op when storage is unavailable
+ * (the raw value would then flow to the server — callers that need a hard
+ * guarantee should feature-detect storage first).
+ */
+function applyOutgoingRedaction(
+  actionElement: Element,
+  opts: RedactOptions | undefined,
+  sink: (key: string, sentinel: RedactSentinel) => void,
+): void {
+  const storage = getStorage(opts);
+  if (!storage) return;
+  const scope = opts?.scope ?? resolveScope(actionElement.ownerDocument);
+
+  for (const el of collectRedactInputs(actionElement)) {
+    const field = el.getAttribute("data-lvt-redact");
+    if (!field || !hasValue(el)) continue;
+
+    try {
+      storage.setItem(storageKey(scope, field), el.value);
+    } catch {
+      // Quota exceeded or storage disabled mid-session: skip persisting. We do
+      // NOT fall through to leaking the raw value — the sink still writes the
+      // sentinel below, so the secret never leaves the browser.
+    }
+    // The payload key the server sees is the element's `name` (falling back to
+    // the redact field name, mirroring the event-delegation "name || value"
+    // convention).
+    const key = el.getAttribute("name") || field;
+    sink(key, { redacted: true, field });
+  }
+}
+
+/**
+ * Persist redacted values to localStorage and replace them in the outgoing
+ * JSON action payload with a sentinel. Mutates `data` in place. Used by the
+ * WebSocket / HTTP-JSON send path.
+ */
+export function redactActionData(
+  actionElement: Element,
+  data: Record<string, unknown>,
+  opts?: RedactOptions,
+): void {
+  applyOutgoingRedaction(actionElement, opts, (key, sentinel) => {
+    data[key] = sentinel;
+  });
+}
+
+/**
+ * Persist redacted values to localStorage and replace them in an outgoing
+ * multipart `FormData` with a JSON-encoded sentinel. Mutates `formData` in
+ * place. Used by the Tier-1 file-upload send path (sendHTTPMultipart), which
+ * bypasses the JSON payload — without this, a redacted field in a form that
+ * also has a file input would POST its raw value as a multipart field.
+ *
+ * FormData values are strings, so the sentinel is JSON-encoded; the server
+ * recognises a redacted multipart field by parsing the value and finding
+ * `redacted:true` (mirroring the object sentinel on the JSON path).
+ */
+export function redactFormData(
+  form: Element,
+  formData: FormData,
+  opts?: RedactOptions,
+): void {
+  applyOutgoingRedaction(form, opts, (key, sentinel) => {
+    formData.set(key, JSON.stringify(sentinel));
+  });
+}
+
+/**
+ * Substitute real values back into the rendered DOM. Call on the LIVE element
+ * after the patch commits (redacted content tokens are static, so they only
+ * exist on the committed DOM, never in an update patch).
+ *
+ * Handles two surfaces:
+ *   - `input[data-lvt-redact]` (and textarea/select): sets `.value`.
+ *   - `[[field]]` tokens in text nodes: replaces with the stored value.
+ *
+ * Reads are cached per call so repeated tokens cost one storage hit each.
+ */
+export function hydrateRedactedTokens(root: Element, opts?: RedactOptions): void {
+  const storage = getStorage(opts);
+  if (!storage) return;
+  const scope = opts?.scope ?? resolveScope(root.ownerDocument);
+
+  const cache = new Map<string, string | null>();
+  const read = (field: string): string | null => {
+    if (cache.has(field)) return cache.get(field)!;
+    let v: string | null = null;
+    try {
+      v = storage.getItem(storageKey(scope, field));
+    } catch {
+      v = null;
+    }
+    cache.set(field, v);
+    return v;
+  };
+
+  // 1. Tagged value elements. Skip the element the user is currently editing —
+  // overwriting .value mid-keystroke would clobber in-progress input (and the
+  // stored value may lag what they've typed since the last dispatch).
+  const active = root.ownerDocument?.activeElement ?? null;
+  root.querySelectorAll?.("[data-lvt-redact]").forEach((el) => {
+    if (el === active) return;
+    const field = el.getAttribute("data-lvt-redact");
+    if (!field || !hasValue(el)) return;
+    const v = read(field);
+    if (v !== null) el.value = v;
+  });
+
+  // 2. `[[field]]` tokens in text nodes. Walk only text nodes; never touches
+  // attributes or element structure, so morphdom still diffs normally.
+  const ownerDoc = root.ownerDocument;
+  if (!ownerDoc) return;
+  const walker = ownerDoc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const pending: Text[] = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+    if (n.nodeValue && n.nodeValue.includes("[[")) {
+      pending.push(n as Text);
+    }
+  }
+  for (const textNode of pending) {
+    const replaced = textNode.nodeValue!.replace(TOKEN_RE, (whole, field: string) => {
+      const v = read(field);
+      return v !== null ? v : whole;
+    });
+    if (replaced !== textNode.nodeValue) {
+      textNode.nodeValue = replaced;
+    }
+  }
+}

--- a/dom/redact.ts
+++ b/dom/redact.ts
@@ -33,6 +33,11 @@ const STORAGE_PREFIX = "lvt-redact";
 // The grammar is bracket-based, not angle-based: "<<name>>" is mangled by both
 // html/template's escaper and the browser's innerHTML parser (it reads "<name>"
 // as a tag), whereas "[[name]]" survives every context intact.
+//
+// The `g` flag carries `lastIndex` state, but it is only ever used with
+// String.prototype.replace (which resets lastIndex on each call), so the shared
+// module-level instance is safe. Do not switch to `.exec()` in a loop without
+// reconsidering this.
 const TOKEN_RE = /\[\[([\w.-]+)\]\]/g;
 
 export interface RedactOptions {
@@ -104,9 +109,14 @@ function collectRedactInputs(actionElement: Element): Element[] {
  * Shared outgoing-redaction core. For every redact-tagged element at/under
  * `actionElement`: persist its value to localStorage and hand the sink the
  * payload key + sentinel to write. The sink differs per transport (a JSON
- * payload object vs. a multipart FormData). No-op when storage is unavailable
- * (the raw value would then flow to the server — callers that need a hard
- * guarantee should feature-detect storage first).
+ * payload object vs. a multipart FormData).
+ *
+ * Redaction is fail-closed: the sentinel is ALWAYS written, regardless of
+ * whether persistence is possible. Persistence is the best-effort part — if
+ * localStorage is entirely unavailable (disabled / sandboxed iframe) or setItem
+ * throws (quota), the raw value is still dropped from the payload so it never
+ * reaches the server. The security guarantee (never leak) takes priority over
+ * the UX (being able to restore the value later).
  */
 function applyOutgoingRedaction(
   actionElement: Element,
@@ -114,19 +124,22 @@ function applyOutgoingRedaction(
   sink: (key: string, sentinel: RedactSentinel) => void,
 ): void {
   const storage = getStorage(opts);
-  if (!storage) return;
-  const scope = opts?.scope ?? resolveScope(actionElement.ownerDocument);
+  const scope = storage
+    ? (opts?.scope ?? resolveScope(actionElement.ownerDocument))
+    : null;
 
   for (const el of collectRedactInputs(actionElement)) {
     const field = el.getAttribute("data-lvt-redact");
     if (!field || !hasValue(el)) continue;
 
-    try {
-      storage.setItem(storageKey(scope, field), el.value);
-    } catch {
-      // Quota exceeded or storage disabled mid-session: skip persisting. We do
-      // NOT fall through to leaking the raw value — the sink still writes the
-      // sentinel below, so the secret never leaves the browser.
+    // Persist best-effort; both branches (no storage, setItem throws) fall
+    // through to the sentinel write below — never to leaking the raw value.
+    if (storage && scope) {
+      try {
+        storage.setItem(storageKey(scope, field), el.value);
+      } catch {
+        // Quota exceeded — value not persisted, but still redacted below.
+      }
     }
     // The payload key the server sees is the element's `name` (falling back to
     // the redact field name, mirroring the event-delegation "name || value"

--- a/dom/redact.ts
+++ b/dom/redact.ts
@@ -78,19 +78,17 @@ function hasValue(el: Element): el is HTMLInputElement | HTMLTextAreaElement | H
 }
 
 /**
- * Collect every redact-tagged value element at or under `actionElement`.
- * `actionElement` itself is included when it is the tagged element (the
- * single-input change/input event path), as well as any descendants (the
- * form-submit path).
+ * Collect every redact-tagged element at or under `root` — `root` itself when it
+ * carries the attribute, plus all descendants. Used by both the outgoing path
+ * (the action element may be the tagged input) and the incoming path (so a
+ * tagged root is hydrated, not just its children).
  */
-function collectRedactInputs(actionElement: Element): Element[] {
+function collectRedactElements(root: Element): Element[] {
   const found: Element[] = [];
-  if (actionElement.hasAttribute("data-lvt-redact")) {
-    found.push(actionElement);
+  if (root.hasAttribute("data-lvt-redact")) {
+    found.push(root);
   }
-  actionElement
-    .querySelectorAll?.("[data-lvt-redact]")
-    .forEach((el) => found.push(el));
+  root.querySelectorAll?.("[data-lvt-redact]").forEach((el) => found.push(el));
   return found;
 }
 
@@ -117,7 +115,7 @@ function applyOutgoingRedaction(
     ? (opts?.scope ?? resolveScope(actionElement.ownerDocument))
     : null;
 
-  for (const el of collectRedactInputs(actionElement)) {
+  for (const el of collectRedactElements(actionElement)) {
     const field = el.getAttribute("data-lvt-redact");
     if (!field || !hasValue(el)) continue;
 
@@ -203,16 +201,18 @@ export function hydrateRedactedTokens(root: Element, opts?: RedactOptions): void
   // mid-keystroke would clobber in-progress input (and the stored value may lag
   // what they've typed since the last dispatch).
   const active = root.ownerDocument?.activeElement ?? null;
-  root.querySelectorAll?.("[data-lvt-redact]").forEach((el) => {
-    if (el === active) return;
+  for (const el of collectRedactElements(root)) {
+    if (el === active) continue;
     const field = el.getAttribute("data-lvt-redact");
-    if (!field) return;
+    if (!field) continue;
     const v = read(field);
-    if (v === null) return;
+    if (v === null) continue;
     if (hasValue(el)) {
+      // For file inputs, el.value is the fake C:\fakepath string, not file
+      // contents — redacting file fields is out of scope for this helper.
       el.value = v;
     } else {
       el.textContent = v;
     }
-  });
+  }
 }

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -35,6 +35,7 @@ import { setupInvokerPolyfill } from "./dom/invoker-polyfill";
 import { setupHashLink, teardownHashLink, openFromHash, safeMatchesPopoverOpen } from "./dom/hash-link";
 import { setupScrollAway, teardownScrollAway } from "./dom/scroll-away";
 import { setupSpy, teardownSpy } from "./dom/spy";
+import { hydrateRedactedTokens } from "./dom/redact";
 import { TreeRenderer } from "./state/tree-renderer";
 import {
   RangeDomApplier,
@@ -1826,6 +1827,16 @@ export class LiveTemplateClient {
       // preventing leaked attributes on the live DOM.
       this.rangeDomApplier.cleanupMarkers(element);
     }
+
+    // Preview-mode hydration: substitute real values back from localStorage
+    // into data-lvt-redact inputs and `[[field]]` placeholder tokens. Runs on
+    // the LIVE element AFTER morphdom (not the detached tempWrapper before it):
+    // redacted content tokens like `[[passport]]` are static, so they're never
+    // re-walked in an update patch — scanning the committed DOM is the only way
+    // to catch them. Runs before focus restoration so a restored input's value
+    // is present when its focus/selection is reapplied. No-op when nothing is
+    // tagged/stored.
+    hydrateRedactedTokens(element);
 
     // Restore focus to previously focused element
     this.focusManager.restoreFocusedElement();

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1828,14 +1828,13 @@ export class LiveTemplateClient {
       this.rangeDomApplier.cleanupMarkers(element);
     }
 
-    // Preview-mode hydration: substitute real values back from localStorage
-    // into data-lvt-redact inputs and `[[field]]` placeholder tokens. Runs on
-    // the LIVE element AFTER morphdom (not the detached tempWrapper before it):
-    // redacted content tokens like `[[passport]]` are static, so they're never
-    // re-walked in an update patch — scanning the committed DOM is the only way
-    // to catch them. Runs before focus restoration so a restored input's value
-    // is present when its focus/selection is reapplied. No-op when nothing is
-    // tagged/stored.
+    // Preview-mode hydration: fill [data-lvt-redact] elements from localStorage
+    // (.value for inputs, textContent for spans). Runs on the LIVE element AFTER
+    // morphdom (not the detached tempWrapper before it): a redacted element is
+    // static, so it's never re-walked in an update patch — the committed DOM is
+    // the only place to catch it. Runs before focus restoration so a restored
+    // input's value is present when its focus/selection is reapplied. No-op when
+    // nothing is tagged/stored.
     hydrateRedactedTokens(element);
 
     // Restore focus to previously focused element

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -235,6 +235,17 @@ describe("hydrateRedactedTokens", () => {
     expect(root.querySelector("input")!.value).toBe("X1234567");
   });
 
+  it("hydrates root itself when it carries the attribute (not just descendants)", () => {
+    storage.setItem("lvt-redact:s1:passport", "X1234567");
+    const root = document.createElement("span");
+    root.setAttribute("data-lvt-redact", "passport");
+    document.body.appendChild(root);
+
+    hydrateRedactedTokens(root, { storage, scope: "s1" });
+
+    expect(root.textContent).toBe("X1234567");
+  });
+
   it("fills textContent of a tagged non-input element (the lvt.Redact span)", () => {
     storage.setItem("lvt-redact:s1:passport", "X1234567");
     const root = document.createElement("div");

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it, beforeEach } from "@jest/globals";
+
+import {
+  redactActionData,
+  redactFormData,
+  hydrateRedactedTokens,
+  type RedactSentinel,
+} from "../dom/redact";
+
+// Minimal in-memory Storage stand-in so tests don't depend on jsdom's
+// localStorage and can assert exactly what was written.
+class FakeStorage implements Storage {
+  private map = new Map<string, string>();
+  get length() {
+    return this.map.size;
+  }
+  clear() {
+    this.map.clear();
+  }
+  getItem(key: string) {
+    return this.map.has(key) ? this.map.get(key)! : null;
+  }
+  key(i: number) {
+    return Array.from(this.map.keys())[i] ?? null;
+  }
+  removeItem(key: string) {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string) {
+    this.map.set(key, value);
+  }
+}
+
+// A storage whose setItem always throws (quota exceeded / disabled).
+class ThrowingStorage extends FakeStorage {
+  setItem(): void {
+    throw new Error("QuotaExceededError");
+  }
+}
+
+describe("redactActionData", () => {
+  let storage: FakeStorage;
+  beforeEach(() => {
+    storage = new FakeStorage();
+    document.body.innerHTML = "";
+  });
+
+  it("persists the value and replaces it with a sentinel (single tagged input)", () => {
+    const input = document.createElement("input");
+    input.setAttribute("name", "passport");
+    input.setAttribute("data-lvt-redact", "passport");
+    input.value = "X1234567";
+
+    const data: Record<string, unknown> = { passport: "X1234567" };
+    redactActionData(input, data, { storage, scope: "s1" });
+
+    expect(storage.getItem("lvt-redact:s1:passport")).toBe("X1234567");
+    expect(data.passport).toEqual({ redacted: true, field: "passport" } as RedactSentinel);
+  });
+
+  it("redacts tagged descendants on the form-submit path", () => {
+    const form = document.createElement("form");
+    form.innerHTML = `
+      <input name="name" value="Ada" />
+      <input name="ssn" data-lvt-redact="ssn" value="111-22-3333" />
+    `;
+
+    const data: Record<string, unknown> = { name: "Ada", ssn: "111-22-3333" };
+    redactActionData(form, data, { storage, scope: "s1" });
+
+    // Non-tagged field is untouched.
+    expect(data.name).toBe("Ada");
+    // Tagged field is redacted + stored.
+    expect(data.ssn).toEqual({ redacted: true, field: "ssn" });
+    expect(storage.getItem("lvt-redact:s1:ssn")).toBe("111-22-3333");
+  });
+
+  it("uses the redact field name as the payload key when name is absent", () => {
+    const input = document.createElement("input");
+    input.setAttribute("data-lvt-redact", "tax_id");
+    input.value = "42";
+
+    const data: Record<string, unknown> = { value: "42" };
+    redactActionData(input, data, { storage, scope: "s1" });
+
+    expect(data.tax_id).toEqual({ redacted: true, field: "tax_id" });
+    expect(storage.getItem("lvt-redact:s1:tax_id")).toBe("42");
+  });
+
+  it("is a no-op when no element is tagged", () => {
+    const input = document.createElement("input");
+    input.setAttribute("name", "plain");
+    input.value = "visible";
+
+    const data: Record<string, unknown> = { plain: "visible" };
+    redactActionData(input, data, { storage, scope: "s1" });
+
+    expect(data.plain).toBe("visible");
+    expect(storage.length).toBe(0);
+  });
+
+  it("drops the raw value rather than leaking it when storage.setItem throws", () => {
+    const input = document.createElement("input");
+    input.setAttribute("name", "passport");
+    input.setAttribute("data-lvt-redact", "passport");
+    input.value = "secret";
+
+    const data: Record<string, unknown> = { passport: "secret" };
+    redactActionData(input, data, { storage: new ThrowingStorage(), scope: "s1" });
+
+    // The secret must never survive in the payload, even if persistence failed.
+    expect(data.passport).toEqual({ redacted: true, field: "passport" });
+  });
+
+  it("resolves the scope from the page's data-lvt-id when none is given", () => {
+    document.body.innerHTML = `<div data-lvt-id="page-xyz"></div>`;
+    const input = document.createElement("input");
+    input.setAttribute("name", "passport");
+    input.setAttribute("data-lvt-redact", "passport");
+    input.value = "Z9";
+    document.body.querySelector("[data-lvt-id]")!.appendChild(input);
+
+    const data: Record<string, unknown> = { passport: "Z9" };
+    redactActionData(input, data, { storage });
+
+    expect(storage.getItem("lvt-redact:page-xyz:passport")).toBe("Z9");
+  });
+});
+
+describe("redactFormData", () => {
+  let storage: FakeStorage;
+  beforeEach(() => {
+    storage = new FakeStorage();
+    document.body.innerHTML = "";
+  });
+
+  it("replaces the tagged field in FormData with a JSON sentinel and stores the raw value", () => {
+    const form = document.createElement("form");
+    form.innerHTML = `
+      <input name="note" value="trip" />
+      <input name="passport" data-lvt-redact="passport" value="X1234567" />
+      <input type="file" name="doc" />
+    `;
+    const fd = new FormData();
+    fd.set("note", "trip");
+    fd.set("passport", "X1234567");
+
+    redactFormData(form, fd, { storage, scope: "s1" });
+
+    // The raw value is gone from the multipart payload.
+    expect(fd.get("passport")).toBe(JSON.stringify({ redacted: true, field: "passport" }));
+    // The non-redacted field is untouched.
+    expect(fd.get("note")).toBe("trip");
+    // The raw value is preserved in localStorage.
+    expect(storage.getItem("lvt-redact:s1:passport")).toBe("X1234567");
+  });
+
+  it("never leaves the raw value anywhere in the serialized multipart body", () => {
+    const form = document.createElement("form");
+    form.innerHTML = `<input name="passport" data-lvt-redact="passport" value="SECRET-999" />`;
+    const fd = new FormData();
+    fd.set("passport", "SECRET-999");
+
+    redactFormData(form, fd, { storage, scope: "s1" });
+
+    // Walk every entry — the raw value must appear in none of them.
+    for (const [, value] of fd.entries()) {
+      expect(String(value)).not.toContain("SECRET-999");
+    }
+  });
+
+  it("drops the raw value even when storage.setItem throws", () => {
+    const form = document.createElement("form");
+    form.innerHTML = `<input name="passport" data-lvt-redact="passport" value="secret" />`;
+    const fd = new FormData();
+    fd.set("passport", "secret");
+
+    redactFormData(form, fd, { storage: new ThrowingStorage(), scope: "s1" });
+
+    expect(fd.get("passport")).toBe(JSON.stringify({ redacted: true, field: "passport" }));
+  });
+
+  it("is a no-op when no field is tagged", () => {
+    const form = document.createElement("form");
+    form.innerHTML = `<input name="plain" value="visible" />`;
+    const fd = new FormData();
+    fd.set("plain", "visible");
+
+    redactFormData(form, fd, { storage, scope: "s1" });
+
+    expect(fd.get("plain")).toBe("visible");
+    expect(storage.length).toBe(0);
+  });
+});
+
+describe("hydrateRedactedTokens", () => {
+  let storage: FakeStorage;
+  beforeEach(() => {
+    storage = new FakeStorage();
+    document.body.innerHTML = "";
+  });
+
+  it("substitutes stored values into tagged input elements", () => {
+    storage.setItem("lvt-redact:s1:passport", "X1234567");
+    const root = document.createElement("div");
+    root.innerHTML = `<input name="passport" data-lvt-redact="passport" value="" />`;
+    document.body.appendChild(root);
+
+    hydrateRedactedTokens(root, { storage, scope: "s1" });
+
+    const input = root.querySelector("input")!;
+    expect(input.value).toBe("X1234567");
+  });
+
+  it("replaces [[field]] tokens in text content", () => {
+    storage.setItem("lvt-redact:s1:passport", "X1234567");
+    const root = document.createElement("div");
+    root.innerHTML = `<span>Your passport: [[passport]]</span>`;
+    document.body.appendChild(root);
+
+    hydrateRedactedTokens(root, { storage, scope: "s1" });
+
+    expect(root.querySelector("span")!.textContent).toBe("Your passport: X1234567");
+  });
+
+  it("replaces multiple distinct tokens in one pass", () => {
+    storage.setItem("lvt-redact:s1:first", "Ada");
+    storage.setItem("lvt-redact:s1:last", "Lovelace");
+    const root = document.createElement("div");
+    root.innerHTML = `<p>[[first]] [[last]]</p>`;
+    document.body.appendChild(root);
+
+    hydrateRedactedTokens(root, { storage, scope: "s1" });
+
+    expect(root.querySelector("p")!.textContent).toBe("Ada Lovelace");
+  });
+
+  it("leaves a token untouched when no value is stored for it", () => {
+    const root = document.createElement("div");
+    root.innerHTML = `<span>[[unknown]]</span>`;
+    document.body.appendChild(root);
+
+    hydrateRedactedTokens(root, { storage, scope: "s1" });
+
+    expect(root.querySelector("span")!.textContent).toBe("[[unknown]]");
+  });
+
+  it("escapes substituted values as text, never as HTML (no XSS)", () => {
+    // A stored value containing markup must land as literal text, not be
+    // parsed as DOM. Setting nodeValue (not innerHTML) guarantees this.
+    storage.setItem("lvt-redact:s1:bio", "<img src=x onerror=alert(1)>");
+    const root = document.createElement("div");
+    root.innerHTML = `<span>[[bio]]</span>`;
+    document.body.appendChild(root);
+
+    hydrateRedactedTokens(root, { storage, scope: "s1" });
+
+    const span = root.querySelector("span")!;
+    expect(span.textContent).toBe("<img src=x onerror=alert(1)>");
+    // No <img> element was created — the value stayed text.
+    expect(span.querySelector("img")).toBeNull();
+  });
+
+  it("does not substitute tokens inside element attributes (content-only)", () => {
+    storage.setItem("lvt-redact:s1:passport", "X1234567");
+    const root = document.createElement("div");
+    // A token in an attribute must NOT be substituted — the walker only
+    // touches text nodes, so the real value never leaks into an attribute.
+    root.innerHTML = `<span title="[[passport]]">visible</span>`;
+    document.body.appendChild(root);
+
+    hydrateRedactedTokens(root, { storage, scope: "s1" });
+
+    expect(root.querySelector("span")!.getAttribute("title")).toBe("[[passport]]");
+  });
+});

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -112,6 +112,30 @@ describe("redactActionData", () => {
     expect(data.passport).toEqual({ redacted: true, field: "passport" });
   });
 
+  it("redacts even when localStorage is entirely unavailable (fail-closed)", () => {
+    // Simulate a browser where localStorage is absent (disabled storage /
+    // sandboxed iframe): getStorage() sees no global and returns null. The raw
+    // value must still be dropped from the payload rather than leaked.
+    const desc = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: undefined,
+    });
+    try {
+      const input = document.createElement("input");
+      input.setAttribute("name", "passport");
+      input.setAttribute("data-lvt-redact", "passport");
+      input.value = "secret";
+
+      const data: Record<string, unknown> = { passport: "secret" };
+      redactActionData(input, data); // no opts -> falls back to (absent) global
+
+      expect(data.passport).toEqual({ redacted: true, field: "passport" });
+    } finally {
+      if (desc) Object.defineProperty(globalThis, "localStorage", desc);
+    }
+  });
+
   it("resolves the scope from the page's data-lvt-id when none is given", () => {
     document.body.innerHTML = `<div data-lvt-id="page-xyz"></div>`;
     const input = document.createElement("input");

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -232,69 +232,87 @@ describe("hydrateRedactedTokens", () => {
 
     hydrateRedactedTokens(root, { storage, scope: "s1" });
 
-    const input = root.querySelector("input")!;
-    expect(input.value).toBe("X1234567");
+    expect(root.querySelector("input")!.value).toBe("X1234567");
   });
 
-  it("replaces [[field]] tokens in text content", () => {
+  it("fills textContent of a tagged non-input element (the lvt.Redact span)", () => {
     storage.setItem("lvt-redact:s1:passport", "X1234567");
     const root = document.createElement("div");
-    root.innerHTML = `<span>Your passport: [[passport]]</span>`;
+    root.innerHTML = `<span data-lvt-redact="passport"></span>`;
     document.body.appendChild(root);
 
     hydrateRedactedTokens(root, { storage, scope: "s1" });
 
-    expect(root.querySelector("span")!.textContent).toBe("Your passport: X1234567");
+    expect(root.querySelector("span")!.textContent).toBe("X1234567");
   });
 
-  it("replaces multiple distinct tokens in one pass", () => {
+  it("fills multiple distinct tagged elements in one pass", () => {
     storage.setItem("lvt-redact:s1:first", "Ada");
     storage.setItem("lvt-redact:s1:last", "Lovelace");
     const root = document.createElement("div");
-    root.innerHTML = `<p>[[first]] [[last]]</p>`;
+    root.innerHTML =
+      `<span data-lvt-redact="first"></span> <span data-lvt-redact="last"></span>`;
     document.body.appendChild(root);
 
     hydrateRedactedTokens(root, { storage, scope: "s1" });
 
-    expect(root.querySelector("p")!.textContent).toBe("Ada Lovelace");
+    const spans = root.querySelectorAll("span");
+    expect(spans[0].textContent).toBe("Ada");
+    expect(spans[1].textContent).toBe("Lovelace");
   });
 
-  it("leaves a token untouched when no value is stored for it", () => {
+  it("leaves a tagged element empty when no value is stored", () => {
     const root = document.createElement("div");
-    root.innerHTML = `<span>[[unknown]]</span>`;
+    root.innerHTML = `<span data-lvt-redact="unknown"></span>`;
     document.body.appendChild(root);
 
     hydrateRedactedTokens(root, { storage, scope: "s1" });
 
-    expect(root.querySelector("span")!.textContent).toBe("[[unknown]]");
+    expect(root.querySelector("span")!.textContent).toBe("");
   });
 
   it("escapes substituted values as text, never as HTML (no XSS)", () => {
-    // A stored value containing markup must land as literal text, not be
-    // parsed as DOM. Setting nodeValue (not innerHTML) guarantees this.
+    // A stored value containing markup must land as literal text (textContent),
+    // not be parsed as DOM.
     storage.setItem("lvt-redact:s1:bio", "<img src=x onerror=alert(1)>");
     const root = document.createElement("div");
-    root.innerHTML = `<span>[[bio]]</span>`;
+    root.innerHTML = `<span data-lvt-redact="bio"></span>`;
     document.body.appendChild(root);
 
     hydrateRedactedTokens(root, { storage, scope: "s1" });
 
     const span = root.querySelector("span")!;
     expect(span.textContent).toBe("<img src=x onerror=alert(1)>");
-    // No <img> element was created — the value stayed text.
     expect(span.querySelector("img")).toBeNull();
   });
 
-  it("does not substitute tokens inside element attributes (content-only)", () => {
+  it("does NOT substitute token-looking text without the attribute (no free scan)", () => {
+    // The security guarantee: only elements carrying data-lvt-redact are filled.
+    // User-posted content that merely names a field must never trigger
+    // substitution of the viewer's stored value.
     storage.setItem("lvt-redact:s1:passport", "X1234567");
     const root = document.createElement("div");
-    // A token in an attribute must NOT be substituted — the walker only
-    // touches text nodes, so the real value never leaks into an attribute.
-    root.innerHTML = `<span title="[[passport]]">visible</span>`;
+    root.innerHTML = `<span>my passport is [[passport]] and {{passport}}</span>`;
     document.body.appendChild(root);
 
     hydrateRedactedTokens(root, { storage, scope: "s1" });
 
-    expect(root.querySelector("span")!.getAttribute("title")).toBe("[[passport]]");
+    const text = root.querySelector("span")!.textContent!;
+    expect(text).toBe("my passport is [[passport]] and {{passport}}");
+    expect(text).not.toContain("X1234567");
+  });
+
+  it("skips the element the user is currently editing", () => {
+    storage.setItem("lvt-redact:s1:passport", "STORED");
+    const root = document.createElement("div");
+    root.innerHTML = `<input name="passport" data-lvt-redact="passport" value="typing" />`;
+    document.body.appendChild(root);
+    const input = root.querySelector("input")!;
+    input.focus();
+
+    hydrateRedactedTokens(root, { storage, scope: "s1" });
+
+    // Focused element keeps the user's in-progress value, not the stored one.
+    expect(input.value).toBe("typing");
   });
 });


### PR DESCRIPTION
## What

Lets an app keep sensitive field values in the visitor's browser and never send them to the server. An element opts in with `data-lvt-redact="<field>"`.

`dom/redact.ts`, wired into the existing send + render paths:

- **Outgoing** (`redactActionData` for JSON, `redactFormData` for multipart): before an action payload is sent, the raw value is written to `localStorage` and replaced with a `{redacted:true,field}` sentinel. **Both** transports are covered — the WebSocket/HTTP JSON path *and* the Tier-1 multipart file-upload path. Redaction is **fail-closed**: the sentinel is written even when `localStorage` is entirely unavailable (disabled / sandboxed iframe), so the raw value never leaks; only persistence is best-effort.
- **Incoming** (`hydrateRedactedTokens`): after morphdom commits, real values are filled into `[data-lvt-redact]` elements from localStorage — `.value` for inputs, `textContent` for the `<span>` the Go `lvt.Redact` helper emits. Substitution is **scoped to the attribute, never a free text scan**, so user-posted content cannot trigger it. Values land via `.value`/`textContent` (never `innerHTML`), so a stored value can't inject markup. The focused element is skipped so mid-keystroke input isn't clobbered.

Values are namespaced by the page's `data-lvt-id` scope.

Pairs with the Go `lvt.Redact` helper in `livetemplate/livetemplate#445`.

## Scope

Purely additive. No new client dependency. Apps without the attribute behave identically.

## Tests

`tests/redact.test.ts` — 18 cases: outgoing JSON + multipart sentinel, localStorage persistence, fail-closed on quota-exceeded AND on absent localStorage, scope resolution, attribute-scoped fill for inputs + spans, focused-element skip, XSS-safety (stored markup stays inert text), and a regression test that token-looking text *without* the attribute is never substituted. Full `npm test` green (692 passed / 1 skipped).

A real-browser end-to-end test against this bundle lives in `livetemplate/docs` (`examples/redacted-form`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)