### PR TITLE
Fix loading lifecycle stuck when an action produces no render diff

### DIFF
--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1414,7 +1414,16 @@ export class LiveTemplateClient {
     };
 
     if (!result.changed && !hasStaticsInTree(update)) {
-      // No changes detected and no statics in update, skip morphdom
+      // No DOM changes to apply — skip morphdom. But the action still
+      // completed, so its loading lifecycle must still resolve: fire the
+      // form lifecycle (which dispatches lvt:done → reactive on:done
+      // attributes, lvt-form:disable-with restore, form aria-busy). Without
+      // this, a no-op action (re-submitting the same value, or any
+      // idempotent action that produces an empty render diff) leaves
+      // spinners spinning and disabled buttons stuck forever.
+      if (meta) {
+        this.formLifecycleManager.handleResponse(meta);
+      }
       return;
     }
 

--- a/tests/loading-lifecycle-empty-diff.test.ts
+++ b/tests/loading-lifecycle-empty-diff.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression test: an action that produces NO render diff must still resolve
+ * its loading lifecycle.
+ *
+ * Bug: updateDOM() short-circuits (skips morphdom) when the update has no
+ * changes and no statics — an empty diff, e.g. re-submitting the same value or
+ * any idempotent action. That early-return also skipped firing the form
+ * lifecycle (handleResponse → lvt:done), so loading indicators wired to
+ * lvt-el:*:on:pending/done (and lvt-form:disable-with / form aria-busy) stayed
+ * stuck forever. The fix resolves the lifecycle before the early-return.
+ */
+
+import { LiveTemplateClient } from "../livetemplate-client";
+import { setupReactiveAttributeListeners } from "../dom/reactive-attributes";
+
+describe("loading lifecycle on an empty-diff response", () => {
+  let client: LiveTemplateClient;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    client = new LiveTemplateClient();
+    setupReactiveAttributeListeners();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("clears reactive on:done state and restores the form even with no DOM diff", () => {
+    const wrapper = document.createElement("div");
+    const form = document.createElement("form");
+    const button = document.createElement("button");
+    button.setAttribute("name", "greet");
+    button.setAttribute("lvt-el:addClass:on:pending", "is-loading");
+    button.setAttribute("lvt-el:removeClass:on:done", "is-loading");
+    button.textContent = "Say hi";
+    form.appendChild(button);
+    wrapper.appendChild(form);
+    document.body.appendChild(wrapper);
+
+    // Simulate the pending state applied when the action is sent: the reactive
+    // attribute added the class, and the form lifecycle marked the submission
+    // active (aria-busy on the form, the active button tracked).
+    button.classList.add("is-loading");
+    form.setAttribute("aria-busy", "true");
+    (client as any).formLifecycleManager.setActiveSubmission(
+      form,
+      button,
+      button.textContent
+    );
+
+    let doneFired = false;
+    document.addEventListener(
+      "lvt:done",
+      () => {
+        doneFired = true;
+      },
+      true
+    );
+
+    // The server responds to a no-op action with an empty update tree.
+    client.updateDOM(wrapper, {} as any, {
+      success: true,
+      action: "greet",
+    } as any);
+
+    expect(doneFired).toBe(true); // lifecycle resolved despite the empty diff
+    expect(button.classList.contains("is-loading")).toBe(false); // on:done applied
+    expect(form.hasAttribute("aria-busy")).toBe(false); // form state restored
+  });
+});


### PR DESCRIPTION
## Problem

A loading indicator wired to `lvt-el:*:on:pending/done` (or `lvt-form:disable-with`, or the form's auto `aria-busy`) gets **stuck forever** whenever an action produces **no render diff** — i.e. any idempotent action: re-submitting the same value, a "save" that saved nothing new, etc. The spinner never stops; the button never re-enables.

## Root cause

`livetemplate-client.ts` `updateDOM()` early-returns to skip morphdom when `!result.changed && !hasStaticsInTree(update)` (an empty diff). That `return` is **before** `handleResponse(meta)`, which dispatches `lvt:done` — the event that resolves all loading lifecycles (reactive `on:done` attributes, `disable-with`, form `aria-busy`). So a no-op action's pending state never clears.

The server is innocent: it always sends the action response (`UpdateResponse{Tree, Meta}`); the client just dropped it on the floor for empty diffs.

## Fix

Resolve the lifecycle before the early-return — a no-op action still completed, so its pending state must clear.

## Test

`tests/loading-lifecycle-empty-diff.test.ts` drives an empty-diff response through `updateDOM` and asserts the reactive `on:done` state clears and the form is restored. Verified it **fails without the fix, passes with it**; full suite (694 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)