### PR TITLE
feat(upload): WS-disabled fallbacks for Direct completion and Volume (#448, #449)

### DIFF
--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1177,6 +1177,9 @@ export class LiveTemplateClient {
       );
     }
     const updateResponse: UpdateResponse = await response.json();
+    // No wrapperElement means connect() never resolved (or the root was
+    // unmounted mid-upload); drop the tree as the sibling HTTP fallbacks
+    // (postUploadStartHTTP / postUploadMultipart) do — there's nothing to morph.
     if (this.wrapperElement) {
       this.updateDOM(
         this.wrapperElement,

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -47,6 +47,7 @@ import { ChangeAutoWirer } from "./state/change-auto-wirer";
 import { WebSocketManager } from "./transport/websocket";
 import { UploadHandler } from "./upload/upload-handler";
 import type {
+  UploadCompleteHTTPMessage,
   UploadProgressMessage,
   UploadStartMessage,
   UploadStartResponse,
@@ -243,6 +244,8 @@ export class LiveTemplateClient {
           !this.useHTTP && this.webSocketManager.getReadyState() === 1,
         postUploadStart: (message, signal) =>
           this.postUploadStartHTTP(message, signal),
+        postUploadComplete: (message, signal) =>
+          this.postUploadCompleteHTTP(message, signal),
       }
     );
 
@@ -1101,7 +1104,7 @@ export class LiveTemplateClient {
     if (!response.ok) {
       const detail = (await response.text().catch(() => "")).trim();
       throw new Error(
-        `Proxied upload failed: ${response.status}${detail ? ` — ${detail}` : ""}`
+        `Multipart upload failed: ${response.status}${detail ? ` — ${detail}` : ""}`
       );
     }
 
@@ -1143,6 +1146,44 @@ export class LiveTemplateClient {
       );
     }
     return (await response.json()) as UploadStartResponse;
+  }
+
+  /**
+   * Post an upload_complete handshake over HTTP (WebSocket-disabled Direct, #448)
+   * and apply the server's tree response. The client re-sends the entry metadata
+   * + the ref it uploaded to so the server can reconstruct the completed entry
+   * (its per-request registry no longer holds the presigned entry) and run the
+   * upload_<field>_complete action.
+   */
+  private async postUploadCompleteHTTP(
+    message: UploadCompleteHTTPMessage,
+    signal?: AbortSignal
+  ): Promise<void> {
+    const response = await fetch(this.getLiveUrl(), {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "X-Lvt-Upload": "complete",
+      },
+      body: JSON.stringify(message),
+      signal,
+    });
+    if (!response.ok) {
+      const detail = (await response.text().catch(() => "")).trim();
+      throw new Error(
+        `upload_complete handshake failed: ${response.status}${detail ? ` — ${detail}` : ""}`
+      );
+    }
+    const updateResponse: UpdateResponse = await response.json();
+    if (this.wrapperElement) {
+      this.updateDOM(
+        this.wrapperElement,
+        updateResponse.tree,
+        updateResponse.meta
+      );
+    }
   }
 
   /**

--- a/tests/upload-handler.test.ts
+++ b/tests/upload-handler.test.ts
@@ -424,6 +424,48 @@ describe("UploadHandler", () => {
       );
     });
 
+    it("completes Direct on the start-of-upload transport, not a mid-upload reconnect (#448)", async () => {
+      let connected = false; // disconnected when the handshake + dispatch run
+      const postUploadStart = jest.fn().mockResolvedValue({
+        upload_name: "avatar",
+        entries: [
+          {
+            entry_id: "entry-1",
+            client_name: "avatar.png",
+            valid: true,
+            auto_upload: true,
+            mode: "direct",
+            external: { uploader: "mock", url: "https://cdn.example/avatar.png" },
+          },
+        ],
+      });
+      const postUploadComplete = jest.fn().mockResolvedValue(undefined);
+      // The slow PUT "reconnects" the socket mid-flight.
+      const mockUploader = {
+        upload: jest.fn().mockImplementation(async () => {
+          connected = true;
+        }),
+      };
+      const directHandler = new UploadHandler(mockSendMessage, {
+        isConnected: () => connected,
+        postUploadStart,
+        postUploadComplete,
+      });
+      directHandler.registerUploader("mock", mockUploader);
+
+      const file = createMockFile("avatar.png", "imgdata", "image/png");
+      await directHandler.startUpload("avatar", [file]);
+      await jest.runAllTimersAsync();
+
+      // The transport was snapshotted before the PUT (disconnected), so completion
+      // stays on HTTP even though the socket came back up during the upload — the
+      // HTTP-start entry only exists in the HTTP completion path.
+      expect(postUploadComplete).toHaveBeenCalledTimes(1);
+      expect(mockSendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: "upload_complete" })
+      );
+    });
+
     it("surfaces an error for a disconnected Direct upload with no HTTP completion transport (#448)", async () => {
       const onError = jest.fn();
       const postUploadStart = jest.fn().mockResolvedValue({

--- a/tests/upload-handler.test.ts
+++ b/tests/upload-handler.test.ts
@@ -384,6 +384,81 @@ describe("UploadHandler", () => {
       expect(postMultipart).toHaveBeenCalledTimes(1);
     });
 
+    it("completes a disconnected Direct upload over HTTP, re-sending the ref (#448)", async () => {
+      const postUploadStart = jest.fn().mockResolvedValue({
+        upload_name: "avatar",
+        entries: [
+          {
+            entry_id: "entry-1",
+            client_name: "avatar.png",
+            valid: true,
+            auto_upload: true,
+            mode: "direct",
+            external: { uploader: "mock", url: "https://cdn.example/avatar.png" },
+          },
+        ],
+      });
+      const mockUploader = { upload: jest.fn().mockResolvedValue(undefined) };
+      const postUploadComplete = jest.fn().mockResolvedValue(undefined);
+      const directHandler = new UploadHandler(mockSendMessage, {
+        isConnected: () => false,
+        postUploadStart,
+        postUploadComplete,
+      });
+      directHandler.registerUploader("mock", mockUploader);
+
+      const file = createMockFile("avatar.png", "imgdata", "image/png");
+      await directHandler.startUpload("avatar", [file]);
+      await jest.runAllTimersAsync();
+
+      // The browser PUT ran, then completion went over HTTP carrying the entry
+      // metadata + the ref it uploaded to — not the WebSocket entry_ids ack.
+      expect(mockUploader.upload).toHaveBeenCalledTimes(1);
+      expect(postUploadComplete).toHaveBeenCalledTimes(1);
+      const msg = postUploadComplete.mock.calls[0][0];
+      expect(msg.upload_name).toBe("avatar");
+      expect(msg.entries[0].ref).toBe("https://cdn.example/avatar.png");
+      expect(msg.entries[0].client_name).toBe("avatar.png");
+      expect(mockSendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: "upload_complete" })
+      );
+    });
+
+    it("falls back to a multipart POST for a disconnected Volume upload (#449)", async () => {
+      const postUploadStart = jest.fn().mockResolvedValue({
+        upload_name: "scan",
+        entries: [
+          {
+            entry_id: "entry-1",
+            client_name: "scan.png",
+            valid: true,
+            auto_upload: true,
+            mode: "volume",
+          },
+        ],
+      });
+      const postMultipart = jest.fn().mockResolvedValue(undefined);
+      const volumeHandler = new UploadHandler(mockSendMessage, {
+        isConnected: () => false,
+        postUploadStart,
+        postMultipartUpload: postMultipart,
+      });
+
+      const file = createMockFile("scan.png", "imgdata", "image/png");
+      await volumeHandler.startUpload("scan", [file]);
+      await jest.runAllTimersAsync();
+
+      // The file went as a single multipart POST (server stages it to Dir)...
+      expect(postMultipart).toHaveBeenCalledTimes(1);
+      const fd = postMultipart.mock.calls[0][0] as FormData;
+      expect(fd.get("lvt-action")).toBe("upload_scan_complete");
+      expect(fd.get("scan")).toBeInstanceOf(File);
+      // ...never over the WebSocket chunk transport.
+      expect(mockSendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: "upload_chunk" })
+      );
+    });
+
     it("logs warning for missing files", async () => {
       const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
 

--- a/tests/upload-handler.test.ts
+++ b/tests/upload-handler.test.ts
@@ -424,6 +424,45 @@ describe("UploadHandler", () => {
       );
     });
 
+    it("surfaces an error for a disconnected Direct upload with no HTTP completion transport (#448)", async () => {
+      const onError = jest.fn();
+      const postUploadStart = jest.fn().mockResolvedValue({
+        upload_name: "avatar",
+        entries: [
+          {
+            entry_id: "entry-1",
+            client_name: "avatar.png",
+            valid: true,
+            auto_upload: true,
+            mode: "direct",
+            external: { uploader: "mock", url: "https://cdn.example/avatar.png" },
+          },
+        ],
+      });
+      const mockUploader = { upload: jest.fn().mockResolvedValue(undefined) };
+      // isConnected:false but no postUploadComplete injected — the completion
+      // must not silently fall back to a sendMessage over the dead socket.
+      const directHandler = new UploadHandler(mockSendMessage, {
+        isConnected: () => false,
+        postUploadStart,
+        onError,
+      });
+      directHandler.registerUploader("mock", mockUploader);
+
+      const file = createMockFile("avatar.png", "imgdata", "image/png");
+      await directHandler.startUpload("avatar", [file]);
+      await jest.runAllTimersAsync();
+
+      expect(mockUploader.upload).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ uploadName: "avatar" }),
+        expect.stringContaining("no HTTP transport configured")
+      );
+      expect(mockSendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: "upload_complete" })
+      );
+    });
+
     it("falls back to a multipart POST for a disconnected Volume upload (#449)", async () => {
       const postUploadStart = jest.fn().mockResolvedValue({
         upload_name: "scan",

--- a/upload/types.ts
+++ b/upload/types.ts
@@ -79,6 +79,25 @@ export interface UploadCompleteMessage {
   entry_ids: string[];
 }
 
+/**
+ * WebSocket-disabled Direct completion (issue #448). Over WebSocket the server
+ * holds the presigned entry from upload_start; over stateless HTTP that entry is
+ * gone by completion time, so the client re-sends the entry metadata (and the
+ * ref it uploaded to) for the server to reconstruct the completed entry.
+ */
+export interface UploadCompleteHTTPMessage {
+  action: "upload_complete";
+  upload_name: string;
+  entries: CompletedEntryMeta[];
+}
+
+export interface CompletedEntryMeta {
+  client_name: string;
+  type: string;
+  size: number;
+  ref: string;
+}
+
 export interface UploadCompleteResponse {
   upload_name: string;
   success: boolean;
@@ -144,6 +163,17 @@ export interface UploadHandlerOptions {
     message: UploadStartMessage,
     signal?: AbortSignal
   ) => Promise<UploadStartResponse>;
+  /**
+   * Posts an upload_complete handshake over HTTP and applies the server's tree
+   * response. Used when the WebSocket is down so a Direct upload's completion
+   * action runs without a persistent registry (#448): the client re-sends the
+   * entry metadata + ref. Injected by the LiveTemplate client; rejects on a
+   * non-2xx response.
+   */
+  postUploadComplete?: (
+    message: UploadCompleteHTTPMessage,
+    signal?: AbortSignal
+  ) => Promise<void>;
 }
 
 export interface Uploader {

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -69,6 +69,11 @@ export class UploadHandler {
     this.uploaders.set("s3", new S3Uploader());
   }
 
+  /** Whether the WebSocket is usable; true when no isConnected probe is wired. */
+  private connected(): boolean {
+    return this.isConnected ? this.isConnected() : true;
+  }
+
   /**
    * Dispatch a valid upload entry to the transport its mode requires. The server
    * declares the mode per-entry; existing entries that only carry `external`
@@ -101,7 +106,7 @@ export class UploadHandler {
         // Volume stages bytes over the WebSocket chunk transport; with the
         // socket down, fall back to a single multipart POST that the server
         // stages to the field's Dir (#449).
-        const connected = this.isConnected ? this.isConnected() : true;
+        const connected = this.connected();
         if (!connected) {
           void this.uploadMultipart(entry);
         } else {
@@ -201,7 +206,7 @@ export class UploadHandler {
     // UploadStartResponse message (routed to handleUploadStartResponse). With
     // the socket down, post the handshake over HTTP and handle the response
     // inline so mode dispatch (and Direct presign) still work.
-    const connected = this.isConnected ? this.isConnected() : true;
+    const connected = this.connected();
     if (!connected) {
       if (!this.postUploadStart) {
         this.failStart(
@@ -364,8 +369,9 @@ export class UploadHandler {
       // side that holds the entry. If we re-checked after the PUT, a WS that
       // dropped or reconnected mid-upload could make the two disagree: a WS-start
       // entry completed over HTTP (or vice-versa) targets a registry that never
-      // had it. Volume snapshots the same way (in dispatchUpload).
-      const connected = this.isConnected ? this.isConnected() : true;
+      // had it. Volume likewise picks its transport up front, at dispatch time
+      // (a mid-transfer drop within either path is out of scope here).
+      const connected = this.connected();
 
       // Start external upload with progress callback
       await uploader.upload(entry, meta, this.onProgress);

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -14,6 +14,7 @@ import type {
   ExternalUploadMeta,
   FileMetadata,
   UploadChunkMessage,
+  UploadCompleteHTTPMessage,
   UploadCompleteMessage,
   UploadEntry,
   UploadHandlerOptions,
@@ -42,6 +43,10 @@ export class UploadHandler {
     message: UploadStartMessage,
     signal?: AbortSignal
   ) => Promise<UploadStartResponse>;
+  private postUploadComplete?: (
+    message: UploadCompleteHTTPMessage,
+    signal?: AbortSignal
+  ) => Promise<void>;
   private pendingHandshakes: Set<AbortController> = new Set();
   private pendingUploads: Set<AbortController> = new Set(); // in-flight proxied fetches
   private previewUrls: Map<string, string> = new Map(); // uploadName -> object URL
@@ -58,6 +63,7 @@ export class UploadHandler {
     this.postMultipartUpload = options.postMultipartUpload;
     this.isConnected = options.isConnected;
     this.postUploadStart = options.postUploadStart;
+    this.postUploadComplete = options.postUploadComplete;
 
     // Register default uploaders
     this.uploaders.set("s3", new S3Uploader());
@@ -74,7 +80,7 @@ export class UploadHandler {
         this.uploadPreview(entry);
         return;
       case "proxied":
-        void this.uploadProxied(entry);
+        void this.uploadMultipart(entry);
         return;
       case "direct":
         if (entry.external) {
@@ -89,10 +95,19 @@ export class UploadHandler {
         }
         return;
       case "volume":
-      default:
+      default: {
         // entry.mode is normalized to a concrete mode at ingest (see
         // handleUploadStartResponse), so the default is just the Volume path.
-        void this.uploadChunked(entry);
+        // Volume stages bytes over the WebSocket chunk transport; with the
+        // socket down, fall back to a single multipart POST that the server
+        // stages to the field's Dir (#449).
+        const connected = this.isConnected ? this.isConnected() : true;
+        if (!connected) {
+          void this.uploadMultipart(entry);
+        } else {
+          void this.uploadChunked(entry);
+        }
+      }
     }
   }
 
@@ -347,14 +362,33 @@ export class UploadHandler {
       // Start external upload with progress callback
       await uploader.upload(entry, meta, this.onProgress);
 
-      // Notify server of completion
-      const completeMessage: UploadCompleteMessage = {
-        action: "upload_complete",
-        upload_name: entry.uploadName,
-        entry_ids: [entry.id],
-      };
-
-      this.sendMessage(completeMessage);
+      // Notify the server of completion. Over WebSocket the server still holds
+      // the presigned entry, so an entry_ids ack suffices. With the socket down
+      // the per-request registry is gone, so re-send the entry metadata + the
+      // ref we uploaded to and let the server reconstruct the entry (#448).
+      const connected = this.isConnected ? this.isConnected() : true;
+      if (!connected && this.postUploadComplete) {
+        const httpComplete: UploadCompleteHTTPMessage = {
+          action: "upload_complete",
+          upload_name: entry.uploadName,
+          entries: [
+            {
+              client_name: entry.file.name,
+              type: entry.file.type,
+              size: entry.file.size,
+              ref: meta.url,
+            },
+          ],
+        };
+        await this.postUploadComplete(httpComplete, entry.abortController?.signal);
+      } else {
+        const completeMessage: UploadCompleteMessage = {
+          action: "upload_complete",
+          upload_name: entry.uploadName,
+          entry_ids: [entry.id],
+        };
+        this.sendMessage(completeMessage);
+      }
       this.finishUpload(entry);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
@@ -368,15 +402,17 @@ export class UploadHandler {
   }
 
   /**
-   * Upload a Proxied file as a single multipart POST to the live URL. The server
-   * streams the bytes straight to the app's OnUpload handler (zero local-disk
-   * staging) and dispatches the upload_<name>_complete action. Independent of
-   * the WebSocket, so it works with the socket disabled.
+   * Upload a file as a single multipart POST to the live URL, carrying the
+   * upload_<name>_complete action and the enclosing form fields. The server
+   * routes the part by the field's configured mode: a Proxied field streams the
+   * bytes to OnUpload (zero local-disk staging), a Volume-with-Dir field stages
+   * them to Dir. Independent of the WebSocket — Proxied always uses this, and
+   * Volume falls back to it when the socket is down (#449).
    */
-  private async uploadProxied(entry: UploadEntry): Promise<void> {
+  private async uploadMultipart(entry: UploadEntry): Promise<void> {
     if (!this.postMultipartUpload) {
       const msg =
-        "Proxied upload unavailable: no multipart transport configured";
+        "Multipart upload unavailable: no multipart transport configured";
       entry.error = msg;
       if (this.onError) this.onError(entry, msg);
       this.cleanupEntries(entry.uploadName);
@@ -411,7 +447,7 @@ export class UploadHandler {
     } finally {
       if (entry.abortController) this.pendingUploads.delete(entry.abortController);
       // Release the DOM reference once the upload is done — the entry may linger
-      // until the cleanup timer fires, and only uploadProxied ever reads it.
+      // until the cleanup timer fires, and only uploadMultipart ever reads it.
       entry.sourceInput = undefined;
     }
   }

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -367,7 +367,17 @@ export class UploadHandler {
       // the per-request registry is gone, so re-send the entry metadata + the
       // ref we uploaded to and let the server reconstruct the entry (#448).
       const connected = this.isConnected ? this.isConnected() : true;
-      if (!connected && this.postUploadComplete) {
+      if (!connected) {
+        if (!this.postUploadComplete) {
+          // The bytes are already on the CDN, but a sendMessage over the dead
+          // socket would silently drop the completion — surface it instead.
+          const msg =
+            "upload_complete unavailable: WebSocket is down and no HTTP transport configured";
+          entry.error = msg;
+          if (this.onError) this.onError(entry, msg);
+          this.cleanupEntries(entry.uploadName);
+          return;
+        }
         const httpComplete: UploadCompleteHTTPMessage = {
           action: "upload_complete",
           upload_name: entry.uploadName,

--- a/upload/upload-handler.ts
+++ b/upload/upload-handler.ts
@@ -48,7 +48,7 @@ export class UploadHandler {
     signal?: AbortSignal
   ) => Promise<void>;
   private pendingHandshakes: Set<AbortController> = new Set();
-  private pendingUploads: Set<AbortController> = new Set(); // in-flight proxied fetches
+  private pendingUploads: Set<AbortController> = new Set(); // in-flight multipart fetches
   private previewUrls: Map<string, string> = new Map(); // uploadName -> object URL
   private inputHandlers: WeakMap<HTMLInputElement, EventListener> = new WeakMap();
 
@@ -359,6 +359,14 @@ export class UploadHandler {
         throw new Error(`Unknown uploader: ${meta.uploader}`);
       }
 
+      // Snapshot the transport BEFORE the (potentially slow) PUT, so the
+      // completion uses the same transport the upload_start handshake did — the
+      // side that holds the entry. If we re-checked after the PUT, a WS that
+      // dropped or reconnected mid-upload could make the two disagree: a WS-start
+      // entry completed over HTTP (or vice-versa) targets a registry that never
+      // had it. Volume snapshots the same way (in dispatchUpload).
+      const connected = this.isConnected ? this.isConnected() : true;
+
       // Start external upload with progress callback
       await uploader.upload(entry, meta, this.onProgress);
 
@@ -366,7 +374,6 @@ export class UploadHandler {
       // the presigned entry, so an entry_ids ack suffices. With the socket down
       // the per-request registry is gone, so re-send the entry metadata + the
       // ref we uploaded to and let the server reconstruct the entry (#448).
-      const connected = this.isConnected ? this.isConnected() : true;
       if (!connected) {
         if (!this.postUploadComplete) {
           // The bytes are already on the CDN, but a sendMessage over the dead


### PR DESCRIPTION
When the WebSocket is down, two upload modes now complete over HTTP. Pairs with the server PR `livetemplate/livetemplate#455`. Fixes livetemplate/livetemplate#448, livetemplate/livetemplate#449 (client side).

## #448 Direct
After the browser PUTs to the presigned URL, `uploadExternal` branches on `isConnected()`: connected → the WebSocket `entry_ids` ack (unchanged); disconnected → a new `postUploadCompleteHTTP` (`X-Lvt-Upload: complete`) re-sending the entry metadata + the ref it uploaded to, so the server reconstructs the completed entry without a persistent registry, then applies the returned tree.

## #449 Volume
A file selected with the socket down now falls back to a single multipart POST instead of WS chunks. `uploadProxied` is generalized to `uploadMultipart` — the transport is identical, and the server routes the part by the field's mode (Proxied → `OnUpload`, Volume-with-`Dir` → staged to `Dir`). The Volume dispatch calls it when `!isConnected()`.

## Tests
`tests/upload-handler.test.ts`: disconnected Direct → `postUploadComplete(ref===meta.url)` (not the WS ack); disconnected Volume → multipart POST (not WS chunks). Both red without the branches; 701 jest pass.

Adds `UploadCompleteHTTPMessage` type + `postUploadComplete` option. Needs a lockstep release after the server release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)