### PR TITLE
feat(upload): client mode dispatch + Proxied/Preview/WS-disabled transport

### DIFF
--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1879,6 +1879,11 @@ export class LiveTemplateClient {
     // nothing is tagged/stored.
     hydrateRedactedTokens(element);
 
+    // Preview-mode uploads: re-attach local object URLs to any
+    // [data-lvt-upload-preview] placeholder the server just re-rendered, so the
+    // on-device preview survives server updates (same rationale as redact).
+    this.uploadHandler.hydratePreviews(element);
+
     // Restore focus to previously focused element
     this.focusManager.restoreFocusedElement();
 

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -240,7 +240,8 @@ export class LiveTemplateClient {
         postMultipartUpload: (formData) => this.postUploadMultipart(formData),
         isConnected: () =>
           !this.useHTTP && this.webSocketManager.getReadyState() === 1,
-        postUploadStart: (message) => this.postUploadStartHTTP(message),
+        postUploadStart: (message, signal) =>
+          this.postUploadStartHTTP(message, signal),
       }
     );
 
@@ -1109,7 +1110,8 @@ export class LiveTemplateClient {
    * as a normal action.
    */
   private async postUploadStartHTTP(
-    message: UploadStartMessage
+    message: UploadStartMessage,
+    signal?: AbortSignal
   ): Promise<UploadStartResponse> {
     const response = await fetch(this.getLiveUrl(), {
       method: "POST",
@@ -1120,6 +1122,7 @@ export class LiveTemplateClient {
         "X-Lvt-Upload": "start",
       },
       body: JSON.stringify(message),
+      signal,
     });
     if (!response.ok) {
       const detail = (await response.text().catch(() => "")).trim();

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1066,16 +1066,23 @@ export class LiveTemplateClient {
    * upload handler can surface the failure to the app; it is transport-agnostic
    * (works whether or not the WebSocket is connected).
    */
-  private async postUploadMultipart(formData: FormData): Promise<void> {
+  private async postUploadMultipart(
+    formData: FormData,
+    signal?: AbortSignal
+  ): Promise<void> {
     const liveUrl = this.getLiveUrl();
     const response = await fetch(liveUrl, {
       method: "POST",
       credentials: "include",
       headers: {
         Accept: "application/json",
+        // X-Lvt-Upload is a non-safelisted header, so it forces a CORS preflight
+        // — a cross-site page can't silently POST the user's cookies here.
+        "X-Lvt-Upload": "proxied",
         // Do NOT set Content-Type — the browser sets the multipart boundary.
       },
       body: formData,
+      signal,
     });
 
     if (!response.ok) {

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -237,7 +237,8 @@ export class LiveTemplateClient {
             );
           }
         },
-        postMultipartUpload: (formData) => this.postUploadMultipart(formData),
+        postMultipartUpload: (formData, signal) =>
+          this.postUploadMultipart(formData, signal),
         isConnected: () =>
           !this.useHTTP && this.webSocketManager.getReadyState() === 1,
         postUploadStart: (message, signal) =>

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -643,6 +643,7 @@ export class LiveTemplateClient {
     this.hiddenAt = 0;
     this.reconnecting = false;
     this.teardownVisibilityReconnect();
+    this.uploadHandler.revokePreviews();
     this.eventDelegator.teardownDOMEventTriggerDelegation();
     teardownHashLink();
     teardownAutoClickTimers();

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -236,6 +236,7 @@ export class LiveTemplateClient {
             );
           }
         },
+        postMultipartUpload: (formData) => this.postUploadMultipart(formData),
       }
     );
 
@@ -1051,6 +1052,38 @@ export class LiveTemplateClient {
       }
     } catch (error) {
       this.logger.error("Failed to send HTTP multipart request:", error);
+    }
+  }
+
+  /**
+   * POST a Proxied upload's multipart body to the live URL and apply the tree
+   * response. Unlike sendHTTPMultipart this REJECTS on a non-2xx response so the
+   * upload handler can surface the failure to the app; it is transport-agnostic
+   * (works whether or not the WebSocket is connected).
+   */
+  private async postUploadMultipart(formData: FormData): Promise<void> {
+    const liveUrl = this.getLiveUrl();
+    const response = await fetch(liveUrl, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        // Do NOT set Content-Type — the browser sets the multipart boundary.
+      },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Proxied upload failed: ${response.status}`);
+    }
+
+    const updateResponse: UpdateResponse = await response.json();
+    if (this.wrapperElement) {
+      this.updateDOM(
+        this.wrapperElement,
+        updateResponse.tree,
+        updateResponse.meta
+      );
     }
   }
 

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1079,7 +1079,10 @@ export class LiveTemplateClient {
     });
 
     if (!response.ok) {
-      throw new Error(`Proxied upload failed: ${response.status}`);
+      const detail = (await response.text().catch(() => "")).trim();
+      throw new Error(
+        `Proxied upload failed: ${response.status}${detail ? ` — ${detail}` : ""}`
+      );
     }
 
     const updateResponse: UpdateResponse = await response.json();
@@ -1112,7 +1115,10 @@ export class LiveTemplateClient {
       body: JSON.stringify(message),
     });
     if (!response.ok) {
-      throw new Error(`upload_start handshake failed: ${response.status}`);
+      const detail = (await response.text().catch(() => "")).trim();
+      throw new Error(
+        `upload_start handshake failed: ${response.status}${detail ? ` — ${detail}` : ""}`
+      );
     }
     return (await response.json()) as UploadStartResponse;
   }

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -48,6 +48,7 @@ import { WebSocketManager } from "./transport/websocket";
 import { UploadHandler } from "./upload/upload-handler";
 import type {
   UploadProgressMessage,
+  UploadStartMessage,
   UploadStartResponse,
 } from "./upload/types";
 import type {
@@ -237,6 +238,9 @@ export class LiveTemplateClient {
           }
         },
         postMultipartUpload: (formData) => this.postUploadMultipart(formData),
+        isConnected: () =>
+          !this.useHTTP && this.webSocketManager.getReadyState() === 1,
+        postUploadStart: (message) => this.postUploadStartHTTP(message),
       }
     );
 
@@ -1085,6 +1089,31 @@ export class LiveTemplateClient {
         updateResponse.meta
       );
     }
+  }
+
+  /**
+   * Post an upload_start handshake over HTTP (WebSocket-disabled fallback) and
+   * return the parsed UploadStartResponse. The X-Lvt-Upload header tells the
+   * server to answer with the handshake response rather than treating the body
+   * as a normal action.
+   */
+  private async postUploadStartHTTP(
+    message: UploadStartMessage
+  ): Promise<UploadStartResponse> {
+    const response = await fetch(this.getLiveUrl(), {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "X-Lvt-Upload": "start",
+      },
+      body: JSON.stringify(message),
+    });
+    if (!response.ok) {
+      throw new Error(`upload_start handshake failed: ${response.status}`);
+    }
+    return (await response.json()) as UploadStartResponse;
   }
 
   /**

--- a/tests/upload-handler.test.ts
+++ b/tests/upload-handler.test.ts
@@ -261,6 +261,50 @@ describe("UploadHandler", () => {
       );
     });
 
+    it("previews locally without uploading when mode is preview", async () => {
+      const createObjectURL = jest
+        .fn()
+        .mockReturnValue("blob:mock-url");
+      (global as any).URL.createObjectURL = createObjectURL;
+      (global as any).URL.revokeObjectURL = jest.fn();
+
+      document.body.innerHTML = `<img data-lvt-upload-preview="draft" />`;
+
+      const postMultipart = jest.fn().mockResolvedValue(undefined);
+      const previewHandler = new UploadHandler(mockSendMessage, {
+        postMultipartUpload: postMultipart,
+      });
+
+      const file = createMockFile("photo.png", "imgdata", "image/png");
+      await previewHandler.startUpload("draft", [file]);
+      await previewHandler.handleUploadStartResponse({
+        upload_name: "draft",
+        entries: [
+          {
+            entry_id: "entry-1",
+            client_name: "photo.png",
+            valid: true,
+            auto_upload: true,
+            mode: "preview",
+          },
+        ],
+      });
+      await jest.runAllTimersAsync();
+
+      // A local object URL is created and applied to the placeholder...
+      expect(createObjectURL).toHaveBeenCalledWith(file);
+      const img = document.querySelector(
+        '[data-lvt-upload-preview="draft"]'
+      ) as HTMLImageElement;
+      expect(img.getAttribute("src")).toBe("blob:mock-url");
+
+      // ...and nothing is uploaded (no chunks, no multipart POST).
+      expect(postMultipart).not.toHaveBeenCalled();
+      expect(mockSendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: "upload_chunk" })
+      );
+    });
+
     it("logs warning for missing files", async () => {
       const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
 

--- a/tests/upload-handler.test.ts
+++ b/tests/upload-handler.test.ts
@@ -305,6 +305,37 @@ describe("UploadHandler", () => {
       );
     });
 
+    it("posts the handshake over HTTP when the WebSocket is down", async () => {
+      const postUploadStart = jest.fn().mockResolvedValue({
+        upload_name: "doc",
+        entries: [
+          {
+            entry_id: "entry-1",
+            client_name: "scan.png",
+            valid: true,
+            auto_upload: true,
+            mode: "proxied",
+          },
+        ],
+      });
+      const postMultipart = jest.fn().mockResolvedValue(undefined);
+      const offlineHandler = new UploadHandler(mockSendMessage, {
+        isConnected: () => false,
+        postUploadStart,
+        postMultipartUpload: postMultipart,
+      });
+
+      const file = createMockFile("scan.png", "imgdata", "image/png");
+      await offlineHandler.startUpload("doc", [file]);
+      await jest.runAllTimersAsync();
+
+      // Handshake went over HTTP (not the WebSocket sendMessage path)...
+      expect(postUploadStart).toHaveBeenCalledTimes(1);
+      expect(mockSendMessage).not.toHaveBeenCalled();
+      // ...and the response was handled inline, dispatching the proxied upload.
+      expect(postMultipart).toHaveBeenCalledTimes(1);
+    });
+
     it("logs warning for missing files", async () => {
       const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
 

--- a/tests/upload-handler.test.ts
+++ b/tests/upload-handler.test.ts
@@ -224,6 +224,43 @@ describe("UploadHandler", () => {
       );
     });
 
+    it("posts a multipart upload (not WS chunks) when mode is proxied", async () => {
+      const postMultipart = jest.fn().mockResolvedValue(undefined);
+      const proxiedHandler = new UploadHandler(mockSendMessage, {
+        postMultipartUpload: postMultipart,
+      });
+
+      const file = createMockFile("scan.png", "imgdata", "image/png");
+      await proxiedHandler.startUpload("doc", [file]);
+
+      const response: UploadStartResponse = {
+        upload_name: "doc",
+        entries: [
+          {
+            entry_id: "entry-1",
+            client_name: "scan.png",
+            valid: true,
+            auto_upload: true,
+            mode: "proxied",
+          },
+        ],
+      };
+
+      await proxiedHandler.handleUploadStartResponse(response);
+      await jest.runAllTimersAsync();
+
+      // Proxied uploads go via a single multipart POST...
+      expect(postMultipart).toHaveBeenCalledTimes(1);
+      const fd = postMultipart.mock.calls[0][0] as FormData;
+      expect(fd.get("lvt-action")).toBe("upload_doc_complete");
+      expect(fd.get("doc")).toBeInstanceOf(File);
+
+      // ...and never over the WebSocket chunk transport.
+      expect(mockSendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: "upload_chunk" })
+      );
+    });
+
     it("logs warning for missing files", async () => {
       const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
 

--- a/upload/types.ts
+++ b/upload/types.ts
@@ -124,7 +124,7 @@ export interface UploadHandlerOptions {
    * client so the upload handler stays transport-agnostic. Resolves when the
    * POST completes; rejects on a non-2xx response.
    */
-  postMultipartUpload?: (formData: FormData) => Promise<void>;
+  postMultipartUpload?: (formData: FormData, signal?: AbortSignal) => Promise<void>;
   /**
    * Reports whether the WebSocket is currently usable. When false, the upload
    * handshake is sent over HTTP instead (see postUploadStart).

--- a/upload/types.ts
+++ b/upload/types.ts
@@ -135,7 +135,10 @@ export interface UploadHandlerOptions {
    * Used when the WebSocket is down so mode dispatch (and Direct presign) still
    * work. Injected by the LiveTemplate client; rejects on a non-2xx response.
    */
-  postUploadStart?: (message: UploadStartMessage) => Promise<UploadStartResponse>;
+  postUploadStart?: (
+    message: UploadStartMessage,
+    signal?: AbortSignal
+  ) => Promise<UploadStartResponse>;
 }
 
 export interface Uploader {

--- a/upload/types.ts
+++ b/upload/types.ts
@@ -16,12 +16,24 @@ export interface UploadConfig {
   chunkSize?: number;
 }
 
+/**
+ * UploadMode mirrors the server's UploadConfig.Mode. It is chosen purely by
+ * server config and delivered per-entry in the upload_start response; the client
+ * dispatches the matching transport.
+ *  - "volume":  WebSocket-chunked staging to the server's disk
+ *  - "direct":  browser → cloud via a presigned URL (carries `external`)
+ *  - "proxied": one multipart POST per file → server streams to remote storage
+ *  - "preview": file stays on device; only metadata is sent
+ */
+export type UploadMode = "volume" | "direct" | "proxied" | "preview";
+
 export interface UploadEntryInfo {
   entry_id: string;
   client_name: string;
   valid: boolean;
   error?: string;
   auto_upload: boolean;
+  mode?: UploadMode;
   external?: ExternalUploadMeta;
 }
 
@@ -92,6 +104,7 @@ export interface UploadEntry {
   valid: boolean;
   done: boolean;
   error?: string;
+  mode?: UploadMode;
   external?: ExternalUploadMeta;
   abortController?: AbortController;
 }
@@ -105,6 +118,13 @@ export interface UploadHandlerOptions {
   onProgress?: UploadProgressCallback;
   onComplete?: UploadCompleteCallback;
   onError?: UploadErrorCallback;
+  /**
+   * Posts a Proxied upload's multipart body (file + action fields) to the live
+   * URL and applies the server's tree response. Injected by the LiveTemplate
+   * client so the upload handler stays transport-agnostic. Resolves when the
+   * POST completes; rejects on a non-2xx response.
+   */
+  postMultipartUpload?: (formData: FormData) => Promise<void>;
 }
 
 export interface Uploader {

--- a/upload/types.ts
+++ b/upload/types.ts
@@ -125,6 +125,17 @@ export interface UploadHandlerOptions {
    * POST completes; rejects on a non-2xx response.
    */
   postMultipartUpload?: (formData: FormData) => Promise<void>;
+  /**
+   * Reports whether the WebSocket is currently usable. When false, the upload
+   * handshake is sent over HTTP instead (see postUploadStart).
+   */
+  isConnected?: () => boolean;
+  /**
+   * Posts an upload_start handshake over HTTP and returns the parsed response.
+   * Used when the WebSocket is down so mode dispatch (and Direct presign) still
+   * work. Injected by the LiveTemplate client; rejects on a non-2xx response.
+   */
+  postUploadStart?: (message: UploadStartMessage) => Promise<UploadStartResponse>;
 }
 
 export interface Uploader {

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -67,16 +67,27 @@ export class UploadHandler {
         if (entry.external) void this.uploadExternal(entry, entry.external);
         return;
       case "volume":
-        void this.uploadChunked(entry);
-        return;
       default:
-        // No mode (legacy server): infer from presence of presigned meta.
-        if (entry.external) {
-          void this.uploadExternal(entry, entry.external);
-        } else {
-          void this.uploadChunked(entry);
-        }
+        // entry.mode is normalized to a concrete mode at ingest (see
+        // handleUploadStartResponse), so the default is just the Volume path.
+        void this.uploadChunked(entry);
     }
+  }
+
+  /**
+   * Mark an upload finished and run the shared post-completion steps: fire the
+   * onComplete callback, clear the file input, and schedule entry cleanup.
+   * Callers that talk to the server (chunked/external) send their own
+   * upload_complete message first.
+   */
+  private finishUpload(entry: UploadEntry): void {
+    entry.done = true;
+    entry.progress = 100;
+    if (this.onComplete) {
+      this.onComplete(entry.uploadName, [entry]);
+    }
+    this.clearFileInput(entry.uploadName);
+    this.cleanupEntries(entry.uploadName);
   }
 
   /**
@@ -188,7 +199,10 @@ export class UploadHandler {
         valid: info.valid,
         done: false,
         error: info.error,
-        mode: info.mode,
+        // Normalize legacy responses (no mode) at the ingest boundary: a
+        // presigned entry is Direct, otherwise server-side Volume. Downstream
+        // dispatch then only ever sees a concrete mode.
+        mode: info.mode ?? (info.external ? "direct" : "volume"),
         external: info.external,
       };
 
@@ -235,16 +249,7 @@ export class UploadHandler {
       };
 
       this.sendMessage(completeMessage);
-
-      if (this.onComplete) {
-        this.onComplete(entry.uploadName, [entry]);
-      }
-
-      // Clear the file input to prevent re-upload of the same file
-      this.clearFileInput(entry.uploadName);
-
-      // Schedule cleanup after completion
-      this.cleanupEntries(entry.uploadName);
+      this.finishUpload(entry);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       entry.error = errorMsg;
@@ -280,14 +285,7 @@ export class UploadHandler {
       formData.set(entry.uploadName, entry.file, entry.file.name);
 
       await this.postMultipartUpload(formData);
-
-      entry.done = true;
-      entry.progress = 100;
-      if (this.onComplete) {
-        this.onComplete(entry.uploadName, [entry]);
-      }
-      this.clearFileInput(entry.uploadName);
-      this.cleanupEntries(entry.uploadName);
+      this.finishUpload(entry);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       entry.error = errorMsg;
@@ -418,16 +416,7 @@ export class UploadHandler {
       };
 
       this.sendMessage(completeMessage);
-
-      if (this.onComplete) {
-        this.onComplete(entry.uploadName, [entry]);
-      }
-
-      // Clear the file input to prevent re-upload of the same file
-      this.clearFileInput(entry.uploadName);
-
-      // Schedule cleanup after completion
-      this.cleanupEntries(entry.uploadName);
+      this.finishUpload(entry);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       entry.error = errorMsg;

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -38,8 +38,10 @@ export class UploadHandler {
   ) => Promise<void>;
   private isConnected?: () => boolean;
   private postUploadStart?: (
-    message: UploadStartMessage
+    message: UploadStartMessage,
+    signal?: AbortSignal
   ) => Promise<UploadStartResponse>;
+  private pendingHandshakes: Set<AbortController> = new Set();
   private previewUrls: Map<string, string> = new Map(); // uploadName -> object URL
   private inputHandlers: WeakMap<HTMLInputElement, EventListener> = new WeakMap();
 
@@ -176,15 +178,26 @@ export class UploadHandler {
         );
         return;
       }
+      const controller = new AbortController();
+      this.pendingHandshakes.add(controller);
       try {
-        const response = await this.postUploadStart(startMessage);
-        await this.handleUploadStartResponse(response);
+        const response = await this.postUploadStart(
+          startMessage,
+          controller.signal
+        );
+        // Skip if teardown aborted us mid-flight, so we don't create a preview
+        // object URL after revokePreviews already ran.
+        if (!controller.signal.aborted) {
+          await this.handleUploadStartResponse(response);
+        }
       } catch (error) {
         this.failStart(
           uploadName,
           files,
           error instanceof Error ? error.message : String(error)
         );
+      } finally {
+        this.pendingHandshakes.delete(controller);
       }
       return;
     }
@@ -391,8 +404,8 @@ export class UploadHandler {
     );
     els.forEach((el) => {
       if (el instanceof HTMLImageElement) {
-        el.src = url;
-      } else {
+        if (el.src !== url) el.src = url;
+      } else if (el.getAttribute("src") !== url) {
         el.setAttribute("src", url);
       }
     });
@@ -422,6 +435,12 @@ export class UploadHandler {
 
   /** Revoke all preview object URLs. Called on teardown to avoid leaks. */
   revokePreviews(): void {
+    // Abort in-flight offline handshakes first so a late resolution doesn't
+    // create a new preview URL after we've cleared the map.
+    for (const controller of this.pendingHandshakes) {
+      controller.abort();
+    }
+    this.pendingHandshakes.clear();
     for (const url of this.previewUrls.values()) {
       URL.revokeObjectURL(url);
     }

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -32,6 +32,7 @@ export class UploadHandler {
   private onProgress?: (entry: UploadEntry) => void;
   private onComplete?: (uploadName: string, entries: UploadEntry[]) => void;
   private onError?: (entry: UploadEntry, error: string) => void;
+  private postMultipartUpload?: (formData: FormData) => Promise<void>;
   private inputHandlers: WeakMap<HTMLInputElement, EventListener> = new WeakMap();
 
   constructor(
@@ -42,9 +43,39 @@ export class UploadHandler {
     this.onProgress = options.onProgress;
     this.onComplete = options.onComplete;
     this.onError = options.onError;
+    this.postMultipartUpload = options.postMultipartUpload;
 
     // Register default uploaders
     this.uploaders.set("s3", new S3Uploader());
+  }
+
+  /**
+   * Dispatch a valid upload entry to the transport its mode requires. The server
+   * declares the mode per-entry; existing entries that only carry `external`
+   * (no mode) fall back to the Direct path for backward compatibility.
+   */
+  private dispatchUpload(entry: UploadEntry): void {
+    switch (entry.mode) {
+      case "preview":
+        // Preview never uploads; bytes stay on the device. (Handled in Phase 5.)
+        return;
+      case "proxied":
+        void this.uploadProxied(entry);
+        return;
+      case "direct":
+        if (entry.external) void this.uploadExternal(entry, entry.external);
+        return;
+      case "volume":
+        void this.uploadChunked(entry);
+        return;
+      default:
+        // No mode (legacy server): infer from presence of presigned meta.
+        if (entry.external) {
+          void this.uploadExternal(entry, entry.external);
+        } else {
+          void this.uploadChunked(entry);
+        }
+    }
   }
 
   /**
@@ -156,6 +187,7 @@ export class UploadHandler {
         valid: info.valid,
         done: false,
         error: info.error,
+        mode: info.mode,
         external: info.external,
       };
 
@@ -170,15 +202,10 @@ export class UploadHandler {
         continue;
       }
 
-      // Only start upload immediately if autoUpload is true
-      // Otherwise, entries are stored and will be uploaded on form submit
+      // Only start upload immediately if autoUpload is true; otherwise the entry
+      // waits for an explicit form-submit trigger.
       if (info.auto_upload) {
-        // Start upload (external or chunked)
-        if (info.external) {
-          this.uploadExternal(entry, info.external);
-        } else {
-          this.uploadChunked(entry);
-        }
+        this.dispatchUpload(entry);
       }
     }
   }
@@ -224,6 +251,48 @@ export class UploadHandler {
         this.onError(entry, errorMsg);
       }
       // Schedule cleanup after error
+      this.cleanupEntries(entry.uploadName);
+    }
+  }
+
+  /**
+   * Upload a Proxied file as a single multipart POST to the live URL. The server
+   * streams the bytes straight to the app's OnUpload handler (zero local-disk
+   * staging) and dispatches the upload_<name>_complete action. Independent of
+   * the WebSocket, so it works with the socket disabled.
+   */
+  private async uploadProxied(entry: UploadEntry): Promise<void> {
+    if (!this.postMultipartUpload) {
+      const msg =
+        "Proxied upload unavailable: no multipart transport configured";
+      entry.error = msg;
+      if (this.onError) this.onError(entry, msg);
+      this.cleanupEntries(entry.uploadName);
+      return;
+    }
+
+    try {
+      const formData = new FormData();
+      // Write value fields BEFORE the file part so the server resolves the
+      // action regardless of multipart part ordering.
+      formData.set("lvt-action", `upload_${entry.uploadName}_complete`);
+      formData.set(entry.uploadName, entry.file, entry.file.name);
+
+      await this.postMultipartUpload(formData);
+
+      entry.done = true;
+      entry.progress = 100;
+      if (this.onComplete) {
+        this.onComplete(entry.uploadName, [entry]);
+      }
+      this.clearFileInput(entry.uploadName);
+      this.cleanupEntries(entry.uploadName);
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      entry.error = errorMsg;
+      if (this.onError) {
+        this.onError(entry, errorMsg);
+      }
       this.cleanupEntries(entry.uploadName);
     }
   }
@@ -372,11 +441,7 @@ export class UploadHandler {
 
     // Start uploads
     for (const entry of pendingEntries) {
-      if (entry.external) {
-        this.uploadExternal(entry, entry.external);
-      } else {
-        this.uploadChunked(entry);
-      }
+      this.dispatchUpload(entry);
     }
   }
 

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -70,7 +70,16 @@ export class UploadHandler {
         void this.uploadProxied(entry);
         return;
       case "direct":
-        if (entry.external) void this.uploadExternal(entry, entry.external);
+        if (entry.external) {
+          void this.uploadExternal(entry, entry.external);
+        } else {
+          // Direct requires presign metadata; surface the misconfig instead of
+          // silently abandoning the entry.
+          const msg = "direct upload mode requires presigned upload metadata";
+          entry.error = msg;
+          if (this.onError) this.onError(entry, msg);
+          this.cleanupEntries(entry.uploadName);
+        }
         return;
       case "volume":
       default:
@@ -346,6 +355,11 @@ export class UploadHandler {
     if (this.onComplete) {
       this.onComplete(entry.uploadName, [entry]);
     }
+
+    // Drop the tracking entry (the blob URL lives in previewUrls, not entries),
+    // matching every other completed-upload path, so re-selecting the same field
+    // doesn't accumulate stale entries.
+    this.cleanupEntries(entry.uploadName);
   }
 
   /** Point every preview placeholder for uploadName at the given object URL. */

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -103,6 +103,12 @@ export class UploadHandler {
   private finishUpload(entry: UploadEntry): void {
     entry.done = true;
     entry.progress = 100;
+    // Emit a final 100% tick so every completed path (proxied included) sends it
+    // — a progress bar waiting on 100% won't hang. Idempotent for chunked/external
+    // which already reach 100% during transfer.
+    if (this.onProgress) {
+      this.onProgress(entry);
+    }
     if (this.onComplete) {
       this.onComplete(entry.uploadName, [entry]);
     }
@@ -404,11 +410,17 @@ export class UploadHandler {
   /** Point every preview placeholder for uploadName at the given object URL. */
   private applyPreview(uploadName: string, url: string): void {
     // Escape the field name so a name with a quote/bracket can't break or inject
-    // into the selector (falls back to the raw value where CSS.escape is absent).
-    const safeName =
-      typeof CSS !== "undefined" && CSS.escape
-        ? CSS.escape(uploadName)
-        : uploadName;
+    // into the selector. Prefer CSS.escape; without it, only proceed for a simple
+    // identifier (the normal case) and otherwise skip rather than run a
+    // possibly-broken selector (hydratePreviews still re-applies via attr reads).
+    let safeName: string;
+    if (typeof CSS !== "undefined" && CSS.escape) {
+      safeName = CSS.escape(uploadName);
+    } else if (/^[\w-]+$/.test(uploadName)) {
+      safeName = uploadName;
+    } else {
+      return;
+    }
     const els = document.querySelectorAll<HTMLElement>(
       `[data-lvt-upload-preview="${safeName}"]`
     );

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -33,6 +33,7 @@ export class UploadHandler {
   private onComplete?: (uploadName: string, entries: UploadEntry[]) => void;
   private onError?: (entry: UploadEntry, error: string) => void;
   private postMultipartUpload?: (formData: FormData) => Promise<void>;
+  private previewUrls: Map<string, string> = new Map(); // uploadName -> object URL
   private inputHandlers: WeakMap<HTMLInputElement, EventListener> = new WeakMap();
 
   constructor(
@@ -57,7 +58,7 @@ export class UploadHandler {
   private dispatchUpload(entry: UploadEntry): void {
     switch (entry.mode) {
       case "preview":
-        // Preview never uploads; bytes stay on the device. (Handled in Phase 5.)
+        this.uploadPreview(entry);
         return;
       case "proxied":
         void this.uploadProxied(entry);
@@ -295,6 +296,73 @@ export class UploadHandler {
       }
       this.cleanupEntries(entry.uploadName);
     }
+  }
+
+  /**
+   * Preview mode: keep the file on the device and show it locally via an object
+   * URL. Nothing is uploaded — the server already has the file's metadata from
+   * the upload_start handshake. The blob URL is re-applied after server
+   * re-renders by hydratePreviews().
+   */
+  private uploadPreview(entry: UploadEntry): void {
+    // Revoke any prior preview for this field to avoid leaking object URLs.
+    const prev = this.previewUrls.get(entry.uploadName);
+    if (prev) URL.revokeObjectURL(prev);
+
+    const url = URL.createObjectURL(entry.file);
+    this.previewUrls.set(entry.uploadName, url);
+
+    entry.done = true;
+    entry.progress = 100;
+    this.applyPreview(entry.uploadName, url);
+
+    if (this.onComplete) {
+      this.onComplete(entry.uploadName, [entry]);
+    }
+  }
+
+  /** Point every preview placeholder for uploadName at the given object URL. */
+  private applyPreview(uploadName: string, url: string): void {
+    const els = document.querySelectorAll<HTMLElement>(
+      `[data-lvt-upload-preview="${uploadName}"]`
+    );
+    els.forEach((el) => {
+      if (el instanceof HTMLImageElement) {
+        el.src = url;
+      } else {
+        el.setAttribute("src", url);
+      }
+    });
+  }
+
+  /**
+   * Re-attach Preview-mode blob URLs after a DOM morph. The server re-renders
+   * the {{.lvt.UploadPreview}} placeholder with an empty src, so this restores
+   * the local object URL the visitor selected. Called by the client post-update.
+   */
+  hydratePreviews(root: Element): void {
+    const els = root.querySelectorAll<HTMLElement>(
+      "[data-lvt-upload-preview]"
+    );
+    els.forEach((el) => {
+      const name = el.getAttribute("data-lvt-upload-preview");
+      if (!name) return;
+      const url = this.previewUrls.get(name);
+      if (!url) return;
+      if (el instanceof HTMLImageElement) {
+        if (el.src !== url) el.src = url;
+      } else {
+        el.setAttribute("src", url);
+      }
+    });
+  }
+
+  /** Revoke all preview object URLs. Called on teardown to avoid leaks. */
+  revokePreviews(): void {
+    for (const url of this.previewUrls.values()) {
+      URL.revokeObjectURL(url);
+    }
+    this.previewUrls.clear();
   }
 
   /**

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -164,26 +164,42 @@ export class UploadHandler {
     // the socket down, post the handshake over HTTP and handle the response
     // inline so mode dispatch (and Direct presign) still work.
     const connected = this.isConnected ? this.isConnected() : true;
-    if (!connected && this.postUploadStart) {
+    if (!connected) {
+      if (!this.postUploadStart) {
+        this.failStart(
+          uploadName,
+          files,
+          "upload unavailable: WebSocket is closed and no HTTP fallback is configured"
+        );
+        return;
+      }
       try {
         const response = await this.postUploadStart(startMessage);
         await this.handleUploadStartResponse(response);
       } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        this.pendingFiles.delete(uploadName);
-        for (const file of files) {
-          if (this.onError) {
-            this.onError(
-              { id: "", file, uploadName, progress: 0, bytesUploaded: 0, valid: false, done: false },
-              msg
-            );
-          }
-        }
+        this.failStart(
+          uploadName,
+          files,
+          error instanceof Error ? error.message : String(error)
+        );
       }
       return;
     }
 
     this.sendMessage(startMessage);
+  }
+
+  // failStart reports a handshake failure on every selected file and clears the
+  // pending set, so a startUpload that can't reach the server isn't silent.
+  private failStart(uploadName: string, files: File[], message: string): void {
+    this.pendingFiles.delete(uploadName);
+    if (!this.onError) return;
+    for (const file of files) {
+      this.onError(
+        { id: "", file, uploadName, progress: 0, bytesUploaded: 0, valid: false, done: false },
+        message
+      );
+    }
   }
 
   /**
@@ -356,9 +372,11 @@ export class UploadHandler {
       this.onComplete(entry.uploadName, [entry]);
     }
 
-    // Drop the tracking entry (the blob URL lives in previewUrls, not entries),
-    // matching every other completed-upload path, so re-selecting the same field
-    // doesn't accumulate stale entries.
+    // Clear the input and drop the tracking entry, matching every other
+    // completed-upload path, so re-submitting doesn't re-trigger on the same
+    // file. The blob URL lives in previewUrls (not the input), so the preview
+    // survives the clear.
+    this.clearFileInput(entry.uploadName);
     this.cleanupEntries(entry.uploadName);
   }
 

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -403,8 +403,14 @@ export class UploadHandler {
 
   /** Point every preview placeholder for uploadName at the given object URL. */
   private applyPreview(uploadName: string, url: string): void {
+    // Escape the field name so a name with a quote/bracket can't break or inject
+    // into the selector (falls back to the raw value where CSS.escape is absent).
+    const safeName =
+      typeof CSS !== "undefined" && CSS.escape
+        ? CSS.escape(uploadName)
+        : uploadName;
     const els = document.querySelectorAll<HTMLElement>(
-      `[data-lvt-upload-preview="${uploadName}"]`
+      `[data-lvt-upload-preview="${safeName}"]`
     );
     els.forEach((el) => {
       if (el instanceof HTMLImageElement) {

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -42,6 +42,7 @@ export class UploadHandler {
     signal?: AbortSignal
   ) => Promise<UploadStartResponse>;
   private pendingHandshakes: Set<AbortController> = new Set();
+  private pendingUploads: Set<AbortController> = new Set(); // in-flight proxied fetches
   private previewUrls: Map<string, string> = new Map(); // uploadName -> object URL
   private inputHandlers: WeakMap<HTMLInputElement, EventListener> = new WeakMap();
 
@@ -365,6 +366,7 @@ export class UploadHandler {
     }
 
     entry.abortController = new AbortController();
+    this.pendingUploads.add(entry.abortController);
     // A single fetch has no native upload progress, so emit a start event (0%)
     // and let finishUpload emit 100% — a progress bar won't sit frozen with no
     // signal at all.
@@ -385,6 +387,8 @@ export class UploadHandler {
         this.onError(entry, errorMsg);
       }
       this.cleanupEntries(entry.uploadName);
+    } finally {
+      if (entry.abortController) this.pendingUploads.delete(entry.abortController);
     }
   }
 
@@ -461,12 +465,17 @@ export class UploadHandler {
 
   /** Revoke all preview object URLs. Called on teardown to avoid leaks. */
   revokePreviews(): void {
-    // Abort in-flight offline handshakes first so a late resolution doesn't
-    // create a new preview URL after we've cleared the map.
+    // Abort in-flight offline handshakes and proxied upload fetches first, so a
+    // late resolution doesn't create a preview URL or apply a tree update after
+    // the client has torn down.
     for (const controller of this.pendingHandshakes) {
       controller.abort();
     }
     this.pendingHandshakes.clear();
+    for (const controller of this.pendingUploads) {
+      controller.abort();
+    }
+    this.pendingUploads.clear();
     for (const url of this.previewUrls.values()) {
       URL.revokeObjectURL(url);
     }

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -33,6 +33,10 @@ export class UploadHandler {
   private onComplete?: (uploadName: string, entries: UploadEntry[]) => void;
   private onError?: (entry: UploadEntry, error: string) => void;
   private postMultipartUpload?: (formData: FormData) => Promise<void>;
+  private isConnected?: () => boolean;
+  private postUploadStart?: (
+    message: UploadStartMessage
+  ) => Promise<UploadStartResponse>;
   private previewUrls: Map<string, string> = new Map(); // uploadName -> object URL
   private inputHandlers: WeakMap<HTMLInputElement, EventListener> = new WeakMap();
 
@@ -45,6 +49,8 @@ export class UploadHandler {
     this.onComplete = options.onComplete;
     this.onError = options.onError;
     this.postMultipartUpload = options.postMultipartUpload;
+    this.isConnected = options.isConnected;
+    this.postUploadStart = options.postUploadStart;
 
     // Register default uploaders
     this.uploaders.set("s3", new S3Uploader());
@@ -138,12 +144,35 @@ export class UploadHandler {
       size: file.size,
     }));
 
-    // Send upload_start message to server
     const startMessage: UploadStartMessage = {
       action: "upload_start",
       upload_name: uploadName,
       files: fileMetadata,
     };
+
+    // Over an open WebSocket the server replies with a separate
+    // UploadStartResponse message (routed to handleUploadStartResponse). With
+    // the socket down, post the handshake over HTTP and handle the response
+    // inline so mode dispatch (and Direct presign) still work.
+    const connected = this.isConnected ? this.isConnected() : true;
+    if (!connected && this.postUploadStart) {
+      try {
+        const response = await this.postUploadStart(startMessage);
+        await this.handleUploadStartResponse(response);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        this.pendingFiles.delete(uploadName);
+        for (const file of files) {
+          if (this.onError) {
+            this.onError(
+              { id: "", file, uploadName, progress: 0, bytesUploaded: 0, valid: false, done: false },
+              msg
+            );
+          }
+        }
+      }
+      return;
+    }
 
     this.sendMessage(startMessage);
   }

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -348,6 +348,10 @@ export class UploadHandler {
     }
 
     entry.abortController = new AbortController();
+    // A single fetch has no native upload progress, so emit a start event (0%)
+    // and let finishUpload emit 100% — a progress bar won't sit frozen with no
+    // signal at all.
+    if (this.onProgress) this.onProgress(entry);
     try {
       const formData = new FormData();
       // Write value fields BEFORE the file part so the server resolves the
@@ -417,10 +421,7 @@ export class UploadHandler {
    * the local object URL the visitor selected. Called by the client post-update.
    */
   hydratePreviews(root: Element): void {
-    const els = root.querySelectorAll<HTMLElement>(
-      "[data-lvt-upload-preview]"
-    );
-    els.forEach((el) => {
+    const apply = (el: Element) => {
       const name = el.getAttribute("data-lvt-upload-preview");
       if (!name) return;
       const url = this.previewUrls.get(name);
@@ -430,7 +431,12 @@ export class UploadHandler {
       } else if (el.getAttribute("src") !== url) {
         el.setAttribute("src", url);
       }
-    });
+    };
+    // querySelectorAll skips the root itself, so match it explicitly.
+    if (root.matches("[data-lvt-upload-preview]")) apply(root);
+    root
+      .querySelectorAll<HTMLElement>("[data-lvt-upload-preview]")
+      .forEach(apply);
   }
 
   /** Revoke all preview object URLs. Called on teardown to avoid leaks. */

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -215,13 +215,24 @@ export class UploadHandler {
   // pending set, so a startUpload that can't reach the server isn't silent.
   private failStart(uploadName: string, files: File[], message: string): void {
     this.pendingFiles.delete(uploadName);
-    if (!this.onError) return;
-    for (const file of files) {
-      this.onError(
-        { id: "", file, uploadName, progress: 0, bytesUploaded: 0, valid: false, done: false },
+    const onError = this.onError;
+    if (!onError) return;
+    // Distinct synthetic ids per file (no server entry exists yet) so a consumer
+    // keying per-file error state doesn't collapse a multi-file failure.
+    files.forEach((file, i) => {
+      onError(
+        {
+          id: `pending-${uploadName}-${i}`,
+          file,
+          uploadName,
+          progress: 0,
+          bytesUploaded: 0,
+          valid: false,
+          done: false,
+        },
         message
       );
-    }
+    });
   }
 
   /**
@@ -390,21 +401,12 @@ export class UploadHandler {
 
     const url = URL.createObjectURL(entry.file);
     this.previewUrls.set(entry.uploadName, url);
-
-    entry.done = true;
-    entry.progress = 100;
     this.applyPreview(entry.uploadName, url);
 
-    if (this.onComplete) {
-      this.onComplete(entry.uploadName, [entry]);
-    }
-
-    // Clear the input and drop the tracking entry, matching every other
-    // completed-upload path, so re-submitting doesn't re-trigger on the same
-    // file. The blob URL lives in previewUrls (not the input), so the preview
-    // survives the clear.
-    this.clearFileInput(entry.uploadName);
-    this.cleanupEntries(entry.uploadName);
+    // Share the completion path with every other mode (progress 100% tick,
+    // onComplete, input clear, cleanup). The blob URL lives in previewUrls, not
+    // the input, so it survives the clear.
+    this.finishUpload(entry);
   }
 
   /** Point every preview placeholder for uploadName at the given object URL. */

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -32,7 +32,10 @@ export class UploadHandler {
   private onProgress?: (entry: UploadEntry) => void;
   private onComplete?: (uploadName: string, entries: UploadEntry[]) => void;
   private onError?: (entry: UploadEntry, error: string) => void;
-  private postMultipartUpload?: (formData: FormData) => Promise<void>;
+  private postMultipartUpload?: (
+    formData: FormData,
+    signal?: AbortSignal
+  ) => Promise<void>;
   private isConnected?: () => boolean;
   private postUploadStart?: (
     message: UploadStartMessage
@@ -331,6 +334,7 @@ export class UploadHandler {
       return;
     }
 
+    entry.abortController = new AbortController();
     try {
       const formData = new FormData();
       // Write value fields BEFORE the file part so the server resolves the
@@ -338,7 +342,7 @@ export class UploadHandler {
       formData.set("lvt-action", `upload_${entry.uploadName}_complete`);
       formData.set(entry.uploadName, entry.file, entry.file.name);
 
-      await this.postMultipartUpload(formData);
+      await this.postMultipartUpload(formData, entry.abortController.signal);
       this.finishUpload(entry);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
@@ -410,7 +414,7 @@ export class UploadHandler {
       if (!url) return;
       if (el instanceof HTMLImageElement) {
         if (el.src !== url) el.src = url;
-      } else {
+      } else if (el.getAttribute("src") !== url) {
         el.setAttribute("src", url);
       }
     });


### PR DESCRIPTION
Client side of the four upload-modes feature (livetemplate#447, server PR livetemplate/livetemplate#450).

## Changes
- Per-entry `UploadMode` (`volume`/`direct`/`proxied`/`preview`) on the `upload_start` response; `dispatchUpload` routes each entry to its transport. Legacy mode-less entries are normalized at the ingest boundary (presigned ⇒ direct, else volume).
- **Proxied**: one multipart POST per file to the live URL (`postMultipartUpload`), value fields before the file part; the server streams it to `OnUpload`.
- **Preview**: `URL.createObjectURL` local preview filling `[data-lvt-upload-preview]`, `hydratePreviews` re-attaches after server morphs, `revokePreviews` frees URLs; nothing is uploaded.
- **WS-disabled**: when the socket is down, `startUpload` posts the `upload_start` handshake over HTTP (`X-Lvt-Upload: start`) via `postUploadStart` and handles the response inline — making Proxied + Preview fully WebSocket-independent.
- Shared completion steps extracted into `finishUpload()`.

## Tests
jest: mode dispatch (proxied/preview), WS-disabled HTTP handshake routing. Full suite green (698 passed). Browser e2e lives in the docs example (`livetemplate/docs#…`).

Requires server PR livetemplate/livetemplate#450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)