### PR TITLE
fix(upload): bind SSR'd lvt-upload change handler on connect (#453)

### DIFF
--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -578,6 +578,17 @@ export class LiveTemplateClient {
     // Set up event delegation for lvt-* attributes
     this.eventDelegator.setupEventDelegation();
 
+    // Bind change handlers on file inputs that were SSR'd and already present
+    // at connect time. The post-render block in updateDOM only (re)binds these
+    // when a render adds nodes or touches a directive; a hydrate-idempotent
+    // first render would otherwise leave SSR'd lvt-upload inputs without a
+    // change listener, so AutoUpload-on-select silently no-ops (issue #453).
+    // initializeFileInputs is WeakMap-guarded, so running it here AND in the
+    // post-render path never double-binds.
+    if (this.wrapperElement) {
+      this.uploadHandler.initializeFileInputs(this.wrapperElement);
+    }
+
     // Set up window-* event delegation
     this.eventDelegator.setupWindowEventDelegation();
 

--- a/tests/upload-ssr-binding.test.ts
+++ b/tests/upload-ssr-binding.test.ts
@@ -1,0 +1,139 @@
+import { LiveTemplateClient } from "../livetemplate-client";
+
+// Regression test for issue #453: a file input with lvt-upload that is SSR'd
+// (present in the DOM before connect) and never re-rendered with new nodes must
+// still get its change handler bound on connect(). Before the fix, the handler
+// was bound only from updateDOM's post-render block, which is skipped on a
+// hydrate-idempotent first render — so selecting a file sent no upload_start.
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  url: string;
+  readyState: number = MockWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  sent: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    if (this.onclose) {
+      this.onclose(new CloseEvent("close", { code: 1000 }));
+    }
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    if (this.onopen) {
+      this.onopen(new Event("open"));
+    }
+  }
+}
+
+let mockSockets: MockWebSocket[] = [];
+
+function installMockWebSocket() {
+  mockSockets = [];
+  const WS = jest.fn().mockImplementation((url: string) => {
+    const sock = new MockWebSocket(url);
+    mockSockets.push(sock);
+    return sock;
+  }) as any;
+  WS.CONNECTING = 0;
+  WS.OPEN = 1;
+  WS.CLOSING = 2;
+  WS.CLOSED = 3;
+  (global as any).WebSocket = WS;
+}
+
+function installFetchStub() {
+  if (typeof (globalThis as any).fetch !== "function") {
+    (globalThis as any).fetch = () => {};
+  }
+  jest
+    .spyOn(globalThis as any, "fetch")
+    .mockImplementation((...args: unknown[]) => {
+      const opts = args[1] as any;
+      if (opts?.method === "HEAD") {
+        return Promise.resolve(
+          new Response(null, {
+            status: 200,
+            headers: { "X-LiveTemplate-WebSocket": "enabled" },
+          })
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    });
+}
+
+// Build the wrapper with an SSR'd lvt-upload file input already present, exactly
+// as a server would render it before the client connects.
+function createSSRWrapper(): HTMLDivElement {
+  const wrapper = document.createElement("div");
+  wrapper.setAttribute("data-lvt-id", "test-ssr-upload");
+  wrapper.innerHTML = `<input type="file" lvt-upload="avatar" id="avatar-input" />`;
+  document.body.appendChild(wrapper);
+  return wrapper;
+}
+
+describe("SSR'd lvt-upload binding on connect (issue #453)", () => {
+  let client: LiveTemplateClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.replaceChildren();
+    installMockWebSocket();
+    installFetchStub();
+    history.replaceState(null, "", "/test");
+  });
+
+  afterEach(() => {
+    client?.disconnect();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  async function connectClient(): Promise<void> {
+    client = new LiveTemplateClient({ logLevel: "error" });
+    const connectPromise = client.connect();
+    // Resolve the HEAD fetch that probes for WebSocket support
+    await jest.advanceTimersByTimeAsync(0);
+    // Open the WebSocket — useHTTP=false, readyState=OPEN
+    mockSockets[0]?.simulateOpen();
+    await connectPromise;
+  }
+
+  it("binds the change handler and sends upload_start on file select", async () => {
+    createSSRWrapper();
+    await connectClient();
+
+    const input = document.getElementById("avatar-input") as HTMLInputElement;
+    const file = new File(["hello"], "avatar.png", { type: "image/png" });
+    Object.defineProperty(input, "files", { value: [file], configurable: true });
+
+    input.dispatchEvent(new Event("change"));
+
+    const uploadStart = mockSockets[0].sent
+      .map((raw) => JSON.parse(raw))
+      .find((msg) => msg.action === "upload_start");
+
+    expect(uploadStart).toMatchObject({
+      action: "upload_start",
+      upload_name: "avatar",
+    });
+  });
+});


### PR DESCRIPTION
## Problem

A file input with `lvt-upload` + `AutoUpload: true` that is **server-rendered in the initial HTML** and reproduced identically by the first WebSocket render (hydrate-idempotent) never gets its `change` handler bound. Selecting a file does nothing — no `upload_start`, no upload.

Fixes livetemplate/livetemplate#453.

## Root cause

`UploadHandler.initializeFileInputs(element)` is the only place the per-input `change` handler is bound, and on the client it runs **only** from the post-render block in `updateDOM`, guarded by:

```js
if (this.nodesAddedThisRender > 0 || this.directiveTouchedThisRender) { ... initializeFileInputs(element) }
```

For an SSR'd input whose first WS render matches the already-present DOM, morphdom adds no nodes and touches no directive, so the guard is false and the input is left without a listener. `connect()` wires *document-level* delegation unconditionally but never binds the *per-input* upload handler.

## Fix

Bind SSR'd file inputs once in `connect()`, right after `setupEventDelegation()` — the same place document-level delegation is wired unconditionally. `initializeFileInputs` is WeakMap-guarded (it removes any existing handler before re-adding), so running it here **and** in the post-render path never double-binds. The guard and its perf optimization are left untouched.

## Tests

- New `tests/upload-ssr-binding.test.ts`: connects with an SSR'd `lvt-upload` input present, fires `change` with **no** intervening render, asserts `upload_start` is sent. Proven **red without the fix** (no frame) and **green with it**.
- Full suite green (699 passing).
- Browser-verified end-to-end (chromedp): same fixture, swapping only the bundle — v0.13.0 bundle → no `upload_start` (the #453 symptom); fixed bundle → `upload_start` sent + upload completes.

## Follow-up (out of scope)

`setupFxDOMEventTriggers` (SSR'd `lvt-fx:event:on:trigger` elements) shares the same latent connect-time gap and is the one remaining guarded sibling not yet bound at connect (`setupDOMEventTriggerDelegation` already is, via the no-arg form). Tracked separately; #453 is upload-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)