### PR TITLE
Add opt-in lvt-mod:skip-when-typing guard for window keyboard bindings

### DIFF
--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -38,7 +38,7 @@ const DRAG_EVENTS = new Set([
 // `lvt-mod:skip-when-typing` guard on window keyboard bindings.
 const EDITABLE_SELECTOR = [
   'input:not([type="button"]):not([type="submit"]):not([type="reset"])'
-    + ':not([type="checkbox"]):not([type="radio"])',
+    + ':not([type="checkbox"]):not([type="radio"]):not([type="image"])',
   "textarea",
   "select",
   '[contenteditable=""]',

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -31,6 +31,24 @@ const DRAG_EVENTS = new Set([
   "dragleave",
 ]);
 
+// Elements where the user is "typing" — text-entry inputs, textareas, selects
+// (type-ahead), and contenteditable regions. Button/checkbox/radio inputs are
+// deliberately excluded: they accept activation keys, not text, so a global
+// shortcut should still fire when one of them is focused. Used by the opt-in
+// `lvt-mod:skip-when-typing` guard on window keyboard bindings.
+const EDITABLE_SELECTOR = [
+  'input:not([type="button"]):not([type="submit"]):not([type="reset"])'
+    + ':not([type="checkbox"]):not([type="radio"])',
+  "textarea",
+  "select",
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
+].join(", ");
+
+function isEditableTarget(node: EventTarget | null): boolean {
+  return node instanceof Element && node.closest(EDITABLE_SELECTOR) !== null;
+}
+
 export interface EventDelegationContext {
   getWrapperElement(): Element | null;
   getRateLimitedHandlers(): WeakMap<Element, Map<string, Function>>;
@@ -721,6 +739,17 @@ export class EventDelegator {
             const keyFilter = element.getAttribute("lvt-key");
             const keyboardEvent = e as KeyboardEvent;
             if (keyFilter && keyboardEvent.key !== keyFilter) {
+              return;
+            }
+
+            // Opt-in guard: suppress this binding while the user is typing in an
+            // editable element, so e.g. "j" typed into a comment box doesn't
+            // trigger a navigation shortcut. Bindings WITHOUT this attribute
+            // (e.g. Escape-to-cancel) still fire while typing.
+            if (
+              element.hasAttribute("lvt-mod:skip-when-typing") &&
+              isEditableTarget(document.activeElement)
+            ) {
               return;
             }
           }

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -32,16 +32,17 @@ const DRAG_EVENTS = new Set([
 ]);
 
 // Elements where the user is "typing" — text-entry inputs, textareas, selects
-// (type-ahead), and contenteditable regions. Button/submit/reset/checkbox/
-// radio/image inputs are deliberately excluded: they accept activation keys,
-// not text, so a global shortcut should still fire when one of them is focused.
-// input[type="range"] is intentionally NOT excluded — it responds to arrow
-// keys, so suppressing arrow-bound shortcuts while a slider is focused lets the
-// slider consume the arrows. Used by the opt-in `lvt-mod:skip-when-typing`
-// guard on window keyboard bindings.
+// (type-ahead), and contenteditable regions. Inputs that act as buttons rather
+// than text fields — button/submit/reset/checkbox/radio/image/file — are
+// deliberately excluded: they accept activation keys, not text, so a global
+// shortcut should still fire when one of them is focused. The rest stay in
+// scope, including the keys-but-no-typing cases: input[type="range"] (arrows
+// move the slider) and input[type="number"] (arrows step + you type digits) —
+// suppressing shortcuts while one is focused lets the control consume the key.
+// Used by the opt-in `lvt-mod:skip-when-typing` guard on window key bindings.
 const EDITABLE_SELECTOR = [
   'input:not([type="button"]):not([type="submit"]):not([type="reset"])'
-    + ':not([type="checkbox"]):not([type="radio"]):not([type="image"])',
+    + ':not([type="checkbox"]):not([type="radio"]):not([type="image"]):not([type="file"])',
   "textarea",
   "select",
   '[contenteditable=""]',

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -32,10 +32,13 @@ const DRAG_EVENTS = new Set([
 ]);
 
 // Elements where the user is "typing" — text-entry inputs, textareas, selects
-// (type-ahead), and contenteditable regions. Button/checkbox/radio inputs are
-// deliberately excluded: they accept activation keys, not text, so a global
-// shortcut should still fire when one of them is focused. Used by the opt-in
-// `lvt-mod:skip-when-typing` guard on window keyboard bindings.
+// (type-ahead), and contenteditable regions. Button/submit/reset/checkbox/
+// radio/image inputs are deliberately excluded: they accept activation keys,
+// not text, so a global shortcut should still fire when one of them is focused.
+// input[type="range"] is intentionally NOT excluded — it responds to arrow
+// keys, so suppressing arrow-bound shortcuts while a slider is focused lets the
+// slider consume the arrows. Used by the opt-in `lvt-mod:skip-when-typing`
+// guard on window keyboard bindings.
 const EDITABLE_SELECTOR = [
   'input:not([type="button"]):not([type="submit"]):not([type="reset"])'
     + ':not([type="checkbox"]):not([type="radio"]):not([type="image"])',
@@ -57,7 +60,7 @@ function deepActiveElement(): Element | null {
   return el;
 }
 
-function isEditableTarget(node: EventTarget | null): boolean {
+function isEditableTarget(node: Element | null): boolean {
   return node instanceof Element && node.closest(EDITABLE_SELECTOR) !== null;
 }
 

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -46,6 +46,7 @@ const EDITABLE_SELECTOR = [
   "select",
   '[contenteditable=""]',
   '[contenteditable="true"]',
+  '[contenteditable="plaintext-only"]',
 ].join(", ");
 
 // deepActiveElement resolves the *actually* focused element across shadow
@@ -747,20 +748,21 @@ export class EventDelegator {
           const action = element.getAttribute(attrName);
           if (!action) return;
 
-          if (
-            (eventType === "keydown" || eventType === "keyup") &&
-            element.hasAttribute("lvt-key")
-          ) {
-            const keyFilter = element.getAttribute("lvt-key");
+          if (eventType === "keydown" || eventType === "keyup") {
             const keyboardEvent = e as KeyboardEvent;
-            if (keyFilter && keyboardEvent.key !== keyFilter) {
-              return;
+            if (element.hasAttribute("lvt-key")) {
+              const keyFilter = element.getAttribute("lvt-key");
+              if (keyFilter && keyboardEvent.key !== keyFilter) {
+                return;
+              }
             }
 
             // Opt-in guard: suppress this binding while the user is typing in an
             // editable element, so e.g. "j" typed into a comment box doesn't
-            // trigger a navigation shortcut. Bindings WITHOUT this attribute
-            // (e.g. Escape-to-cancel) still fire while typing.
+            // trigger a navigation shortcut. Applies whenever the attribute is
+            // present — independent of lvt-key — so a guarded binding without a
+            // key filter is still suppressed while typing. Bindings WITHOUT this
+            // attribute (e.g. Escape-to-cancel) still fire while typing.
             if (
               element.hasAttribute("lvt-mod:skip-when-typing") &&
               isEditableTarget(deepActiveElement())

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -45,6 +45,18 @@ const EDITABLE_SELECTOR = [
   '[contenteditable="true"]',
 ].join(", ");
 
+// deepActiveElement resolves the *actually* focused element across shadow
+// boundaries. document.activeElement returns the shadow HOST when focus is
+// inside a web component's shadow root, so we descend through shadowRoot.
+// activeElement (recursively, for nested shadow DOM) to reach the real input.
+function deepActiveElement(): Element | null {
+  let el: Element | null = document.activeElement;
+  while (el?.shadowRoot?.activeElement) {
+    el = el.shadowRoot.activeElement;
+  }
+  return el;
+}
+
 function isEditableTarget(node: EventTarget | null): boolean {
   return node instanceof Element && node.closest(EDITABLE_SELECTOR) !== null;
 }
@@ -748,7 +760,7 @@ export class EventDelegator {
             // (e.g. Escape-to-cancel) still fire while typing.
             if (
               element.hasAttribute("lvt-mod:skip-when-typing") &&
-              isEditableTarget(document.activeElement)
+              isEditableTarget(deepActiveElement())
             ) {
               return;
             }

--- a/dom/event-delegation.ts
+++ b/dom/event-delegation.ts
@@ -42,7 +42,8 @@ const DRAG_EVENTS = new Set([
 // Used by the opt-in `lvt-mod:skip-when-typing` guard on window key bindings.
 const EDITABLE_SELECTOR = [
   'input:not([type="button"]):not([type="submit"]):not([type="reset"])'
-    + ':not([type="checkbox"]):not([type="radio"]):not([type="image"]):not([type="file"])',
+    + ':not([type="checkbox"]):not([type="radio"]):not([type="image"]):not([type="file"])'
+    + ':not([type="color"])',
   "textarea",
   "select",
   '[contenteditable=""]',
@@ -63,7 +64,7 @@ function deepActiveElement(): Element | null {
 }
 
 function isEditableTarget(node: Element | null): boolean {
-  return node instanceof Element && node.closest(EDITABLE_SELECTOR) !== null;
+  return node !== null && node.closest(EDITABLE_SELECTOR) !== null;
 }
 
 export interface EventDelegationContext {

--- a/tests/event-delegation.test.ts
+++ b/tests/event-delegation.test.ts
@@ -725,6 +725,21 @@ describe("EventDelegator", () => {
       expect(context.send).toHaveBeenCalledWith({ action: "nextFile", data: {} });
     });
 
+    it("guards keyup bindings too (skip-when-typing is not keydown-only)", () => {
+      const { wrapper, context } = setupWindowKeydown(
+        "wrapper-guard-keyup",
+        `
+          <div lvt-on:window:keyup="nextFile" lvt-key="j" lvt-mod:skip-when-typing></div>
+          <textarea id="composer"></textarea>
+        `
+      );
+      (wrapper.querySelector("#composer") as HTMLTextAreaElement).focus();
+
+      window.dispatchEvent(new KeyboardEvent("keyup", { key: "j" }));
+
+      expect(context.send).not.toHaveBeenCalled();
+    });
+
     it("fires a binding WITHOUT the opt-in even while a textarea is focused (Escape case)", () => {
       const { wrapper, context } = setupWindowKeydown(
         "wrapper-guard-escape",

--- a/tests/event-delegation.test.ts
+++ b/tests/event-delegation.test.ts
@@ -688,6 +688,27 @@ describe("EventDelegator", () => {
       expect(context.send).not.toHaveBeenCalled();
     });
 
+    it("suppresses an opted-in binding while a shadow-DOM input is focused", () => {
+      const { wrapper, context } = setupWindowKeydown(
+        "wrapper-guard-shadow",
+        `
+          <div lvt-on:window:keydown="nextFile" lvt-key="j" lvt-mod:skip-when-typing></div>
+          <div id="host"></div>
+        `
+      );
+      // document.activeElement returns the shadow HOST, so the guard must
+      // descend through shadowRoot.activeElement to find the real input.
+      const host = wrapper.querySelector("#host") as HTMLElement;
+      const root = host.attachShadow({ mode: "open" });
+      const input = document.createElement("textarea");
+      root.appendChild(input);
+      input.focus();
+
+      pressKey("j");
+
+      expect(context.send).not.toHaveBeenCalled();
+    });
+
     it("fires an opted-in binding when focus is on a non-editable element", () => {
       const { wrapper, context } = setupWindowKeydown(
         "wrapper-guard-button",

--- a/tests/event-delegation.test.ts
+++ b/tests/event-delegation.test.ts
@@ -623,6 +623,107 @@ describe("EventDelegator", () => {
     });
   });
 
+  describe("window keydown skip-when-typing guard", () => {
+    const setupWindowKeydown = (wrapperId: string, innerHTML: string) => {
+      const wrapper = document.createElement("div");
+      wrapper.setAttribute("data-lvt-id", wrapperId);
+      wrapper.innerHTML = innerHTML;
+      document.body.appendChild(wrapper);
+
+      const context = createContext(wrapper);
+      const delegator = new EventDelegator(
+        context,
+        createLogger({ scope: "EventDelegatorTest", level: "silent" })
+      );
+      delegator.setupWindowEventDelegation();
+      return { wrapper, context };
+    };
+
+    const pressKey = (key: string) => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key }));
+    };
+
+    it("suppresses an opted-in binding while a textarea is focused", () => {
+      const { wrapper, context } = setupWindowKeydown(
+        "wrapper-guard-textarea",
+        `
+          <div lvt-on:window:keydown="nextFile" lvt-key="j" lvt-mod:skip-when-typing></div>
+          <textarea id="composer"></textarea>
+        `
+      );
+      (wrapper.querySelector("#composer") as HTMLTextAreaElement).focus();
+
+      pressKey("j");
+
+      expect(context.send).not.toHaveBeenCalled();
+    });
+
+    it("suppresses an opted-in binding while a text input is focused", () => {
+      const { wrapper, context } = setupWindowKeydown(
+        "wrapper-guard-input",
+        `
+          <div lvt-on:window:keydown="nextFile" lvt-key="j" lvt-mod:skip-when-typing></div>
+          <input id="filter" type="text" />
+        `
+      );
+      (wrapper.querySelector("#filter") as HTMLInputElement).focus();
+
+      pressKey("j");
+
+      expect(context.send).not.toHaveBeenCalled();
+    });
+
+    it("suppresses an opted-in binding while a contenteditable region is focused", () => {
+      const { wrapper, context } = setupWindowKeydown(
+        "wrapper-guard-ce",
+        `
+          <div lvt-on:window:keydown="nextFile" lvt-key="j" lvt-mod:skip-when-typing></div>
+          <div id="rich" contenteditable="true" tabindex="0"></div>
+        `
+      );
+      (wrapper.querySelector("#rich") as HTMLElement).focus();
+
+      pressKey("j");
+
+      expect(context.send).not.toHaveBeenCalled();
+    });
+
+    it("fires an opted-in binding when focus is on a non-editable element", () => {
+      const { wrapper, context } = setupWindowKeydown(
+        "wrapper-guard-button",
+        `
+          <div lvt-on:window:keydown="nextFile" lvt-key="j" lvt-mod:skip-when-typing></div>
+          <button id="go" type="button">go</button>
+        `
+      );
+      (wrapper.querySelector("#go") as HTMLButtonElement).focus();
+
+      pressKey("j");
+
+      expect(context.send).toHaveBeenCalledTimes(1);
+      expect(context.send).toHaveBeenCalledWith({ action: "nextFile", data: {} });
+    });
+
+    it("fires a binding WITHOUT the opt-in even while a textarea is focused (Escape case)", () => {
+      const { wrapper, context } = setupWindowKeydown(
+        "wrapper-guard-escape",
+        `
+          <div lvt-on:window:keydown="clearSelection" lvt-key="Escape"></div>
+          <textarea id="composer"></textarea>
+        `
+      );
+      (wrapper.querySelector("#composer") as HTMLTextAreaElement).focus();
+
+      pressKey("Escape");
+
+      expect(context.send).toHaveBeenCalledTimes(1);
+      expect(context.send).toHaveBeenCalledWith({
+        action: "clearSelection",
+        data: {},
+      });
+    });
+  });
+
   describe("orphan buttons (formless standalone)", () => {
     it("button with name triggers action", () => {
       const wrapper = document.createElement("div");

--- a/tests/event-delegation.test.ts
+++ b/tests/event-delegation.test.ts
@@ -725,6 +725,23 @@ describe("EventDelegator", () => {
       expect(context.send).toHaveBeenCalledWith({ action: "nextFile", data: {} });
     });
 
+    it("suppresses an opted-in binding while a range input is focused (arrows adjust the slider)", () => {
+      const { wrapper, context } = setupWindowKeydown(
+        "wrapper-guard-range",
+        `
+          <div lvt-on:window:keydown="nextFile" lvt-key="ArrowDown" lvt-mod:skip-when-typing></div>
+          <input id="slider" type="range" />
+        `
+      );
+      (wrapper.querySelector("#slider") as HTMLInputElement).focus();
+
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+
+      // range inputs are intentionally "editable": the arrow goes to the slider,
+      // not the shortcut.
+      expect(context.send).not.toHaveBeenCalled();
+    });
+
     it("guards keyup bindings too (skip-when-typing is not keydown-only)", () => {
       const { wrapper, context } = setupWindowKeydown(
         "wrapper-guard-keyup",

--- a/tests/event-delegation.test.ts
+++ b/tests/event-delegation.test.ts
@@ -757,6 +757,21 @@ describe("EventDelegator", () => {
       expect(context.send).not.toHaveBeenCalled();
     });
 
+    it("guards a skip-when-typing binding even without an lvt-key filter", () => {
+      const { wrapper, context } = setupWindowKeydown(
+        "wrapper-guard-nokey",
+        `
+          <div lvt-on:window:keydown="ping" lvt-mod:skip-when-typing></div>
+          <textarea id="composer"></textarea>
+        `
+      );
+      (wrapper.querySelector("#composer") as HTMLTextAreaElement).focus();
+
+      pressKey("x"); // any key — no lvt-key filter on the binding
+
+      expect(context.send).not.toHaveBeenCalled();
+    });
+
     it("fires a binding WITHOUT the opt-in even while a textarea is focused (Escape case)", () => {
       const { wrapper, context } = setupWindowKeydown(
         "wrapper-guard-escape",


### PR DESCRIPTION
## What

Adds an opt-in `lvt-mod:skip-when-typing` modifier for `lvt-on:window:keydown`/`keyup` bindings. When present, the binding does **not** fire if `document.activeElement` is (or is within) an editable element — a text-like `<input>`, `<textarea>`, `<select>`, or `[contenteditable]`. Button/checkbox/radio inputs are not treated as editable, so shortcuts still fire when one is focused.

## Why

Global single-key shortcuts (e.g. `j`/`k` to navigate) previously fired even while the user was typing in a text field, so a shortcut letter couldn't coexist with text entry. The guard is **opt-in** so that bindings which *must* fire while typing (e.g. `Escape` to cancel) simply omit the attribute and keep working.

Consumed downstream by prereview's keyboard-support feature (livetemplate/prereview#28).

## Tests

`tests/event-delegation.test.ts` covers: opted-in binding suppressed in textarea/input/contenteditable; fires on non-editable focus; and a binding without the opt-in still fires while a textarea is focused. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)