### PR TITLE
Durable <details> open + generic lvt-fx:resize directive

### DIFF
--- a/dom/resize.ts
+++ b/dom/resize.ts
@@ -1,0 +1,187 @@
+/**
+ * lvt-fx:resize — make an element edge-draggable to resize, updating a CSS
+ * custom property live and (optionally) persisting it to localStorage. Pure
+ * client-side: no server round-trip. Modeled on the area-select directive's
+ * pointer-capture + arm/sweep/cleanup lifecycle.
+ *
+ * Usage:
+ *   <aside lvt-fx:resize="--pr-drawer-w"
+ *          data-resize-handle=".resize-handle"   // selector for the grab handle
+ *          data-resize-min="180" data-resize-max="560"  // px clamp
+ *          data-resize-axis="x"                   // x (default) | y
+ *          data-resize-edge="end"                 // end (default) | start
+ *          data-resize-store="prereview.drawerW"> // localStorage key (optional)
+ *     …
+ *     <div class="resize-handle"></div>
+ *   </aside>
+ *
+ * The CSS variable is set on document.documentElement (:root) rather than the
+ * host so it survives morphdom re-renders — the host element is inside the
+ * livetemplate-managed subtree and its inline style would be diffed away, but
+ * :root sits outside it and is never patched. The stylesheet reads the var,
+ * e.g. `width: var(--pr-drawer-w)`.
+ */
+
+interface ResizeEntry {
+  cleanup: () => void;
+}
+
+const resizeArmed = new WeakMap<Element, ResizeEntry>();
+// Tracked so teardownResizeForRoot can sweep without a live DOM query.
+const resizeElements = new Set<Element>();
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, v));
+}
+
+function readNumberAttr(el: Element, name: string, fallback: number): number {
+  const raw = el.getAttribute(name);
+  if (raw == null || raw.trim() === "") return fallback;
+  const n = parseFloat(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * Set the CSS variable on :root. Kept on the document element so it is never
+ * touched by the morphdom pass that patches the livetemplate wrapper subtree.
+ */
+function setVar(varName: string, px: number): void {
+  document.documentElement.style.setProperty(varName, `${px}px`);
+}
+
+function attachResize(host: HTMLElement, varName: string): ResizeEntry {
+  const handleSel = host.getAttribute("data-resize-handle");
+  const handle: HTMLElement = handleSel
+    ? (host.querySelector<HTMLElement>(handleSel) ?? host)
+    : host;
+  const axis = (host.getAttribute("data-resize-axis") || "x").toLowerCase();
+  const edge = (host.getAttribute("data-resize-edge") || "end").toLowerCase();
+  const min = readNumberAttr(host, "data-resize-min", 0);
+  const max = readNumberAttr(host, "data-resize-max", Number.MAX_SAFE_INTEGER);
+  const storeKey = host.getAttribute("data-resize-store");
+
+  // Restore a persisted width once on arm. Applying it to :root before the
+  // first paint keeps the drawer at the user's chosen width without a flash.
+  if (storeKey) {
+    try {
+      const saved = window.localStorage.getItem(storeKey);
+      if (saved != null) {
+        const px = parseFloat(saved);
+        if (Number.isFinite(px)) setVar(varName, clamp(px, min, max));
+      }
+    } catch {
+      /* localStorage may be unavailable (private mode / disabled) — ignore. */
+    }
+  }
+
+  let startPos = 0;
+  let startSize = 0;
+  let activePointer: number | null = null;
+
+  const onPointerMove = (e: PointerEvent) => {
+    if (activePointer === null || e.pointerId !== activePointer) return;
+    const pos = axis === "y" ? e.clientY : e.clientX;
+    // "start" edge grows when dragging toward the origin; "end" edge grows
+    // when dragging away from it.
+    const delta = edge === "start" ? startPos - pos : pos - startPos;
+    setVar(varName, clamp(startSize + delta, min, max));
+    e.preventDefault();
+  };
+
+  const onPointerUp = (e: PointerEvent) => {
+    if (activePointer === null || e.pointerId !== activePointer) return;
+    activePointer = null;
+    handle.removeEventListener("pointermove", onPointerMove);
+    handle.removeEventListener("pointerup", onPointerUp);
+    handle.removeEventListener("pointercancel", onPointerUp);
+    try {
+      handle.releasePointerCapture(e.pointerId);
+    } catch {
+      /* capture may already be lost (e.g. element removed mid-drag). */
+    }
+    host.removeAttribute("data-resizing");
+    if (storeKey) {
+      const current = getComputedStyle(host)[
+        axis === "y" ? "height" : "width"
+      ];
+      const px = parseFloat(current);
+      if (Number.isFinite(px)) {
+        try {
+          window.localStorage.setItem(storeKey, String(Math.round(px)));
+        } catch {
+          /* persistence is best-effort. */
+        }
+      }
+    }
+  };
+
+  const onPointerDown = (e: PointerEvent) => {
+    // Primary button / touch / pen only; ignore secondary buttons.
+    if (e.button !== 0) return;
+    activePointer = e.pointerId;
+    startPos = axis === "y" ? e.clientY : e.clientX;
+    const rect = host.getBoundingClientRect();
+    startSize = axis === "y" ? rect.height : rect.width;
+    try {
+      handle.setPointerCapture(e.pointerId);
+    } catch {
+      /* capture is an optimization; dragging still works without it. */
+    }
+    host.setAttribute("data-resizing", "");
+    handle.addEventListener("pointermove", onPointerMove);
+    handle.addEventListener("pointerup", onPointerUp);
+    handle.addEventListener("pointercancel", onPointerUp);
+    e.preventDefault();
+  };
+
+  handle.addEventListener("pointerdown", onPointerDown);
+
+  return {
+    cleanup: () => {
+      handle.removeEventListener("pointerdown", onPointerDown);
+      handle.removeEventListener("pointermove", onPointerMove);
+      handle.removeEventListener("pointerup", onPointerUp);
+      handle.removeEventListener("pointercancel", onPointerUp);
+      resizeArmed.delete(host);
+      resizeElements.delete(host);
+    },
+  };
+}
+
+/**
+ * Arm every [lvt-fx:resize] element under root, and sweep entries whose element
+ * was disconnected or had the attribute removed by a server diff. Idempotent:
+ * re-running keeps already-armed elements (so an in-flight drag survives a
+ * re-render) and only attaches newly-appeared ones.
+ */
+export function handleResizeDirectives(rootElement: Element): void {
+  for (const element of Array.from(resizeElements)) {
+    if (!element.isConnected || !element.hasAttribute("lvt-fx:resize")) {
+      resizeArmed.get(element)?.cleanup();
+    }
+  }
+
+  const matches = rootElement.querySelectorAll<HTMLElement>("[lvt-fx\\:resize]");
+  for (const el of matches) {
+    const varName = el.getAttribute("lvt-fx:resize");
+    if (!varName) {
+      console.warn(
+        `lvt-fx:resize requires a CSS variable name, got: ${JSON.stringify(varName)}`
+      );
+      continue;
+    }
+    if (resizeArmed.has(el)) continue; // already armed — keep listeners
+    const entry = attachResize(el, varName);
+    resizeArmed.set(el, entry);
+    resizeElements.add(el);
+  }
+}
+
+/** Cancel resize listeners for every armed element under root (disconnect/destroy). */
+export function teardownResizeForRoot(root: Element): void {
+  for (const element of Array.from(resizeElements)) {
+    if (root.contains(element)) {
+      resizeArmed.get(element)?.cleanup();
+    }
+  }
+}

--- a/dom/resize.ts
+++ b/dom/resize.ts
@@ -15,6 +15,10 @@
  *     <div class="resize-handle"></div>
  *   </aside>
  *
+ * The handle element needs `touch-action: none` in CSS — onPointerMove calls
+ * preventDefault(), so without it the drag silently interferes with page scroll
+ * on touch devices (iOS/Android).
+ *
  * The CSS variable is set on document.documentElement (:root) rather than the
  * host so it survives morphdom re-renders — the host element is inside the
  * livetemplate-managed subtree and its inline style would be diffed away, but
@@ -123,8 +127,20 @@ function attachResize(host: HTMLElement, varName: string): ResizeEntry {
     if (e.button !== 0) return;
     activePointer = e.pointerId;
     startPos = axis === "y" ? e.clientY : e.clientX;
+    // Anchor the drag to the current variable value (the logical size we
+    // control), not the rendered box — under content-box + padding the rect
+    // differs from the var and the first drag would jump. getComputedStyle on
+    // :root resolves an inline override or the stylesheet default; fall back to
+    // the rendered rect only when the var is unset.
+    const fromVar = parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue(varName)
+    );
     const rect = host.getBoundingClientRect();
-    startSize = axis === "y" ? rect.height : rect.width;
+    startSize = Number.isFinite(fromVar)
+      ? fromVar
+      : axis === "y"
+        ? rect.height
+        : rect.width;
     try {
       handle.setPointerCapture(e.pointerId);
     } catch {
@@ -145,6 +161,10 @@ function attachResize(host: HTMLElement, varName: string): ResizeEntry {
       handle.removeEventListener("pointermove", onPointerMove);
       handle.removeEventListener("pointerup", onPointerUp);
       handle.removeEventListener("pointercancel", onPointerUp);
+      // Drop the :root override so a different element can't inherit this one's
+      // width before its own attachResize runs (it restores from localStorage
+      // or the stylesheet default on re-arm).
+      document.documentElement.style.removeProperty(varName);
       resizeArmed.delete(host);
       resizeElements.delete(host);
     },

--- a/dom/resize.ts
+++ b/dom/resize.ts
@@ -33,6 +33,10 @@ interface ResizeEntry {
 const resizeArmed = new WeakMap<Element, ResizeEntry>();
 // Tracked so teardownResizeForRoot can sweep without a live DOM query.
 const resizeElements = new Set<Element>();
+// varName -> the host that currently owns that :root custom property. Only the
+// owner clears the property on cleanup, so two hosts sharing a var name don't
+// nuke it for each other; a conflict is warned about at arm time.
+const armedVars = new Map<string, Element>();
 
 function clamp(v: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, v));
@@ -161,10 +165,13 @@ function attachResize(host: HTMLElement, varName: string): ResizeEntry {
       handle.removeEventListener("pointermove", onPointerMove);
       handle.removeEventListener("pointerup", onPointerUp);
       handle.removeEventListener("pointercancel", onPointerUp);
-      // Drop the :root override so a different element can't inherit this one's
-      // width before its own attachResize runs (it restores from localStorage
-      // or the stylesheet default on re-arm).
-      document.documentElement.style.removeProperty(varName);
+      // Drop the :root override so a different element can't inherit this
+      // one's width before its own attachResize runs — but only if we still
+      // own the var, so a host sharing the name keeps it.
+      if (armedVars.get(varName) === host) {
+        document.documentElement.style.removeProperty(varName);
+        armedVars.delete(varName);
+      }
       resizeArmed.delete(host);
       resizeElements.delete(host);
     },
@@ -202,16 +209,26 @@ export function handleResizeDirectives(rootElement: Element): void {
       continue;
     }
     if (resizeArmed.has(el)) continue; // already armed — keep listeners
+    const owner = armedVars.get(varName);
+    if (owner && owner !== el && owner.isConnected) {
+      console.warn(
+        `lvt-fx:resize: "${varName}" is already controlled by another connected element; they will fight over it.`
+      );
+    }
     const entry = attachResize(el, varName);
     resizeArmed.set(el, entry);
     resizeElements.add(el);
+    armedVars.set(varName, el);
   }
 }
 
 /** Cancel resize listeners for every armed element under root (disconnect/destroy). */
 export function teardownResizeForRoot(root: Element): void {
   for (const element of Array.from(resizeElements)) {
-    if (root.contains(element)) {
+    // Also clean up already-detached hosts (e.g. removed via replaceChildren
+    // before teardown) so destroy-time state is clean immediately, not just on
+    // the next handleResizeDirectives sweep.
+    if (root.contains(element) || !element.isConnected) {
       resizeArmed.get(element)?.cleanup();
     }
   }

--- a/dom/resize.ts
+++ b/dom/resize.ts
@@ -127,8 +127,10 @@ function attachResize(host: HTMLElement, varName: string): ResizeEntry {
   };
 
   const onPointerDown = (e: PointerEvent) => {
-    // Primary button / touch / pen only; ignore secondary buttons.
-    if (e.button !== 0) return;
+    // Primary button / touch / pen only; ignore secondary buttons. Also ignore
+    // a second pointerdown while a drag is in flight (two-finger / pen+touch),
+    // which would otherwise clobber the active drag's start state.
+    if (e.button !== 0 || activePointer !== null) return;
     activePointer = e.pointerId;
     startPos = axis === "y" ? e.clientY : e.clientX;
     // Anchor the drag to the current variable value (the logical size we
@@ -224,11 +226,12 @@ export function handleResizeDirectives(rootElement: Element): void {
 
 /** Cancel resize listeners for every armed element under root (disconnect/destroy). */
 export function teardownResizeForRoot(root: Element): void {
+  // Only sweep elements under THIS root. resizeElements is a module-level
+  // singleton shared across clients, so cleaning up by !isConnected here would
+  // let one client tear down nodes another client briefly detached mid-render.
+  // Disconnected hosts are reclaimed by the handleResizeDirectives sweep.
   for (const element of Array.from(resizeElements)) {
-    // Also clean up already-detached hosts (e.g. removed via replaceChildren
-    // before teardown) so destroy-time state is clean immediately, not just on
-    // the next handleResizeDirectives sweep.
-    if (root.contains(element) || !element.isConnected) {
+    if (root.contains(element)) {
       resizeArmed.get(element)?.cleanup();
     }
   }

--- a/dom/resize.ts
+++ b/dom/resize.ts
@@ -101,10 +101,13 @@ function attachResize(host: HTMLElement, varName: string): ResizeEntry {
     }
     host.removeAttribute("data-resizing");
     if (storeKey) {
-      const current = getComputedStyle(host)[
-        axis === "y" ? "height" : "width"
-      ];
-      const px = parseFloat(current);
+      // Persist the value we actually wrote (the :root custom property), not
+      // getComputedStyle(host) — the host's used width can differ from the var
+      // (border-box, padding, calc(), flex), which would restore a wrong size.
+      // This is also a single synchronous read, no forced layout.
+      const px = parseFloat(
+        document.documentElement.style.getPropertyValue(varName)
+      );
       if (Number.isFinite(px)) {
         try {
           window.localStorage.setItem(storeKey, String(Math.round(px)));
@@ -167,6 +170,14 @@ export function handleResizeDirectives(rootElement: Element): void {
     if (!varName) {
       console.warn(
         `lvt-fx:resize requires a CSS variable name, got: ${JSON.stringify(varName)}`
+      );
+      continue;
+    }
+    // Must be a custom property — otherwise we'd set a real CSS property like
+    // `width` on :root, a surprising footgun.
+    if (!varName.startsWith("--")) {
+      console.warn(
+        `lvt-fx:resize value must be a CSS custom property (--name), got: ${JSON.stringify(varName)}`
       );
       continue;
     }

--- a/dom/resize.ts
+++ b/dom/resize.ts
@@ -59,9 +59,19 @@ function setVar(varName: string, px: number): void {
 
 function attachResize(host: HTMLElement, varName: string): ResizeEntry {
   const handleSel = host.getAttribute("data-resize-handle");
-  const handle: HTMLElement = handleSel
-    ? (host.querySelector<HTMLElement>(handleSel) ?? host)
-    : host;
+  let handle: HTMLElement = host;
+  if (handleSel) {
+    const found = host.querySelector<HTMLElement>(handleSel);
+    if (found) {
+      handle = found;
+    } else {
+      // Selector set but matched nothing — almost certainly a template typo.
+      // Falling back to the whole host as the drag target is surprising, so warn.
+      console.warn(
+        `lvt-fx:resize: data-resize-handle "${handleSel}" matched no element; using the host as the drag target.`
+      );
+    }
+  }
   const axis = (host.getAttribute("data-resize-axis") || "x").toLowerCase();
   const edge = (host.getAttribute("data-resize-edge") || "end").toLowerCase();
   const min = readNumberAttr(host, "data-resize-min", 0);

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -31,6 +31,7 @@ import {
   setupFxLifecycleListeners,
   teardownFxLifecycleListeners,
 } from "./dom/directives";
+import { handleResizeDirectives, teardownResizeForRoot } from "./dom/resize";
 import { EventDelegator } from "./dom/event-delegation";
 import { LinkInterceptor } from "./dom/link-interceptor";
 import { ObserverManager } from "./dom/observer-manager";
@@ -676,6 +677,7 @@ export class LiveTemplateClient {
       teardownScrollAway(this.wrapperElement);
       teardownSpy(this.wrapperElement);
       teardownAreaSelectForRoot(this.wrapperElement);
+      teardownResizeForRoot(this.wrapperElement);
       teardownRegionSelectForRoot(this.wrapperElement);
       teardownProxyBridgeForRoot(this.wrapperElement);
       teardownIframeAutoHeightForRoot(this.wrapperElement);
@@ -1807,6 +1809,28 @@ export class LiveTemplateClient {
           (toEl as Element).setAttribute('open', '');
         }
 
+        // <details lvt-ignore-attrs>: the user's live open/closed state is
+        // authoritative in BOTH directions. Plain lvt-ignore-attrs only revives
+        // attributes the server OMITS, so a server-emitted `open` (e.g. a default-
+        // expanded folder) would re-open after the user collapsed it. Syncing
+        // toEl's `open` to fromEl's live state before morphdom's attr diff keeps
+        // the disclosure where the user left it: the server sets the initial
+        // default on insert (no fromEl yet), the user owns it thereafter, and
+        // data-lvt-force-update lets the server reassert control. Bare <details>
+        // (no opt-in) keep the default server-wins behaviour.
+        if (
+          fromEl instanceof HTMLDetailsElement &&
+          (fromEl as Element).hasAttribute('lvt-ignore-attrs') &&
+          !(toEl as Element).hasAttribute('data-lvt-force-update') &&
+          toEl.nodeType === Node.ELEMENT_NODE
+        ) {
+          if (fromEl.open) {
+            (toEl as Element).setAttribute('open', '');
+          } else {
+            (toEl as Element).removeAttribute('open');
+          }
+        }
+
         // Skip open popovers entirely (top-layer state has no DOM representation).
         if (
           !(toEl as Element).hasAttribute("data-lvt-force-update") &&
@@ -2043,6 +2067,10 @@ export class LiveTemplateClient {
     // send the event delegator uses so the WS/HTTP routing is
     // identical to a normal action.
     handleAreaSelectDirectives(element, (message) => this.send(message));
+    // resize is client-only (updates a CSS var on :root + localStorage), so
+    // unlike area-select it needs no send() callback. Arm/sweep is idempotent
+    // so an in-flight drag survives a re-render.
+    handleResizeDirectives(element);
     // region-select is the area-select drag spine over an iframe / code
     // overlay: a drawn box is hit-tested to a source line range. Same
     // send-callback wiring; the overlay is parent light DOM so it works

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1821,8 +1821,7 @@ export class LiveTemplateClient {
         if (
           fromEl instanceof HTMLDetailsElement &&
           (fromEl as Element).hasAttribute('lvt-ignore-attrs') &&
-          !(toEl as Element).hasAttribute('data-lvt-force-update') &&
-          toEl.nodeType === Node.ELEMENT_NODE
+          !(toEl as Element).hasAttribute('data-lvt-force-update')
         ) {
           if (fromEl.open) {
             (toEl as Element).setAttribute('open', '');

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1825,13 +1825,14 @@ export class LiveTemplateClient {
         // no-op for `open`). lvt-ignore-attrs is only the opt-in marker.
         if (
           fromEl instanceof HTMLDetailsElement &&
+          toEl instanceof HTMLDetailsElement &&
           fromEl.hasAttribute('lvt-ignore-attrs') &&
-          !(toEl as Element).hasAttribute('data-lvt-force-update')
+          !toEl.hasAttribute('data-lvt-force-update')
         ) {
           if (fromEl.open) {
-            (toEl as Element).setAttribute('open', '');
+            toEl.setAttribute('open', '');
           } else {
-            (toEl as Element).removeAttribute('open');
+            toEl.removeAttribute('open');
           }
         }
 

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1818,9 +1818,14 @@ export class LiveTemplateClient {
         // default on insert (no fromEl yet), the user owns it thereafter, and
         // data-lvt-force-update lets the server reassert control. Bare <details>
         // (no opt-in) keep the default server-wins behaviour.
+        //
+        // Ordering: we don't rely on lvt-ignore-attrs to suppress the `open`
+        // diff — we set toEl's `open` to the live value HERE, so morphdom's
+        // subsequent attribute sync copies that same value back onto fromEl (a
+        // no-op for `open`). lvt-ignore-attrs is only the opt-in marker.
         if (
           fromEl instanceof HTMLDetailsElement &&
-          (fromEl as Element).hasAttribute('lvt-ignore-attrs') &&
+          fromEl.hasAttribute('lvt-ignore-attrs') &&
           !(toEl as Element).hasAttribute('data-lvt-force-update')
         ) {
           if (fromEl.open) {

--- a/tests/preserve.test.ts
+++ b/tests/preserve.test.ts
@@ -800,6 +800,114 @@ describe("lvt-ignore and lvt-ignore-attrs", () => {
     expect(input.getAttribute('aria-invalid')).toBe("true");
   });
 
+  it("details lvt-ignore-attrs: user-collapsed default-OPEN folder stays collapsed", () => {
+    // A server-default-expanded folder (<details open>) that the user collapses
+    // must STAY collapsed across re-renders. Plain lvt-ignore-attrs can't do this
+    // (it only revives server-omitted attrs); the dedicated <details> open-sync
+    // makes the live state win in this direction too.
+    const initialTree = {
+      s: [
+        `<details lvt-ignore-attrs open data-key="d"><summary>changed</summary>`,
+        `</details>`,
+      ],
+      0: `<a class="file" data-key="f">b.go</a>`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const details = wrapper.querySelector("details") as HTMLDetailsElement;
+    expect(details.open).toBe(true);
+
+    // User collapses the auto-expanded folder.
+    details.removeAttribute("open");
+    expect(details.open).toBe(false);
+
+    // Server re-renders, still emitting `open` (it's a default-open folder), and
+    // updates a child (file selection).
+    client.updateDOM(wrapper, {
+      s: [
+        `<details lvt-ignore-attrs open data-key="d"><summary>changed</summary>`,
+        `</details>`,
+      ],
+      0: `<a class="file selected" data-key="f">b.go</a>`,
+    });
+
+    const after = wrapper.querySelector("details") as HTMLDetailsElement;
+    expect(after.open).toBe(false); // stays collapsed — the fix
+    // Child still updated.
+    expect(wrapper.querySelector("a.file")!.className).toBe("file selected");
+  });
+
+  it("details lvt-ignore-attrs: user-opened default-CLOSED folder stays open + children update", () => {
+    const initialTree = {
+      s: [
+        `<details lvt-ignore-attrs data-key="d2"><summary>src</summary>`,
+        `</details>`,
+      ],
+      0: `<a class="file" data-key="f2">a.go</a>`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const details = wrapper.querySelector("details") as HTMLDetailsElement;
+    expect(details.open).toBe(false);
+
+    details.setAttribute("open", ""); // user expands
+    expect(details.open).toBe(true);
+
+    // Server re-render (still omits open) with a child change.
+    client.updateDOM(wrapper, { 0: `<a class="file selected" data-key="f2">a.go</a>` });
+
+    const after = wrapper.querySelector("details") as HTMLDetailsElement;
+    expect(after.open).toBe(true); // stays open
+    expect(wrapper.querySelector("a.file")!.className).toBe("file selected");
+  });
+
+  it("details lvt-ignore-attrs: data-lvt-force-update lets the server reassert open state", () => {
+    const initialTree = {
+      s: [
+        `<details lvt-ignore-attrs open data-key="d3"><summary>x</summary>`,
+        `</details>`,
+      ],
+      0: `<span>v1</span>`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const details = wrapper.querySelector("details") as HTMLDetailsElement;
+    details.removeAttribute("open"); // user collapses
+    expect(details.open).toBe(false);
+
+    // Server force-updates to reassert open.
+    client.updateDOM(wrapper, {
+      s: [
+        `<details lvt-ignore-attrs open data-lvt-force-update data-key="d3"><summary>x</summary>`,
+        `</details>`,
+      ],
+      0: `<span>v2</span>`,
+    });
+
+    const after = wrapper.querySelector("details") as HTMLDetailsElement;
+    expect(after.open).toBe(true); // server wins under force-update
+    expect(after.hasAttribute("data-lvt-force-update")).toBe(false); // self-clears
+  });
+
+  it("bare <details> (no lvt-ignore-attrs) keeps default server-wins behaviour", () => {
+    // Control: without the opt-in, the user's open state is clobbered by the
+    // server's HTML, matching the documented default.
+    const initialTree = {
+      s: [`<details data-key="d4"><summary>src</summary>`, `</details>`],
+      0: `<a class="file" data-key="f4">c.go</a>`,
+    };
+    client.updateDOM(wrapper, initialTree);
+
+    const details = wrapper.querySelector("details") as HTMLDetailsElement;
+    details.setAttribute("open", "");
+    expect(details.open).toBe(true);
+
+    client.updateDOM(wrapper, { 0: `<a class="file x" data-key="f4">c.go</a>` });
+
+    const after = wrapper.querySelector("details") as HTMLDetailsElement;
+    expect(after.open).toBe(false); // clobbered — server wins
+  });
+
   it("preserves the element's children as well", () => {
     // lvt-ignore is a full-element bail-out: attributes, children,
     // everything stays as-is. Useful for third-party widgets that

--- a/tests/resize.test.ts
+++ b/tests/resize.test.ts
@@ -88,6 +88,17 @@ describe("lvt-fx:resize arm/sweep lifecycle", () => {
     warn.mockRestore();
   });
 
+  it("warns and skips when the value is not a custom property (footgun guard)", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    localStorage.setItem("test.w", "350");
+    makeHost({ ...baseAttrs, "lvt-fx:resize": "width" });
+    handleResizeDirectives(document.body);
+    expect(warn).toHaveBeenCalled();
+    // Must NOT have written a real `width` property onto :root.
+    expect(document.documentElement.style.getPropertyValue("width")).toBe("");
+    warn.mockRestore();
+  });
+
   it("sweeps the entry when the attribute is removed", () => {
     const host = makeHost(baseAttrs);
     handleResizeDirectives(document.body);

--- a/tests/resize.test.ts
+++ b/tests/resize.test.ts
@@ -99,6 +99,27 @@ describe("lvt-fx:resize arm/sweep lifecycle", () => {
     warn.mockRestore();
   });
 
+  it("warns when two connected elements share the same resize var", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    document.body.replaceChildren();
+    const wrap = document.createElement("div");
+    wrap.setAttribute("data-lvt-id", "t");
+    for (let i = 0; i < 2; i++) {
+      const host = document.createElement("aside");
+      for (const [k, v] of Object.entries(baseAttrs)) host.setAttribute(k, v);
+      const h = document.createElement("div");
+      h.className = "resize-handle";
+      host.appendChild(h);
+      wrap.appendChild(host);
+    }
+    document.body.appendChild(wrap);
+    handleResizeDirectives(document.body);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("already controlled")
+    );
+    warn.mockRestore();
+  });
+
   it("sweeps the entry when the attribute is removed", () => {
     const host = makeHost(baseAttrs);
     handleResizeDirectives(document.body);

--- a/tests/resize.test.ts
+++ b/tests/resize.test.ts
@@ -56,6 +56,25 @@ describe("lvt-fx:resize restore + clamp", () => {
     expect(document.documentElement.style.getPropertyValue("--w")).toBe("200px");
   });
 
+  it("teardownResizeForRoot clears the :root custom property", () => {
+    localStorage.setItem("test.w", "350");
+    makeHost(baseAttrs);
+    handleResizeDirectives(document.body);
+    expect(document.documentElement.style.getPropertyValue("--w")).toBe("350px");
+    teardownResizeForRoot(document.body);
+    expect(document.documentElement.style.getPropertyValue("--w")).toBe("");
+  });
+
+  it("warns and falls back to the host when the handle selector misses", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    makeHost({ ...baseAttrs, "data-resize-handle": ".does-not-exist" });
+    handleResizeDirectives(document.body);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("matched no element")
+    );
+    warn.mockRestore();
+  });
+
   it("does nothing when there is no persisted width", () => {
     makeHost(baseAttrs);
     handleResizeDirectives(document.body);

--- a/tests/resize.test.ts
+++ b/tests/resize.test.ts
@@ -1,0 +1,99 @@
+/**
+ * lvt-fx:resize directive — unit coverage for the deterministic, non-pointer
+ * logic: restore-from-localStorage with clamping, idempotent re-arm, sweep on
+ * attribute removal, and the missing-var warning. The live pointer drag is
+ * covered end-to-end by the prereview chromedp test (jsdom has no PointerEvent).
+ */
+import { handleResizeDirectives, teardownResizeForRoot } from "../dom/resize";
+
+function makeHost(attrs: Record<string, string>): HTMLElement {
+  document.body.replaceChildren();
+  document.documentElement.style.removeProperty("--w");
+  const wrapper = document.createElement("div");
+  wrapper.setAttribute("data-lvt-id", "test");
+  const host = document.createElement("aside");
+  for (const [k, v] of Object.entries(attrs)) host.setAttribute(k, v);
+  const handle = document.createElement("div");
+  handle.className = "resize-handle";
+  host.appendChild(handle);
+  wrapper.appendChild(host);
+  document.body.appendChild(wrapper);
+  return host;
+}
+
+const baseAttrs = {
+  "lvt-fx:resize": "--w",
+  "data-resize-handle": ".resize-handle",
+  "data-resize-min": "200",
+  "data-resize-max": "560",
+  "data-resize-store": "test.w",
+};
+
+afterEach(() => {
+  localStorage.clear();
+  teardownResizeForRoot(document.body);
+});
+
+describe("lvt-fx:resize restore + clamp", () => {
+  it("restores a persisted width within range onto :root", () => {
+    localStorage.setItem("test.w", "350");
+    makeHost(baseAttrs);
+    handleResizeDirectives(document.body);
+    expect(document.documentElement.style.getPropertyValue("--w")).toBe("350px");
+  });
+
+  it("clamps a persisted width above max", () => {
+    localStorage.setItem("test.w", "5000");
+    makeHost(baseAttrs);
+    handleResizeDirectives(document.body);
+    expect(document.documentElement.style.getPropertyValue("--w")).toBe("560px");
+  });
+
+  it("clamps a persisted width below min", () => {
+    localStorage.setItem("test.w", "50");
+    makeHost(baseAttrs);
+    handleResizeDirectives(document.body);
+    expect(document.documentElement.style.getPropertyValue("--w")).toBe("200px");
+  });
+
+  it("does nothing when there is no persisted width", () => {
+    makeHost(baseAttrs);
+    handleResizeDirectives(document.body);
+    expect(document.documentElement.style.getPropertyValue("--w")).toBe("");
+  });
+
+  it("ignores a non-numeric persisted value", () => {
+    localStorage.setItem("test.w", "wide");
+    makeHost(baseAttrs);
+    handleResizeDirectives(document.body);
+    expect(document.documentElement.style.getPropertyValue("--w")).toBe("");
+  });
+});
+
+describe("lvt-fx:resize arm/sweep lifecycle", () => {
+  it("is idempotent — re-running does not throw or duplicate work", () => {
+    localStorage.setItem("test.w", "300");
+    makeHost(baseAttrs);
+    handleResizeDirectives(document.body);
+    expect(() => handleResizeDirectives(document.body)).not.toThrow();
+    expect(document.documentElement.style.getPropertyValue("--w")).toBe("300px");
+  });
+
+  it("warns and skips when the var name is empty", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const host = makeHost({ ...baseAttrs, "lvt-fx:resize": "" });
+    handleResizeDirectives(document.body);
+    expect(warn).toHaveBeenCalled();
+    expect(host.hasAttribute("data-resizing")).toBe(false);
+    warn.mockRestore();
+  });
+
+  it("sweeps the entry when the attribute is removed", () => {
+    const host = makeHost(baseAttrs);
+    handleResizeDirectives(document.body);
+    // Removing the directive attribute and re-running should clean up without
+    // error (no listeners left dangling on the handle).
+    host.removeAttribute("lvt-fx:resize");
+    expect(() => handleResizeDirectives(document.body)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Two client capabilities that let apps build a GitHub-style **collapsible, resizable sidebar with zero custom JavaScript** (consumed by prereview's new file-tree sidebar).

## 1. Durable `<details lvt-ignore-attrs>` open state
morphdom syncs attributes to the server's HTML on every render, so a user-toggled disclosure snaps back on the next re-render. `onBeforeElUpdated` now makes a `<details>`'s **live `open` state authoritative in both directions** when it opts in via `lvt-ignore-attrs`:
- the server sets the initial default on insert,
- the user owns it thereafter,
- `data-lvt-force-update` lets the server reassert control.

Bare `<details>` (no opt-in) keep their documented server-wins behaviour. Mirrors the existing `HTMLDialogElement` open-preservation block, just bidirectional and gated.

## 2. `lvt-fx:resize` — generic edge-drag resize directive
Drag a handle to update a CSS custom property live, clamped and optionally persisted:
```html
<aside lvt-fx:resize="--w" data-resize-handle=".handle"
       data-resize-min="200" data-resize-max="560" data-resize-store="app.w">
  …<div class="handle"></div>
</aside>
```
- updates the var on **`:root`** so morphdom never strips it,
- clamps to `data-resize-min`/`-max`,
- persists to `localStorage` (`data-resize-store`) and restores on arm.

Modeled on the `lvt-fx:area-select` pointer-capture + arm/sweep/cleanup lifecycle.

## Tests
- `tests/preserve.test.ts` — 4 new durability cases (default-open collapse sticks, default-closed open sticks + children update, force-update override, bare-`<details>` control).
- `tests/resize.test.ts` — 8 restore/clamp/lifecycle cases.
- Full suite: 749 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bnEwkKH6E9q2QQnqj3cWe