### PR TITLE
feat(upload): serialize the form's fields into a Proxied upload

### DIFF
--- a/tests/upload-handler.test.ts
+++ b/tests/upload-handler.test.ts
@@ -261,6 +261,50 @@ describe("UploadHandler", () => {
       );
     });
 
+    it("serializes the triggering input's form fields into a proxied upload, before the file", async () => {
+      const postMultipart = jest.fn().mockResolvedValue(undefined);
+      const proxiedHandler = new UploadHandler(mockSendMessage, {
+        postMultipartUpload: postMultipart,
+      });
+
+      // The file input lives in a form carrying a record id (a value field) and
+      // a second, unrelated file input that must NOT become a value field.
+      const form = document.createElement("form");
+      form.innerHTML =
+        '<input type="hidden" name="id" value="item-42">' +
+        '<input type="file" name="other" lvt-upload="other">' +
+        '<input type="file" name="doc" lvt-upload="doc">';
+      const input = form.querySelector('input[name="doc"]') as HTMLInputElement;
+
+      const file = createMockFile("scan.png", "imgdata", "image/png");
+      await proxiedHandler.startUpload("doc", [file], input);
+      await proxiedHandler.handleUploadStartResponse({
+        upload_name: "doc",
+        entries: [
+          {
+            entry_id: "entry-1",
+            client_name: "scan.png",
+            valid: true,
+            auto_upload: true,
+            mode: "proxied",
+          },
+        ],
+      });
+      await jest.runAllTimersAsync();
+
+      const fd = postMultipart.mock.calls[0][0] as FormData;
+      // The record id rides along as a value field...
+      expect(fd.get("id")).toBe("item-42");
+      // ...ordered before the streamed file part, so OnUpload sees it mid-stream.
+      const keys = [...fd.keys()];
+      expect(keys.indexOf("id")).toBeLessThan(keys.indexOf("doc"));
+      // The streamed file is still the file part; the other file input is not
+      // serialized as a value field, and the action is untouched.
+      expect(fd.get("doc")).toBeInstanceOf(File);
+      expect(fd.get("other")).toBeNull();
+      expect(fd.get("lvt-action")).toBe("upload_doc_complete");
+    });
+
     it("previews locally without uploading when mode is preview", async () => {
       const createObjectURL = jest
         .fn()

--- a/tests/upload-handler.test.ts
+++ b/tests/upload-handler.test.ts
@@ -272,6 +272,7 @@ describe("UploadHandler", () => {
       const form = document.createElement("form");
       form.innerHTML =
         '<input type="hidden" name="id" value="item-42">' +
+        '<input type="password" name="secret" value="hunter2">' +
         '<input type="file" name="other" lvt-upload="other">' +
         '<input type="file" name="doc" lvt-upload="doc">';
       const input = form.querySelector('input[name="doc"]') as HTMLInputElement;
@@ -303,6 +304,9 @@ describe("UploadHandler", () => {
       expect(fd.get("doc")).toBeInstanceOf(File);
       expect(fd.get("other")).toBeNull();
       expect(fd.get("lvt-action")).toBe("upload_doc_complete");
+      // Password inputs are never serialized into the upload POST — a co-located
+      // credential must not ride along with an auto-fired upload.
+      expect(fd.get("secret")).toBeNull();
     });
 
     it("previews locally without uploading when mode is preview", async () => {

--- a/upload/types.ts
+++ b/upload/types.ts
@@ -107,6 +107,11 @@ export interface UploadEntry {
   mode?: UploadMode;
   external?: ExternalUploadMeta;
   abortController?: AbortController;
+  // The file input that triggered this upload, when known. Proxied uploads use
+  // its enclosing form to serialize the form's value fields (e.g. a record id)
+  // into the multipart POST, so the server can associate the streamed bytes with
+  // a record inside OnUpload.
+  sourceInput?: HTMLInputElement;
 }
 
 export type UploadProgressCallback = (entry: UploadEntry) => void;

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -26,6 +26,7 @@ import type {
 export class UploadHandler {
   private entries: Map<string, UploadEntry> = new Map();
   private pendingFiles: Map<string, File[]> = new Map(); // uploadName -> files
+  private pendingInputs: Map<string, HTMLInputElement> = new Map(); // uploadName -> triggering input
   private autoUploadConfig: Map<string, boolean> = new Map(); // uploadName -> autoUpload
   private chunkSize: number;
   private uploaders: Map<string, Uploader> = new Map();
@@ -141,8 +142,9 @@ export class UploadHandler {
         if (!files || files.length === 0) return;
 
         // Always send upload_start to get validation and config
-        // But only proceed with chunks if autoUpload is true
-        this.startUpload(uploadName, Array.from(files));
+        // But only proceed with chunks if autoUpload is true. Pass the triggering
+        // input so a Proxied upload can serialize its enclosing form's fields.
+        this.startUpload(uploadName, Array.from(files), input);
       };
 
       input.addEventListener("change", handler);
@@ -154,9 +156,18 @@ export class UploadHandler {
   /**
    * Start upload process for selected files
    */
-  async startUpload(uploadName: string, files: File[]): Promise<void> {
+  async startUpload(
+    uploadName: string,
+    files: File[],
+    sourceInput?: HTMLInputElement
+  ): Promise<void> {
     // Store files temporarily for when server response arrives
     this.pendingFiles.set(uploadName, files);
+    if (sourceInput) {
+      this.pendingInputs.set(uploadName, sourceInput);
+    } else {
+      this.pendingInputs.delete(uploadName);
+    }
 
     // Create file metadata
     const fileMetadata: FileMetadata[] = files.map((file) => ({
@@ -216,6 +227,7 @@ export class UploadHandler {
   // pending set, so a startUpload that can't reach the server isn't silent.
   private failStart(uploadName: string, files: File[], message: string): void {
     this.pendingFiles.delete(uploadName);
+    this.pendingInputs.delete(uploadName);
     const onError = this.onError;
     if (!onError) return;
     // Distinct synthetic ids per file (no server entry exists yet) so a consumer
@@ -259,6 +271,11 @@ export class UploadHandler {
     // Clear pending files
     this.pendingFiles.delete(upload_name);
 
+    // The input that triggered this upload (if any), so a Proxied entry can
+    // serialize its enclosing form's fields. Consumed once, like pendingFiles.
+    const sourceInput = this.pendingInputs.get(upload_name);
+    this.pendingInputs.delete(upload_name);
+
     // Build a map from file name to file object for lookup
     const fileMap = new Map<string, File>();
     for (const file of files) {
@@ -292,6 +309,7 @@ export class UploadHandler {
         // dispatch then only ever sees a concrete mode.
         mode: info.mode ?? (info.external ? "direct" : "volume"),
         external: info.external,
+        sourceInput,
       };
 
       this.entries.set(entry.id, entry);
@@ -376,6 +394,9 @@ export class UploadHandler {
       // Write value fields BEFORE the file part so the server resolves the
       // action regardless of multipart part ordering.
       formData.set("lvt-action", `upload_${entry.uploadName}_complete`);
+      // Then the triggering input's enclosing form fields (e.g. a record id), so
+      // the server can associate the streamed bytes with a record in OnUpload.
+      this.appendFormFields(formData, entry);
       formData.set(entry.uploadName, entry.file, entry.file.name);
 
       await this.postMultipartUpload(formData, entry.abortController.signal);
@@ -389,6 +410,23 @@ export class UploadHandler {
       this.cleanupEntries(entry.uploadName);
     } finally {
       if (entry.abortController) this.pendingUploads.delete(entry.abortController);
+    }
+  }
+
+  /**
+   * appendFormFields serializes the value fields of the form enclosing the
+   * upload's triggering input into formData, ahead of the file part — so a
+   * Proxied OnUpload handler can read them (e.g. a record id) mid-stream. Uses
+   * the browser's native form serialization (successful controls only), skipping
+   * File values (file inputs are sent as the streaming part) and the reserved
+   * lvt-action field. A no-op when the input is outside a form.
+   */
+  private appendFormFields(formData: FormData, entry: UploadEntry): void {
+    const form = entry.sourceInput?.form;
+    if (!form) return;
+    for (const [name, value] of new FormData(form).entries()) {
+      if (name === "lvt-action" || value instanceof File) continue;
+      formData.append(name, value);
     }
   }
 

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -410,6 +410,9 @@ export class UploadHandler {
       this.cleanupEntries(entry.uploadName);
     } finally {
       if (entry.abortController) this.pendingUploads.delete(entry.abortController);
+      // Release the DOM reference once the upload is done — the entry may linger
+      // until the cleanup timer fires, and only uploadProxied ever reads it.
+      entry.sourceInput = undefined;
     }
   }
 
@@ -420,12 +423,25 @@ export class UploadHandler {
    * the browser's native form serialization (successful controls only), skipping
    * File values (file inputs are sent as the streaming part) and the reserved
    * lvt-action field. A no-op when the input is outside a form.
+   *
+   * A Proxied upload auto-fires on file selection (not an explicit submit), so it
+   * POSTs the whole enclosing form. Password inputs are excluded by name so
+   * credentials in a co-located form never ride along with an upload the user
+   * didn't deliberately submit; keep other sensitive controls out of a form that
+   * contains an auto-upload file input.
    */
   private appendFormFields(formData: FormData, entry: UploadEntry): void {
     const form = entry.sourceInput?.form;
     if (!form) return;
+    const passwordFields = new Set<string>();
+    for (const el of Array.from(form.elements)) {
+      const input = el as HTMLInputElement;
+      if (input.type === "password" && input.name) passwordFields.add(input.name);
+    }
     for (const [name, value] of new FormData(form).entries()) {
-      if (name === "lvt-action" || value instanceof File) continue;
+      if (name === "lvt-action" || value instanceof File || passwordFields.has(name)) {
+        continue;
+      }
       formData.append(name, value);
     }
   }

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -428,11 +428,19 @@ export class UploadHandler {
    * POSTs the whole enclosing form. Password inputs are excluded by name so
    * credentials in a co-located form never ride along with an upload the user
    * didn't deliberately submit; keep other sensitive controls out of a form that
-   * contains an auto-upload file input.
+   * contains an auto-upload file input. (A broader opt-in model — only fields
+   * marked to travel — is tracked upstream as a safer-by-default follow-up.)
+   *
+   * Values are read here, at upload time (after the upload_start round-trip), not
+   * at file-selection time, so edits made between selecting the file and the
+   * upload completing are reflected — the freshest form state wins.
    */
   private appendFormFields(formData: FormData, entry: UploadEntry): void {
     const form = entry.sourceInput?.form;
     if (!form) return;
+    // Collect password field names to exclude. Casting to HTMLInputElement is safe
+    // for the type check: only <input> has type="password"; <select>/<textarea>
+    // simply never match and are serialized normally by FormData below.
     const passwordFields = new Set<string>();
     for (const el of Array.from(form.elements)) {
       const input = el as HTMLInputElement;


### PR DESCRIPTION
## What

A Proxied upload POSTed only `lvt-action` + the file, so a streaming `OnUpload` handler had no way to associate the bytes with a record (e.g. a form's hidden `id`) — the sibling fields never left the browser.

Thread the triggering file input through the upload lifecycle (`change` → `startUpload` → `pendingInputs` → `entry.sourceInput`), and in `uploadProxied` serialize its enclosing form's value fields into the multipart POST, **ahead of the file part**, via the browser's native `FormData(form)` (successful controls only; `File` values and `lvt-action` skipped). The server reads them in `OnUpload`.

## Tests

Jest test asserting the record id rides along ordered before the file part, and that other file inputs are not serialized as value fields. Suite (30) + build green via pre-commit.

## Part of a 3-repo change (merge order: livetemplate → this → docs)

Pairs with `livetemplate/livetemplate` `feat/onupload-form-context` (server-side form-values-in-OnUpload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)