### PR TITLE
feat(directives): lvt-fx:region-select + shared box-drag spine

### DIFF
--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1120,6 +1120,21 @@ export function handleIframeAutoHeightDirectives(rootElement: Element): void {
   }
 }
 
+/**
+ * Cancel iframe auto-height listeners for every armed element under root.
+ * Mirror of teardownAreaSelectForRoot for the client disconnect lifecycle:
+ * the per-render sweep can't fire after a disconnect (no more renders), so
+ * without this the iframe's `load` listener + ResizeObserver would leak,
+ * and each reconnect (e.g. Turbo navigation) would add another.
+ */
+export function teardownIframeAutoHeightForRoot(rootElement: Element): void {
+  for (const [element, entry] of Array.from(iframeAutoHeightArmed)) {
+    if (rootElement.contains(element)) {
+      entry.cleanup();
+    }
+  }
+}
+
 function attachIframeAutoHeight(
   iframe: HTMLIFrameElement
 ): IframeAutoHeightEntry {
@@ -2124,6 +2139,9 @@ function resolveRegion(el: HTMLElement, box: BoxDragResult): LineRange | null {
       readCodeRange
     );
   }
+  console.warn(
+    `lvt-fx:region-select: unknown data-surface ${JSON.stringify(surface)} (expected "html" or "code")`
+  );
   return null;
 }
 

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1067,6 +1067,96 @@ export function teardownAreaSelectForRoot(rootElement: Element): void {
   }
 }
 
+// iframeAutoHeightArmed tracks armed `lvt-fx:iframe-autoheight` <iframe>
+// hosts. Map (not WeakMap) so the sweep can iterate to clean up elements
+// whose attribute was removed by a server diff or that were detached —
+// same reasoning as area-select.
+const iframeAutoHeightArmed = new Map<Element, IframeAutoHeightEntry>();
+
+interface IframeAutoHeightEntry {
+  cleanup: () => void;
+  // sync re-measures the iframe height from its content. Called every
+  // render so a reflow that doesn't reload the srcdoc still resizes.
+  sync: () => void;
+}
+
+/**
+ * Apply iframe auto-height directives. `lvt-fx:iframe-autoheight` on a
+ * same-origin `<iframe sandbox="allow-same-origin">` (the prereview HTML
+ * preview) sizes the iframe to its content's scrollHeight on load and
+ * whenever the content reflows (ResizeObserver) — iframes don't size to
+ * their content. The preview is an iframe, not a shadow root, so the
+ * page's own CSS (var()/@media/vw/position:sticky) resolves against a real
+ * viewport (issue #26). Reading scrollHeight requires `allow-same-origin`.
+ *
+ * Selecting a region of the preview to comment on is handled separately,
+ * by an overlay in the PARENT document (lvt-fx:region-select) — not from
+ * inside the iframe: iOS Safari does not deliver iframe-internal events to
+ * parent listeners, so a same-origin contentDocument tap never arrives.
+ *
+ * Idempotent across renders; the sweep at the top cleans up detached /
+ * attribute-cleared iframes.
+ */
+export function handleIframeAutoHeightDirectives(rootElement: Element): void {
+  for (const [element, entry] of Array.from(iframeAutoHeightArmed)) {
+    if (
+      !element.isConnected ||
+      !element.hasAttribute("lvt-fx:iframe-autoheight")
+    ) {
+      entry.cleanup();
+    }
+  }
+
+  const matches = rootElement.querySelectorAll<HTMLIFrameElement>(
+    "iframe[lvt-fx\\:iframe-autoheight]"
+  );
+  for (const el of matches) {
+    const existing = iframeAutoHeightArmed.get(el);
+    if (existing) {
+      existing.sync();
+      continue;
+    }
+    iframeAutoHeightArmed.set(el, attachIframeAutoHeight(el));
+  }
+}
+
+function attachIframeAutoHeight(
+  iframe: HTMLIFrameElement
+): IframeAutoHeightEntry {
+  let resizeObserver: ResizeObserver | null = null;
+
+  const applyHeight = () => {
+    const doc = iframe.contentDocument;
+    if (!doc?.documentElement) return;
+    const h = doc.documentElement.scrollHeight;
+    if (h > 0) iframe.style.height = `${h}px`;
+  };
+
+  const onLoad = () => {
+    const doc = iframe.contentDocument;
+    if (!doc) return;
+    resizeObserver?.disconnect();
+    if (typeof ResizeObserver !== "undefined" && doc.documentElement) {
+      resizeObserver = new ResizeObserver(() => applyHeight());
+      resizeObserver.observe(doc.documentElement);
+    }
+    applyHeight();
+  };
+
+  iframe.addEventListener("load", onLoad);
+  // srcdoc set before this directive ran may have already loaded.
+  if (iframe.contentDocument?.readyState === "complete") onLoad();
+
+  return {
+    cleanup: () => {
+      iframe.removeEventListener("load", onLoad);
+      resizeObserver?.disconnect();
+      iframeAutoHeightArmed.delete(iframe);
+    },
+    sync: () => applyHeight(),
+  };
+}
+
 // urlHashArmed tracks `lvt-fx:url-hash` listeners and their last-
 // mirrored hash. Same Map-not-WeakMap reasoning as area-select: the
 // sweep iterates to detect elements whose attribute was removed by a
@@ -1504,12 +1594,38 @@ function attachURLHash(
 // against the stale-closure trap a caller would hit if their `send`
 // reference changed across renders — e.g. a reconnect rebuilt the
 // transport.
-function attachAreaSelect(
+// BoxDragResult is the final rectangle handed to a box-drag consumer when
+// a real drag (above the click threshold) completes inside the host.
+interface BoxDragResult {
+  // Clamped drag rectangle in VIEWPORT coordinates (host-bounded). Used by
+  // hit-test consumers (region-select) that compare the box against other
+  // elements' getBoundingClientRect().
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  // The same rectangle as 0..1 fractions of the host's rendered rect. Used
+  // by fraction consumers (area-select on an image).
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+// attachBoxDragSelect wires the pointer-drag gesture + live overlay on a
+// host element and invokes onComplete with the final rectangle when the
+// user finishes a drag big enough to count as a selection (not a click).
+// It owns every pointer-capture / re-entrancy / multi-touch / parent-
+// positioning / off-edge-clamping subtlety; consumers differ ONLY in what
+// they do with the result — area-select sends {x,y,w,h} fractions, region-
+// select hit-tests the viewport box to a source line range. This is the
+// shared spine; do not duplicate it.
+function attachBoxDragSelect(
   el: HTMLElement,
-  action: string,
-  initialSend: AreaSelectSendFn
-): AreaSelectEntry {
-  let send = initialSend;
+  warnedParents: WeakSet<Element>,
+  attrName: string,
+  onComplete: (result: BoxDragResult) => void
+): { cleanup: () => void } {
   let overlay: HTMLDivElement | null = null;
   let startClientX = 0;
   let startClientY = 0;
@@ -1608,7 +1724,9 @@ function attachAreaSelect(
       // handlers (if any) run via the platform.
       return;
     }
-    send({ action, data: { x, y, w, h } });
+    // Hand the consumer both the clamped viewport box (x0,y0,x1,y1) and
+    // the host-relative fractions; it decides the payload.
+    onComplete({ left: x0, top: y0, right: x1, bottom: y1, x, y, w, h });
   };
 
   const onPointerLeaveCancel = (e: PointerEvent) => {
@@ -1653,7 +1771,7 @@ function attachAreaSelect(
     // returns "" for unset position). Dedupe via WeakSet so a user
     // dragging repeatedly on the same mis-configured parent gets ONE
     // console message, not one per pointerdown.
-    if (!areaSelectWarnedParents.has(parent)) {
+    if (!warnedParents.has(parent)) {
       const parentPos = window.getComputedStyle(parent).position;
       if (
         parentPos !== "relative" &&
@@ -1662,11 +1780,11 @@ function attachAreaSelect(
         parentPos !== "sticky"
       ) {
         console.warn(
-          "lvt-fx:area-select: parentElement has no positioning context; the drag overlay will be mis-positioned. " +
+          `${attrName}: parentElement has no positioning context; the drag overlay will be mis-positioned. ` +
             "Add position:relative (or absolute/fixed/sticky) to the parent.",
           parent
         );
-        areaSelectWarnedParents.add(parent);
+        warnedParents.add(parent);
       }
     }
     startClientX = e.clientX;
@@ -1808,16 +1926,251 @@ function attachAreaSelect(
     el.removeEventListener("pointerleave", onPointerLeaveCancel);
     el.removeEventListener("dragstart", onDragStart);
     finalize(null, false);
-    areaSelectArmed.delete(el);
   };
 
+  return { cleanup };
+}
+
+// attachAreaSelect wires lvt-fx:area-select on an image host: a drawn box
+// dispatches the action with {x,y,w,h} as 0..1 fractions of the host's
+// rendered rect (image bytes don't reflow, so a pixel rect is stable).
+function attachAreaSelect(
+  el: HTMLElement,
+  action: string,
+  initialSend: AreaSelectSendFn
+): AreaSelectEntry {
+  let send = initialSend;
+  const handle = attachBoxDragSelect(
+    el,
+    areaSelectWarnedParents,
+    "lvt-fx:area-select",
+    (r) => send({ action, data: { x: r.x, y: r.y, w: r.w, h: r.h } })
+  );
   return {
     action,
-    cleanup,
+    cleanup: () => {
+      handle.cleanup();
+      areaSelectArmed.delete(el);
+    },
     updateSend: (s) => {
       send = s;
     },
   };
+}
+
+// regionSelectArmed / regionSelectWarnedParents mirror the area-select
+// singletons (see those for the Map-not-WeakMap reasoning).
+const regionSelectArmed = new Map<Element, AreaSelectEntry>();
+const regionSelectWarnedParents = new WeakSet<Element>();
+
+/**
+ * Apply region-select directives. `lvt-fx:region-select="<actionName>"` on
+ * a transparent overlay (parent light DOM) laid over a rendered-HTML
+ * preview iframe or a code view lets the user DRAW A BOX to comment on a
+ * region — the same touch-capable drag as area-select, but the drawn box
+ * is hit-tested to a SOURCE LINE RANGE instead of a pixel rect, so the
+ * comment survives responsive reflow and round-trips with the raw view +
+ * CSV (issue #26 region comments).
+ *
+ * The overlay's `data-surface` selects the hit-test:
+ *   - "html": the box is intersected against the sibling iframe's
+ *     contentDocument `[data-from]`/`[data-to]` blocks, offset by the
+ *     iframe's viewport position (the auto-height iframe doesn't scroll).
+ *   - "code": the box is intersected against the parent's `[data-line]`
+ *     rows in the same document.
+ * Either resolves to `{from, to[, side]}` and dispatches the action; a box
+ * that hits no line-bearing element dispatches nothing.
+ *
+ * The overlay lives in the PARENT document on purpose: iOS Safari does not
+ * deliver events that happen inside an iframe to a parent listener, so the
+ * old in-iframe tap never arrived on a phone. A parent overlay is the same
+ * event path as the file list, which works.
+ *
+ * Idempotent + swept exactly like area-select. The overlay's parent must
+ * establish a positioning context (the shared drag spine warns if not).
+ * Images keep using lvt-fx:area-select (pixel rects are stable).
+ */
+export function handleRegionSelectDirectives(
+  rootElement: Element,
+  send: AreaSelectSendFn
+): void {
+  for (const [element, entry] of Array.from(regionSelectArmed)) {
+    if (!element.isConnected || !element.hasAttribute("lvt-fx:region-select")) {
+      entry.cleanup();
+    }
+  }
+  const matches = rootElement.querySelectorAll<HTMLElement>(
+    "[lvt-fx\\:region-select]"
+  );
+  if (matches.length === 0) return;
+  for (const el of matches) {
+    const action = el.getAttribute("lvt-fx:region-select");
+    if (!action) {
+      console.warn(
+        `lvt-fx:region-select requires an action name, got: ${JSON.stringify(action)}`
+      );
+      continue;
+    }
+    const existing = regionSelectArmed.get(el);
+    if (existing && existing.action === action) {
+      existing.updateSend(send);
+      continue;
+    }
+    if (existing) existing.cleanup();
+    regionSelectArmed.set(el, attachRegionSelect(el, action, send));
+  }
+}
+
+/**
+ * Cancel region-select listeners for every armed element under root.
+ * Mirror of teardownAreaSelectForRoot for the client disconnect lifecycle.
+ */
+export function teardownRegionSelectForRoot(rootElement: Element): void {
+  for (const [element, entry] of Array.from(regionSelectArmed)) {
+    if (rootElement.contains(element)) {
+      entry.cleanup();
+    }
+  }
+}
+
+function attachRegionSelect(
+  el: HTMLElement,
+  action: string,
+  initialSend: AreaSelectSendFn
+): AreaSelectEntry {
+  let send = initialSend;
+  const handle = attachBoxDragSelect(
+    el,
+    regionSelectWarnedParents,
+    "lvt-fx:region-select",
+    (r) => {
+      const data = resolveRegion(el, r);
+      if (data) send({ action, data });
+    }
+  );
+  return {
+    action,
+    cleanup: () => {
+      handle.cleanup();
+      regionSelectArmed.delete(el);
+    },
+    updateSend: (s) => {
+      send = s;
+    },
+  };
+}
+
+type LineRange = { from: number; to: number; side?: string };
+
+// resolveRegion hit-tests a drawn box (viewport coords) against the line-
+// bearing elements of the overlay's target surface, returning the source
+// line-range payload or null when the box hit nothing.
+function resolveRegion(el: HTMLElement, box: BoxDragResult): LineRange | null {
+  const surface = el.getAttribute("data-surface");
+  if (surface === "html") {
+    // The overlay sits beside the iframe inside a positioned wrapper.
+    const iframe = el.parentElement?.querySelector<HTMLIFrameElement>("iframe");
+    const doc = iframe?.contentDocument;
+    if (!iframe || !doc) return null;
+    const fr = iframe.getBoundingClientRect();
+    return lineRangeFromBox(
+      doc.querySelectorAll("[data-from]"),
+      box,
+      fr.left,
+      fr.top,
+      readHTMLRange
+    );
+  }
+  if (surface === "code") {
+    const root: ParentNode = el.parentElement || document;
+    return lineRangeFromBox(
+      root.querySelectorAll("[data-line]"),
+      box,
+      0,
+      0,
+      readCodeRange
+    );
+  }
+  return null;
+}
+
+// readHTMLRange reads a rendered-HTML block's source span from its
+// data-from / data-to attributes (data-to defaults to data-from).
+function readHTMLRange(el: Element): LineRange | null {
+  const from = parseInt(el.getAttribute("data-from") || "", 10);
+  if (!Number.isFinite(from) || from <= 0) return null;
+  const to = parseInt(el.getAttribute("data-to") || "", 10);
+  return { from, to: Number.isFinite(to) && to >= from ? to : from };
+}
+
+// readCodeRange reads a code row's source line from data-line and its diff
+// side from data-side ("old" rows carry it; everything else is "new").
+function readCodeRange(el: Element): LineRange | null {
+  const n = parseInt(el.getAttribute("data-line") || "", 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return el.getAttribute("data-side") === "old"
+    ? { from: n, to: n, side: "old" }
+    : { from: n, to: n };
+}
+
+/**
+ * lineRangeFromBox intersects a drawn box (viewport coords) with a set of
+ * line-bearing candidate elements and returns a single-side line range of
+ * those that overlap it — `from` = smallest line, `to` = largest.
+ *
+ * The side of the TOPMOST intersecting row fixes the range's side, and
+ * rows of any OTHER side are then excluded. This matters on a diff: a
+ * `del` row's data-line is its OLD line number, an `add`/context row's is
+ * its NEW number — two different coordinate systems. A box that strays
+ * across the add/del boundary must NOT union those into one range (it
+ * would mis-anchor). Restricting to one side mirrors SelectLine's locked-
+ * side invariant. Rendered HTML has no sides (all undefined), so every
+ * overlapping block contributes.
+ *
+ * offsetX/offsetY shift each candidate's rect into the box's coordinate
+ * space (the iframe's viewport origin for the html surface; 0 for code).
+ * Returns null when no candidate overlaps. Exported for unit testing.
+ */
+export function lineRangeFromBox(
+  candidates: ArrayLike<Element>,
+  box: { left: number; top: number; right: number; bottom: number },
+  offsetX: number,
+  offsetY: number,
+  readRange: (el: Element) => LineRange | null
+): LineRange | null {
+  // First pass: collect overlapping rows with their viewport top so the
+  // topmost can fix the side before we union (a box can cross the diff's
+  // add/del boundary).
+  const hits: { top: number; range: LineRange }[] = [];
+  for (const el of Array.from(candidates)) {
+    const r = el.getBoundingClientRect();
+    const top = r.top + offsetY;
+    const bottom = r.bottom + offsetY;
+    const left = r.left + offsetX;
+    const right = r.right + offsetX;
+    // Skip candidates the box doesn't overlap at all.
+    if (
+      right < box.left ||
+      left > box.right ||
+      bottom < box.top ||
+      top > box.bottom
+    ) {
+      continue;
+    }
+    const range = readRange(el);
+    if (range) hits.push({ top, range });
+  }
+  if (hits.length === 0) return null;
+  hits.sort((a, b) => a.top - b.top);
+  const side = hits[0].range.side;
+  let from = Infinity;
+  let to = -Infinity;
+  for (const { range } of hits) {
+    if (range.side !== side) continue; // exclude the other diff side
+    if (range.from < from) from = range.from;
+    if (range.to > to) to = range.to;
+  }
+  return side ? { from, to, side } : { from, to };
 }
 
 function clampRange(n: number, lo: number, hi: number): number {

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1129,6 +1129,10 @@ function attachIframeAutoHeight(
     const doc = iframe.contentDocument;
     if (!doc?.documentElement) return;
     const h = doc.documentElement.scrollHeight;
+    // Skip a 0 height: it means no layout yet (pre-load, or jsdom which
+    // never lays out). A genuinely empty document stays at its default
+    // height until the next `load` re-measures — fine for the preview,
+    // which always has content.
     if (h > 0) iframe.style.height = `${h}px`;
   };
 
@@ -2062,14 +2066,27 @@ function attachRegionSelect(
 
 type LineRange = { from: number; to: number; side?: string };
 
+// previewIframeFor finds the iframe a region overlay covers. The overlay
+// is a sibling of its iframe inside a positioned wrapper and is rendered
+// immediately AFTER it, so the preceding sibling is the target. Prefer
+// that over `wrapper.querySelector("iframe")`, which would silently pick
+// the wrong element if the wrapper ever held more than one iframe; fall
+// back to the first iframe in the wrapper only if the sibling isn't one.
+function previewIframeFor(overlay: HTMLElement): HTMLIFrameElement | null {
+  const prev = overlay.previousElementSibling;
+  if (prev instanceof HTMLIFrameElement) return prev;
+  return (
+    overlay.parentElement?.querySelector<HTMLIFrameElement>("iframe") ?? null
+  );
+}
+
 // resolveRegion hit-tests a drawn box (viewport coords) against the line-
 // bearing elements of the overlay's target surface, returning the source
 // line-range payload or null when the box hit nothing.
 function resolveRegion(el: HTMLElement, box: BoxDragResult): LineRange | null {
   const surface = el.getAttribute("data-surface");
   if (surface === "html") {
-    // The overlay sits beside the iframe inside a positioned wrapper.
-    const iframe = el.parentElement?.querySelector<HTMLIFrameElement>("iframe");
+    const iframe = previewIframeFor(el);
     const doc = iframe?.contentDocument;
     if (!iframe || !doc) return null;
     const fr = iframe.getBoundingClientRect();
@@ -2096,7 +2113,8 @@ function resolveRegion(el: HTMLElement, box: BoxDragResult): LineRange | null {
 
 // readHTMLRange reads a rendered-HTML block's source span from its
 // data-from / data-to attributes (data-to defaults to data-from).
-function readHTMLRange(el: Element): LineRange | null {
+// Exported so unit tests exercise the real reader, not a copy.
+export function readHTMLRange(el: Element): LineRange | null {
   const from = parseInt(el.getAttribute("data-from") || "", 10);
   if (!Number.isFinite(from) || from <= 0) return null;
   const to = parseInt(el.getAttribute("data-to") || "", 10);
@@ -2105,7 +2123,8 @@ function readHTMLRange(el: Element): LineRange | null {
 
 // readCodeRange reads a code row's source line from data-line and its diff
 // side from data-side ("old" rows carry it; everything else is "new").
-function readCodeRange(el: Element): LineRange | null {
+// Exported so unit tests exercise the real reader, not a copy.
+export function readCodeRange(el: Element): LineRange | null {
   const n = parseInt(el.getAttribute("data-line") || "", 10);
   if (!Number.isFinite(n) || n <= 0) return null;
   return el.getAttribute("data-side") === "old"

--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -1126,18 +1126,29 @@ function attachIframeAutoHeight(
   let resizeObserver: ResizeObserver | null = null;
 
   const applyHeight = () => {
-    const doc = iframe.contentDocument;
-    if (!doc?.documentElement) return;
-    const h = doc.documentElement.scrollHeight;
-    // Skip a 0 height: it means no layout yet (pre-load, or jsdom which
-    // never lays out). A genuinely empty document stays at its default
-    // height until the next `load` re-measures — fine for the preview,
-    // which always has content.
-    if (h > 0) iframe.style.height = `${h}px`;
+    try {
+      const doc = iframe.contentDocument;
+      if (!doc?.documentElement) return;
+      const h = doc.documentElement.scrollHeight;
+      // Skip a 0 height: it means no layout yet (pre-load, or jsdom which
+      // never lays out). A genuinely empty document stays at its default
+      // height until the next `load` re-measures — fine for the preview,
+      // which always has content.
+      if (h > 0) iframe.style.height = `${h}px`;
+    } catch {
+      // contentDocument throws on a cross-origin iframe (this directive
+      // expects same-origin). Isolate the failure so a misconfigured host
+      // can't abort the rest of the render's directive sweep.
+    }
   };
 
   const onLoad = () => {
-    const doc = iframe.contentDocument;
+    let doc: Document | null = null;
+    try {
+      doc = iframe.contentDocument;
+    } catch {
+      return; // cross-origin — nothing we can read or observe
+    }
     if (!doc) return;
     resizeObserver?.disconnect();
     if (typeof ResizeObserver !== "undefined" && doc.documentElement) {
@@ -1962,9 +1973,14 @@ function attachAreaSelect(
   };
 }
 
+// region-select reuses the area-select entry shape (action + cleanup +
+// updateSend); the alias names that intent so the map type doesn't read
+// as "a region map holding area entries".
+type BoxDragEntry = AreaSelectEntry;
+
 // regionSelectArmed / regionSelectWarnedParents mirror the area-select
 // singletons (see those for the Map-not-WeakMap reasoning).
-const regionSelectArmed = new Map<Element, AreaSelectEntry>();
+const regionSelectArmed = new Map<Element, BoxDragEntry>();
 const regionSelectWarnedParents = new WeakSet<Element>();
 
 /**
@@ -2041,7 +2057,7 @@ function attachRegionSelect(
   el: HTMLElement,
   action: string,
   initialSend: AreaSelectSendFn
-): AreaSelectEntry {
+): BoxDragEntry {
   let send = initialSend;
   const handle = attachBoxDragSelect(
     el,

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -19,6 +19,7 @@ import {
   handleToastDirectives,
   handleURLHashDirective,
   teardownAreaSelectForRoot,
+  teardownIframeAutoHeightForRoot,
   teardownRegionSelectForRoot,
   teardownURLHashForRoot,
   teardownAutoClickTimers,
@@ -674,6 +675,7 @@ export class LiveTemplateClient {
       teardownSpy(this.wrapperElement);
       teardownAreaSelectForRoot(this.wrapperElement);
       teardownRegionSelectForRoot(this.wrapperElement);
+      teardownIframeAutoHeightForRoot(this.wrapperElement);
       teardownURLHashForRoot(this.wrapperElement);
     }
     this.resetSessionState();

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -12,11 +12,14 @@ import {
   handleAreaSelectDirectives,
   handleAutoClickDirectives,
   handleHighlightDirectives,
+  handleIframeAutoHeightDirectives,
+  handleRegionSelectDirectives,
   handleScrollDirectives,
   handleShadowRootHydration,
   handleToastDirectives,
   handleURLHashDirective,
   teardownAreaSelectForRoot,
+  teardownRegionSelectForRoot,
   teardownURLHashForRoot,
   teardownAutoClickTimers,
   setupToastClickOutside,
@@ -670,6 +673,7 @@ export class LiveTemplateClient {
       teardownScrollAway(this.wrapperElement);
       teardownSpy(this.wrapperElement);
       teardownAreaSelectForRoot(this.wrapperElement);
+      teardownRegionSelectForRoot(this.wrapperElement);
       teardownURLHashForRoot(this.wrapperElement);
     }
     this.resetSessionState();
@@ -2020,6 +2024,16 @@ export class LiveTemplateClient {
     // send the event delegator uses so the WS/HTTP routing is
     // identical to a normal action.
     handleAreaSelectDirectives(element, (message) => this.send(message));
+    // region-select is the area-select drag spine over an iframe / code
+    // overlay: a drawn box is hit-tested to a source line range. Same
+    // send-callback wiring; the overlay is parent light DOM so it works
+    // on iOS (unlike the deleted in-iframe tap).
+    handleRegionSelectDirectives(element, (message) => this.send(message));
+    // iframe-autoheight sizes the sandboxed HTML-preview iframe to its
+    // content (iframes don't size to content). Selection over the preview
+    // is handled by a parent-document overlay (area/region-select), not
+    // from inside the iframe, so this directive needs no send callback.
+    handleIframeAutoHeightDirectives(element);
     // url-hash bridges server state ↔ location.hash. Same send-callback
     // wiring as area-select: the directive needs to dispatch a server
     // action on user-driven hashchange events (anchor click, address-bar
@@ -2037,9 +2051,10 @@ export class LiveTemplateClient {
     // querySelectorAll which stops at shadow boundaries, and the
     // hydration that follows doesn't run them against the new shadow
     // root either. Treat shadow DOM as a style/structure isolation
-    // primitive only — keep directives in light DOM. Today's consumer
-    // (prereview's HTML preview) wraps sanitised user HTML in shadow
-    // DOM purely for style isolation; no directives go in.
+    // primitive only — keep directives in light DOM. (Consumers that
+    // need a real viewport for untrusted markup — e.g. prereview's HTML
+    // preview — use a sandboxed iframe + handleIframeAutoHeightDirectives
+    // instead, reaching the content via the same-origin contentDocument.)
     handleShadowRootHydration(element);
     setupScrollAway(element);
     setupSpy(element);

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -8,6 +8,8 @@ import {
   handleRegionSelectDirectives,
   teardownRegionSelectForRoot,
   lineRangeFromBox,
+  readHTMLRange,
+  readCodeRange,
   handleShadowRootHydration,
   handleURLHashDirective,
   setupFxDOMEventTriggers,
@@ -2597,14 +2599,6 @@ describe("lineRangeFromBox", () => {
       getAttribute: (k: string) => (k in attrs ? attrs[k] : null),
     } as unknown as Element;
   }
-  // Read a [data-from]/[data-to] HTML block range (mirrors readHTMLRange).
-  const readHTML = (el: Element) => {
-    const from = parseInt(el.getAttribute("data-from") || "", 10);
-    if (!Number.isFinite(from) || from <= 0) return null;
-    const to = parseInt(el.getAttribute("data-to") || "", 10);
-    return { from, to: Number.isFinite(to) && to >= from ? to : from };
-  };
-
   it("unions the line ranges of every block the box overlaps", () => {
     const cands = [
       cand({ left: 0, top: 0, right: 100, bottom: 20 }, { "data-from": "2", "data-to": "4" }),
@@ -2617,7 +2611,7 @@ describe("lineRangeFromBox", () => {
       { left: 10, top: 5, right: 90, bottom: 30 },
       0,
       0,
-      readHTML
+      readHTMLRange
     );
     expect(range).toEqual({ from: 2, to: 9 });
   });
@@ -2631,7 +2625,7 @@ describe("lineRangeFromBox", () => {
       { left: 10, top: 200, right: 90, bottom: 260 },
       0,
       0,
-      readHTML
+      readHTMLRange
     );
     expect(range).toBeNull();
   });
@@ -2647,7 +2641,7 @@ describe("lineRangeFromBox", () => {
       { left: 0, top: 105, right: 100, bottom: 115 },
       0,
       100,
-      readHTML
+      readHTMLRange
     );
     expect(range).toEqual({ from: 5, to: 5 });
   });
@@ -2655,14 +2649,6 @@ describe("lineRangeFromBox", () => {
   // A box crossing a diff's add/del boundary must NOT union old-side and
   // new-side line numbers (different coordinate systems). The topmost row
   // fixes the side; the other side's rows are excluded.
-  const readCode = (el: Element) => {
-    const n = parseInt(el.getAttribute("data-line") || "", 10);
-    if (!Number.isFinite(n) || n <= 0) return null;
-    return el.getAttribute("data-side") === "old"
-      ? { from: n, to: n, side: "old" }
-      : { from: n, to: n };
-  };
-
   it("restricts to the topmost row's side when a box crosses the diff boundary (old on top)", () => {
     const cands = [
       cand({ left: 0, top: 0, right: 100, bottom: 20 }, { "data-line": "7", "data-side": "old" }),
@@ -2673,7 +2659,7 @@ describe("lineRangeFromBox", () => {
       { left: 0, top: 5, right: 100, bottom: 35 },
       0,
       0,
-      readCode
+      readCodeRange
     );
     // Only the old-side row survives; the new-side row 8 is excluded.
     expect(range).toEqual({ from: 7, to: 7, side: "old" });
@@ -2690,7 +2676,7 @@ describe("lineRangeFromBox", () => {
       { left: 0, top: 5, right: 100, bottom: 55 },
       0,
       0,
-      readCode
+      readCodeRange
     );
     // Two new-side rows union; the trailing old-side row 3 is excluded.
     expect(range).toEqual({ from: 11, to: 12 });
@@ -2706,7 +2692,7 @@ describe("lineRangeFromBox", () => {
       { left: 0, top: 5, right: 100, bottom: 35 },
       0,
       0,
-      readHTML
+      readHTMLRange
     );
     expect(range).toEqual({ from: 9, to: 9 });
   });

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -5,6 +5,7 @@ import {
   handleAreaSelectDirectives,
   handleAutoClickDirectives,
   handleIframeAutoHeightDirectives,
+  teardownIframeAutoHeightForRoot,
   handleRegionSelectDirectives,
   teardownRegionSelectForRoot,
   lineRangeFromBox,
@@ -2585,6 +2586,24 @@ describe("handleIframeAutoHeightDirectives", () => {
     iframe.style.height = "";
     handleIframeAutoHeightDirectives(document.body);
     expect(iframe.style.height).toBe("");
+  });
+
+  it("teardownIframeAutoHeightForRoot removes the load listener (no leak)", () => {
+    const iframe = makeIframe(100);
+    handleIframeAutoHeightDirectives(document.body);
+    expect(iframe.style.height).toBe("100px");
+
+    teardownIframeAutoHeightForRoot(document.body);
+
+    // After teardown the load listener is gone: a fresh load with taller
+    // content must NOT resize the iframe (proves cleanup ran).
+    Object.defineProperty(
+      iframe.contentDocument!.documentElement,
+      "scrollHeight",
+      { configurable: true, get: () => 999 }
+    );
+    iframe.dispatchEvent(new Event("load"));
+    expect(iframe.style.height).toBe("100px");
   });
 });
 

--- a/tests/directives.test.ts
+++ b/tests/directives.test.ts
@@ -4,6 +4,10 @@ import {
   handleAnimateDirectives,
   handleAreaSelectDirectives,
   handleAutoClickDirectives,
+  handleIframeAutoHeightDirectives,
+  handleRegionSelectDirectives,
+  teardownRegionSelectForRoot,
+  lineRangeFromBox,
   handleShadowRootHydration,
   handleURLHashDirective,
   setupFxDOMEventTriggers,
@@ -2524,5 +2528,230 @@ describe("handleURLHashDirective", () => {
 
     expect(window.history.length).toBe(lengthBefore);
     expect(window.location.hash).toBe("#OTHER.md:L9");
+  });
+});
+
+describe("handleIframeAutoHeightDirectives", () => {
+  // Build an iframe whose same-origin contentDocument we can populate +
+  // drive directly, mirroring the sandboxed HTML-preview iframe. jsdom
+  // performs no layout, so scrollHeight is always 0 — fake it so the
+  // directive's `if (h > 0)` guard has something to size to.
+  function makeIframe(scrollHeight: number): HTMLIFrameElement {
+    const iframe = document.createElement("iframe");
+    iframe.setAttribute("lvt-fx:iframe-autoheight", "");
+    document.body.appendChild(iframe);
+    const doc = iframe.contentDocument!;
+    doc.body.innerHTML = `<div data-from="2" data-to="4">hi</div>`;
+    Object.defineProperty(doc.documentElement, "scrollHeight", {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    // jsdom doesn't fire 'load' for a srcdoc-less iframe; trigger the
+    // directive's load wiring explicitly.
+    iframe.dispatchEvent(new Event("load"));
+    return iframe;
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("sizes the iframe to its content scrollHeight", () => {
+    const iframe = makeIframe(321);
+    handleIframeAutoHeightDirectives(document.body);
+    expect(iframe.style.height).toBe("321px");
+  });
+
+  it("re-measures on a subsequent render without re-arming (sync)", () => {
+    const iframe = makeIframe(100);
+    handleIframeAutoHeightDirectives(document.body);
+    expect(iframe.style.height).toBe("100px");
+
+    // Content reflowed taller; the same element re-syncs on the next pass.
+    Object.defineProperty(
+      iframe.contentDocument!.documentElement,
+      "scrollHeight",
+      { configurable: true, get: () => 250 }
+    );
+    handleIframeAutoHeightDirectives(document.body);
+    expect(iframe.style.height).toBe("250px");
+  });
+
+  it("ignores iframes without the attribute", () => {
+    const iframe = makeIframe(321);
+    iframe.removeAttribute("lvt-fx:iframe-autoheight");
+    iframe.style.height = "";
+    handleIframeAutoHeightDirectives(document.body);
+    expect(iframe.style.height).toBe("");
+  });
+});
+
+describe("lineRangeFromBox", () => {
+  // jsdom does no layout, so fake each candidate's geometry + attributes.
+  function cand(
+    rect: { left: number; top: number; right: number; bottom: number },
+    attrs: Record<string, string>
+  ): Element {
+    return {
+      getBoundingClientRect: () => rect as DOMRect,
+      getAttribute: (k: string) => (k in attrs ? attrs[k] : null),
+    } as unknown as Element;
+  }
+  // Read a [data-from]/[data-to] HTML block range (mirrors readHTMLRange).
+  const readHTML = (el: Element) => {
+    const from = parseInt(el.getAttribute("data-from") || "", 10);
+    if (!Number.isFinite(from) || from <= 0) return null;
+    const to = parseInt(el.getAttribute("data-to") || "", 10);
+    return { from, to: Number.isFinite(to) && to >= from ? to : from };
+  };
+
+  it("unions the line ranges of every block the box overlaps", () => {
+    const cands = [
+      cand({ left: 0, top: 0, right: 100, bottom: 20 }, { "data-from": "2", "data-to": "4" }),
+      cand({ left: 0, top: 20, right: 100, bottom: 40 }, { "data-from": "6", "data-to": "9" }),
+      cand({ left: 0, top: 40, right: 100, bottom: 60 }, { "data-from": "11", "data-to": "12" }),
+    ];
+    // Box covers the first two rows (y 5..30), not the third (y 40..60).
+    const range = lineRangeFromBox(
+      cands,
+      { left: 10, top: 5, right: 90, bottom: 30 },
+      0,
+      0,
+      readHTML
+    );
+    expect(range).toEqual({ from: 2, to: 9 });
+  });
+
+  it("returns null when the box overlaps no candidate", () => {
+    const cands = [
+      cand({ left: 0, top: 0, right: 100, bottom: 20 }, { "data-from": "2", "data-to": "4" }),
+    ];
+    const range = lineRangeFromBox(
+      cands,
+      { left: 10, top: 200, right: 90, bottom: 260 },
+      0,
+      0,
+      readHTML
+    );
+    expect(range).toBeNull();
+  });
+
+  it("applies the offset so iframe-content rects map into box space", () => {
+    // Candidate is at content y 0..20; the iframe sits at viewport y 100.
+    const cands = [
+      cand({ left: 0, top: 0, right: 100, bottom: 20 }, { "data-from": "5", "data-to": "5" }),
+    ];
+    // Box in viewport coords overlaps only AFTER the +100 offset is applied.
+    const range = lineRangeFromBox(
+      cands,
+      { left: 0, top: 105, right: 100, bottom: 115 },
+      0,
+      100,
+      readHTML
+    );
+    expect(range).toEqual({ from: 5, to: 5 });
+  });
+
+  // A box crossing a diff's add/del boundary must NOT union old-side and
+  // new-side line numbers (different coordinate systems). The topmost row
+  // fixes the side; the other side's rows are excluded.
+  const readCode = (el: Element) => {
+    const n = parseInt(el.getAttribute("data-line") || "", 10);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    return el.getAttribute("data-side") === "old"
+      ? { from: n, to: n, side: "old" }
+      : { from: n, to: n };
+  };
+
+  it("restricts to the topmost row's side when a box crosses the diff boundary (old on top)", () => {
+    const cands = [
+      cand({ left: 0, top: 0, right: 100, bottom: 20 }, { "data-line": "7", "data-side": "old" }),
+      cand({ left: 0, top: 20, right: 100, bottom: 40 }, { "data-line": "8" }), // new side
+    ];
+    const range = lineRangeFromBox(
+      cands,
+      { left: 0, top: 5, right: 100, bottom: 35 },
+      0,
+      0,
+      readCode
+    );
+    // Only the old-side row survives; the new-side row 8 is excluded.
+    expect(range).toEqual({ from: 7, to: 7, side: "old" });
+  });
+
+  it("restricts to the new side when the topmost row is new", () => {
+    const cands = [
+      cand({ left: 0, top: 0, right: 100, bottom: 20 }, { "data-line": "11" }), // new side, on top
+      cand({ left: 0, top: 20, right: 100, bottom: 40 }, { "data-line": "12" }), // new side
+      cand({ left: 0, top: 40, right: 100, bottom: 60 }, { "data-line": "3", "data-side": "old" }),
+    ];
+    const range = lineRangeFromBox(
+      cands,
+      { left: 0, top: 5, right: 100, bottom: 55 },
+      0,
+      0,
+      readCode
+    );
+    // Two new-side rows union; the trailing old-side row 3 is excluded.
+    expect(range).toEqual({ from: 11, to: 12 });
+  });
+
+  it("skips candidates whose readRange returns null", () => {
+    const cands = [
+      cand({ left: 0, top: 0, right: 100, bottom: 20 }, { "data-from": "0" }), // invalid
+      cand({ left: 0, top: 20, right: 100, bottom: 40 }, { "data-from": "9", "data-to": "9" }),
+    ];
+    const range = lineRangeFromBox(
+      cands,
+      { left: 0, top: 5, right: 100, bottom: 35 },
+      0,
+      0,
+      readHTML
+    );
+    expect(range).toEqual({ from: 9, to: 9 });
+  });
+});
+
+describe("handleRegionSelectDirectives", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // Build a positioned wrapper containing an overlay host (the parent
+  // positioning context the drag spine warns about otherwise).
+  function makeOverlay(surface: string): HTMLElement {
+    const wrap = document.createElement("div");
+    wrap.style.position = "relative";
+    const overlay = document.createElement("div");
+    overlay.setAttribute("lvt-fx:region-select", "selectBlock");
+    overlay.setAttribute("data-surface", surface);
+    wrap.appendChild(overlay);
+    document.body.appendChild(wrap);
+    return overlay;
+  }
+
+  it("arms an overlay and is idempotent across re-arms", () => {
+    const send = jest.fn();
+    const overlay = makeOverlay("code");
+    handleRegionSelectDirectives(document.body, send);
+    // Re-arm with the same action must not throw or rebind destructively.
+    expect(() => handleRegionSelectDirectives(document.body, send)).not.toThrow();
+    expect(overlay.isConnected).toBe(true);
+  });
+
+  it("sweeps the listener when the attribute is removed", () => {
+    const send = jest.fn();
+    const overlay = makeOverlay("html");
+    handleRegionSelectDirectives(document.body, send);
+    overlay.removeAttribute("lvt-fx:region-select");
+    // Second pass should clean up without error.
+    expect(() => handleRegionSelectDirectives(document.body, send)).not.toThrow();
+  });
+
+  it("teardownRegionSelectForRoot cleans armed overlays under the root", () => {
+    const send = jest.fn();
+    makeOverlay("code");
+    handleRegionSelectDirectives(document.body, send);
+    expect(() => teardownRegionSelectForRoot(document.body)).not.toThrow();
   });
 });


### PR DESCRIPTION
## What

Adds a surface-agnostic **`lvt-fx:region-select`** directive: the user draws a box and it's hit-tested (rect intersection) to a **source line range** over `[data-from]` blocks or `[data-line]` code rows. Built by extracting the battle-tested pointer-drag gesture from `area-select` into a shared **`attachBoxDragSelect`** spine (pointer capture, re-entrancy, multi-touch, off-edge clamping) — so `area-select` and `region-select` share one drag primitive.

Also replaces the iOS-broken in-iframe tap (`lvt-fx:iframe-select`) with a minimal **`lvt-fx:iframe-autoheight`** (sizes a same-origin iframe to its content). Selection moved out of the iframe to a parent-document overlay, which iOS actually delivers events to.

## Why

prereview's HTML preview renders untrusted markup in a sandboxed iframe; the previous in-iframe tap never fired on iOS (Safari doesn't deliver iframe-internal events to parent listeners). A parent overlay + box-drag is the same event path as the working file list.

## Safety / compatibility

- `area-select` behavior is **unchanged** — it's now a thin fraction wrapper over the shared spine; the **29 existing area-select tests pass unchanged** (equivalence proof).
- `region-select` restricts a box to the **topmost row's diff side**, so a box straying across an add/del boundary never unions old/new line-number coordinate systems.
- New jest coverage for `lineRangeFromBox` (intersection/offset/side/null) + directive lifecycle.

Consumed by livetemplate/prereview#26 (region comments on the HTML preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)