### PR TITLE
fix(morphdom): make lvt-on:click checkboxes/radios server-authoritative

### DIFF
--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1823,22 +1823,36 @@ export class LiveTemplateClient {
         // state is user input that must survive scan-loop refreshes. Use
         // data-lvt-force-update to let the server override the user state.
         //
-        // Known limitation: force-update on one radio can uncheck a sibling
-        // that was already processed earlier in the same morphdom pass, since
-        // browser mutual exclusion fires synchronously mid-loop. To safely
-        // reset a radio group, send data-lvt-force-update on ALL radios in
-        // the group, not just the one being checked.
+        // Exception: a control with an lvt-on:click handler routes its own
+        // toggle to the server, which echoes back the authoritative state.
+        // There is no pending local-only selection to protect, so the server's
+        // rendered checked attribute must win — otherwise a server-driven
+        // toggle never reflects in the DOM. This makes lvt-on:click checkboxes
+        // server-authoritative without needing an explicit data-lvt-force-update.
+        //
+        // Known limitation: forcing one radio can uncheck a sibling that was
+        // already processed earlier in the same morphdom pass, since browser
+        // mutual exclusion fires synchronously mid-loop. To safely reset a
+        // radio group, make the server send the authoritative state (or
+        // data-lvt-force-update) on ALL radios in the group, not just one.
         if (
           fromEl instanceof HTMLInputElement &&
           toEl instanceof HTMLInputElement &&
           (fromEl.type === "checkbox" || fromEl.type === "radio")
         ) {
-          if (toEl.hasAttribute("data-lvt-force-update")) {
+          const explicitForce = toEl.hasAttribute("data-lvt-force-update");
+          const serverAuthoritative =
+            explicitForce || toEl.hasAttribute("lvt-on:click");
+          if (serverAuthoritative) {
             fromEl.checked = toEl.checked;
             if (fromEl.type === "checkbox") {
               fromEl.indeterminate = toEl.indeterminate;
             }
-            fromEl.removeAttribute("data-lvt-force-update");
+            // data-lvt-force-update is a one-shot signal; strip it so it does
+            // not persist. lvt-on:click is a durable handler — leave it.
+            if (explicitForce) {
+              fromEl.removeAttribute("data-lvt-force-update");
+            }
           } else {
             toEl.checked = fromEl.checked;
             // Align the checked attribute with the property so morphdom's

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -238,9 +238,12 @@ describe("lvt-ignore and lvt-ignore-attrs", () => {
     // (the toggle is owned by the server, not local optimistic state), and the
     // server's re-render carries the checked attribute. Server must win without
     // needing an explicit data-lvt-force-update — issue tinkerdown#292.
+    // Slot 1 is a co-rendered label that changes each push, so every update is
+    // a real morphdom pass (an identical tree short-circuits in updateDOM).
     const uncheckedTree = {
-      s: [`<div>`, `</div>`],
+      s: [`<div>`, ``, `</div>`],
       0: `<input type="checkbox" data-key="t1" lvt-on:click="Toggle">`,
+      1: `<span>v1</span>`,
     };
     client.updateDOM(wrapper, uncheckedTree);
 
@@ -248,13 +251,52 @@ describe("lvt-ignore and lvt-ignore-attrs", () => {
     expect(cb.checked).toBe(false);
 
     // Server responds to the click with the toggled (checked) state.
-    const checkedTree = {
+    client.updateDOM(wrapper, {
       0: `<input type="checkbox" data-key="t1" lvt-on:click="Toggle" checked>`,
+      1: `<span>v2</span>`,
+    });
+    expect(
+      wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked
+    ).toBe(true);
+
+    // Inverse: the user optimistically unchecks it (live state now stale), but
+    // the server's next render re-affirms checked. Server authority must win in
+    // both directions — the local control never overrides the server value.
+    wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked = false;
+    client.updateDOM(wrapper, {
+      0: `<input type="checkbox" data-key="t1" lvt-on:click="Toggle" checked>`,
+      1: `<span>v3</span>`,
+    });
+    expect(
+      wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked
+    ).toBe(true);
+  });
+
+  it("server wins for a radio with an lvt-on:click handler", () => {
+    // The server-authoritative path also applies to radios. When every radio in
+    // the group is server-bound, the server sends authoritative state for ALL of
+    // them (here: r1 unchecked, r2 checked), which sidesteps the documented
+    // mid-pass mutual-exclusion limitation.
+    const uncheckedTree = {
+      s: [`<form>`, `</form>`],
+      0: `<input type="radio" name="opt" data-key="r1" lvt-on:click="Pick" value="a">` +
+         `<input type="radio" name="opt" data-key="r2" lvt-on:click="Pick" value="b">`,
+    };
+    client.updateDOM(wrapper, uncheckedTree);
+
+    const radios = wrapper.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    expect(radios[0].checked).toBe(false);
+    expect(radios[1].checked).toBe(false);
+
+    const checkedTree = {
+      0: `<input type="radio" name="opt" data-key="r1" lvt-on:click="Pick" value="a">` +
+         `<input type="radio" name="opt" data-key="r2" lvt-on:click="Pick" value="b" checked>`,
     };
     client.updateDOM(wrapper, checkedTree);
 
-    const cbAfter = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
-    expect(cbAfter.checked).toBe(true);
+    const after = wrapper.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+    expect(after[0].checked).toBe(false);
+    expect(after[1].checked).toBe(true);
   });
 
   it("still preserves user state for a checkbox with NO server-bound handler", () => {

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -231,6 +231,50 @@ describe("lvt-ignore and lvt-ignore-attrs", () => {
     expect(afterUpdate[1].checked).toBe(false);
   });
 
+  it("server wins for a checkbox with an lvt-on:click handler", () => {
+    // A checkbox whose toggle is routed to the server via lvt-on:click is
+    // server-authoritative: the click is dispatched and the server echoes back
+    // the new state. At morph time the live control's checked is still false
+    // (the toggle is owned by the server, not local optimistic state), and the
+    // server's re-render carries the checked attribute. Server must win without
+    // needing an explicit data-lvt-force-update — issue tinkerdown#292.
+    const uncheckedTree = {
+      s: [`<div>`, `</div>`],
+      0: `<input type="checkbox" data-key="t1" lvt-on:click="Toggle">`,
+    };
+    client.updateDOM(wrapper, uncheckedTree);
+
+    const cb = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    expect(cb.checked).toBe(false);
+
+    // Server responds to the click with the toggled (checked) state.
+    const checkedTree = {
+      0: `<input type="checkbox" data-key="t1" lvt-on:click="Toggle" checked>`,
+    };
+    client.updateDOM(wrapper, checkedTree);
+
+    const cbAfter = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    expect(cbAfter.checked).toBe(true);
+  });
+
+  it("still preserves user state for a checkbox with NO server-bound handler", () => {
+    // Control: a plain form checkbox (no lvt-on:click) keeps the user's
+    // selection across a server refresh — the default must not regress.
+    const tree = {
+      s: [`<form>`, `</form>`],
+      0: `<input type="checkbox" data-key="p1" value="a">`,
+    };
+    client.updateDOM(wrapper, tree);
+
+    const cb = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    cb.checked = true; // user checks it
+
+    client.updateDOM(wrapper, tree); // server refresh, no checked attribute
+
+    const cbAfter = wrapper.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    expect(cbAfter.checked).toBe(true);
+  });
+
   it("preserves radio button checked state across morphdom updates", () => {
     const initialTree = {
       s: [


### PR DESCRIPTION
## Problem

A checkbox/radio whose toggle is routed to the server via `lvt-on:click` is **server-authoritative**: the click is dispatched and the server echoes the new `checked` state in its re-render. But the morphdom pass defaults to *"user selection wins"* — it copies the live control's checked state onto the incoming element (`toEl.checked = fromEl.checked`) so scan-loop refreshes don't clobber pending user input.

For an `lvt-on:click` control that's backwards: when the live state is stale relative to the server's authoritative value, the server's toggle never reflects in the DOM and the checkbox appears stuck. This surfaced as flaky/failing E2E tests in tinkerdown (livetemplate/tinkerdown#292), where a checkbox toggle was confirmed server-side (WS frame carried `checked`) yet the DOM property stayed `false`.

## Fix

Extend the server-authoritative predicate in `onBeforeElUpdated` so an `lvt-on:click` checkbox/radio is treated like `data-lvt-force-update` — the server's rendered `checked` wins.

- `data-lvt-force-update` stays the explicit **one-shot** override (still stripped after applying).
- `lvt-on:click` is a **durable** handler, left in place, so the control stays authoritative on every update.

This removes the need to sprinkle `data-lvt-force-update` on every server-driven toggle checkbox. The ecosystem already writes this pattern *without* the attribute — `lvt`'s toggle component, datatable row/select-all, tinkerdown auto-tasks — and was latently affected; this retroactively fixes them.

## Tests

- **handler ⇒ server wins** (the bug, now fixed)
- **handler-less ⇒ user state still preserved** (default behavior unchanged — guards against regression)
- **explicit `data-lvt-force-update` still overrides** (existing behavior)

Full suite green (736 passed, 1 skipped). `tsc --noEmit` clean.

## Blast radius

Grepped sibling apps for `lvt-on:click` + checkbox/radio: every occurrence renders server state via `{{if .Checked}}checked{{end}}`, i.e. server-authoritative by intent. No app relies on optimistic-over-server for these controls, so this is a net fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)