### PR TITLE
Liveness heartbeat: detect dead/zombie sockets and reconnect (on by default)

### DIFF
--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -141,13 +141,18 @@ export class LiveTemplateClient {
   // Liveness heartbeat: an app-level ping/pong the client drives to detect a
   // dead OR zombie socket (a socket that still reports OPEN but whose TCP is
   // gone — a documented iOS/mobile behaviour that fires no `close` event, so
-  // neither onDisconnected nor visibilitychange can catch it). When enabled
-  // (heartbeatMs > 0, set from `data-lvt-heartbeat-ms`), every tick sends
+  // neither onDisconnected nor visibilitychange can catch it). Every tick sends
   // {action:"__ping__"} and expects a {pong:true} within a fraction of the
   // interval; a missing pong ⇒ reconnect (which re-syncs via the server's
-  // push-on-connect render). Disabled by default so the framework's
-  // conservative posture is unchanged for apps that don't opt in.
-  private heartbeatMs: number = 0;
+  // push-on-connect render).
+  //
+  // ON BY DEFAULT at DEFAULT_HEARTBEAT_MS — a socket that silently dies should
+  // recover everywhere, not only in apps that remembered to opt in. Tune or
+  // OPT OUT with `data-lvt-heartbeat-ms`: "0" disables it, any value ≥ 1000 sets
+  // the interval. The retry cadence is one interval (bounded by `reconnecting`),
+  // so this is a gentle self-heal, not the tight loop `autoReconnect` guards.
+  private static readonly DEFAULT_HEARTBEAT_MS = 20000;
+  private heartbeatMs: number = LiveTemplateClient.DEFAULT_HEARTBEAT_MS;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private pongDeadlineTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -424,18 +429,18 @@ export class LiveTemplateClient {
           }
         }
 
-        // Liveness heartbeat: opt-in via `data-lvt-heartbeat-ms="<N>"` on the
-        // wrapper (server-set), falling back to <body> like the debounce attr.
-        // When set, the client pings every N ms and reconnects if a pong doesn't
-        // come back — catching dead/zombie sockets that fire no close event.
+        // Liveness heartbeat: ON by default (see the field). Override via
+        // `data-lvt-heartbeat-ms` on the wrapper (server-set), falling back to
+        // <body> like the debounce attr: "0" opts OUT, any value ≥ 1000 sets the
+        // interval. An absent/typo'd value keeps the default. The 1s floor avoids
+        // a pathological tight ping loop from a fat-fingered "20" etc.
         const heartbeatAttr =
           wrapper.getAttribute("data-lvt-heartbeat-ms") ??
           document.body?.getAttribute("data-lvt-heartbeat-ms") ??
           null;
         if (heartbeatAttr !== null && /^\d+$/.test(heartbeatAttr)) {
           const hb = parseInt(heartbeatAttr, 10);
-          // Floor at 1s to avoid a pathological tight ping loop from a typo.
-          if (Number.isFinite(hb) && hb >= 1000) {
+          if (hb === 0 || hb >= 1000) {
             client.heartbeatMs = hb;
           }
         }

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -138,6 +138,19 @@ export class LiveTemplateClient {
   private pageshowHandler: ((e: PageTransitionEvent) => void) | null = null;
   private visibilityReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // Liveness heartbeat: an app-level ping/pong the client drives to detect a
+  // dead OR zombie socket (a socket that still reports OPEN but whose TCP is
+  // gone — a documented iOS/mobile behaviour that fires no `close` event, so
+  // neither onDisconnected nor visibilitychange can catch it). When enabled
+  // (heartbeatMs > 0, set from `data-lvt-heartbeat-ms`), every tick sends
+  // {action:"__ping__"} and expects a {pong:true} within a fraction of the
+  // interval; a missing pong ⇒ reconnect (which re-syncs via the server's
+  // push-on-connect render). Disabled by default so the framework's
+  // conservative posture is unchanged for apps that don't opt in.
+  private heartbeatMs: number = 0;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private pongDeadlineTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor(options: LiveTemplateClientOptions = {}) {
     const { logger: providedLogger, logLevel, debug, ...restOptions } = options;
     const resolvedLevel = logLevel ?? (debug ? "debug" : "info");
@@ -331,6 +344,9 @@ export class LiveTemplateClient {
 
         this.options.onConnect?.();
         this.wrapperElement?.dispatchEvent(new Event("lvt:connected"));
+        // Arm the liveness heartbeat on every (re)connect. Idempotent, and a
+        // no-op unless the app opted in via data-lvt-heartbeat-ms.
+        this.startHeartbeat();
       },
       onDisconnected: () => {
         this.ws = null;
@@ -408,6 +424,22 @@ export class LiveTemplateClient {
           }
         }
 
+        // Liveness heartbeat: opt-in via `data-lvt-heartbeat-ms="<N>"` on the
+        // wrapper (server-set), falling back to <body> like the debounce attr.
+        // When set, the client pings every N ms and reconnects if a pong doesn't
+        // come back — catching dead/zombie sockets that fire no close event.
+        const heartbeatAttr =
+          wrapper.getAttribute("data-lvt-heartbeat-ms") ??
+          document.body?.getAttribute("data-lvt-heartbeat-ms") ??
+          null;
+        if (heartbeatAttr !== null && /^\d+$/.test(heartbeatAttr)) {
+          const hb = parseInt(heartbeatAttr, 10);
+          // Floor at 1s to avoid a pathological tight ping loop from a typo.
+          if (Number.isFinite(hb) && hb >= 1000) {
+            client.heartbeatMs = hb;
+          }
+        }
+
         client.connect().catch((error) => {
           autoInitLogger.error("Auto-initialization connect failed:", error);
         });
@@ -432,6 +464,13 @@ export class LiveTemplateClient {
     response: UpdateResponse,
     event?: MessageEvent<string>
   ): void {
+    // Liveness pong ({pong:true}) — the reply to our heartbeat ping. It carries
+    // no `tree`, so recognise and consume it BEFORE the error/diff paths: clear
+    // the pending pong-deadline and return. Cheapest possible discriminator.
+    if ((response as unknown as { pong?: boolean }).pong) {
+      this.onPong();
+      return;
+    }
     // Error envelope (proposal §3 / V14): a distinct wire message
     // { type:"error", code, topic? } — NOT an UpdateResponse (it carries no
     // `tree`). Surface as an `lvt:error` CustomEvent on the wrapper and
@@ -669,6 +708,7 @@ export class LiveTemplateClient {
     this.useHTTP = false;
     this.hiddenAt = 0;
     this.reconnecting = false;
+    this.stopHeartbeat();
     this.teardownVisibilityReconnect();
     this.uploadHandler.revokePreviews();
     this.eventDelegator.teardownDOMEventTriggerDelegation();
@@ -842,6 +882,92 @@ export class LiveTemplateClient {
     } finally {
       this.reconnecting = false;
     }
+  }
+
+  // startHeartbeat arms the liveness interval (idempotent; no-op unless
+  // heartbeatMs > 0). Called on every (re)connect from onConnected.
+  private startHeartbeat(): void {
+    if (this.heartbeatMs <= 0 || this.heartbeatTimer !== null) return;
+    this.heartbeatTimer = setInterval(
+      () => this.heartbeatTick(),
+      this.heartbeatMs
+    );
+  }
+
+  // stopHeartbeat clears the interval and any pending pong-deadline. Called by
+  // disconnect() so a torn-down client leaves no timers behind.
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    if (this.pongDeadlineTimer !== null) {
+      clearTimeout(this.pongDeadlineTimer);
+      this.pongDeadlineTimer = null;
+    }
+  }
+
+  // heartbeatTick sends one ping and arms a pong-deadline. Skips while hidden
+  // (the visibility path owns that case), mid-reconnect, or in HTTP mode.
+  private heartbeatTick(): void {
+    if (
+      this.useHTTP ||
+      this.reconnecting ||
+      (typeof document !== "undefined" && document.hidden)
+    ) {
+      return;
+    }
+    const readyState = this.webSocketManager.getReadyState();
+    // undefined ⇒ no transport (intentionally disconnected) → nothing to probe.
+    if (readyState === undefined) return;
+    // Not OPEN (CLOSING/CLOSED) while we still believe we're live ⇒ dead socket
+    // that fired no usable close on this client → reconnect.
+    if (readyState !== 1) {
+      this.onHeartbeatDead("socket not open");
+      return;
+    }
+    // A still-pending deadline means the previous ping went unanswered; let it
+    // fire rather than stacking a second probe.
+    if (this.pongDeadlineTimer !== null) return;
+    try {
+      // Send the ping directly over the socket — never via send()'s HTTP
+      // fallback, which would trigger a full render instead of a pong.
+      this.webSocketManager.send(JSON.stringify({ action: "__ping__" }));
+    } catch {
+      this.onHeartbeatDead("ping send threw");
+      return;
+    }
+    // Expect a pong within half the interval (min 2s). A zombie socket accepts
+    // the send() silently but never delivers the reply — that's what this
+    // deadline catches.
+    const deadline = Math.max(2000, Math.floor(this.heartbeatMs / 2));
+    this.pongDeadlineTimer = setTimeout(() => {
+      this.pongDeadlineTimer = null;
+      this.onHeartbeatDead("pong timeout");
+    }, deadline);
+  }
+
+  // onPong clears the pending deadline — the socket answered, so it's alive.
+  private onPong(): void {
+    if (this.pongDeadlineTimer !== null) {
+      clearTimeout(this.pongDeadlineTimer);
+      this.pongDeadlineTimer = null;
+    }
+  }
+
+  // onHeartbeatDead reconnects a socket the heartbeat judged dead. Reuses the
+  // visibility-reconnect path (re-open the WS; the server pushes a fresh render
+  // on connect, re-syncing any state missed during the outage). The
+  // `reconnecting` guard bounds this to one attempt in flight; the next tick
+  // retries if it's still down — a gentle, self-healing cadence, not a storm.
+  private onHeartbeatDead(reason: string): void {
+    if (this.reconnecting) return;
+    if (this.pongDeadlineTimer !== null) {
+      clearTimeout(this.pongDeadlineTimer);
+      this.pongDeadlineTimer = null;
+    }
+    this.logger.info(`Heartbeat: socket dead (${reason}) — reconnecting`);
+    void this.performVisibilityReconnect();
   }
 
   /**

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -105,12 +105,13 @@ describe("Liveness heartbeat", () => {
     jest.restoreAllMocks();
   });
 
-  // Connect with the heartbeat enabled (heartbeatMs is set pre-connect, exactly
-  // as autoInit does from the data-lvt-heartbeat-ms attribute).
+  // Connect with an explicit heartbeat interval (set pre-connect, exactly as
+  // autoInit does from data-lvt-heartbeat-ms). enabled=false opts OUT (0), since
+  // the heartbeat is ON by default now.
   async function connectWithHeartbeat(enabled: boolean): Promise<void> {
     createWrapper();
     client = new LiveTemplateClient({ logLevel: "error" });
-    if (enabled) (client as any).heartbeatMs = HB;
+    (client as any).heartbeatMs = enabled ? HB : 0;
     const connectPromise = client.connect();
     await jest.advanceTimersByTimeAsync(0); // resolve HEAD fetch
     mockSockets[0]?.simulateOpen();
@@ -121,7 +122,20 @@ describe("Liveness heartbeat", () => {
     return sock.sent.filter((m) => m.includes("__ping__")).length;
   }
 
-  it("sends no ping when not opted in", async () => {
+  it("is on by default (no override) and pings at the default interval", async () => {
+    createWrapper();
+    client = new LiveTemplateClient({ logLevel: "error" });
+    const def = (client as any).heartbeatMs;
+    expect(def).toBeGreaterThanOrEqual(1000); // default is a real interval, not 0
+    const connectPromise = client.connect();
+    await jest.advanceTimersByTimeAsync(0);
+    mockSockets[0]?.simulateOpen();
+    await connectPromise;
+    await jest.advanceTimersByTimeAsync(def);
+    expect(pingsSent(mockSockets[0])).toBe(1);
+  });
+
+  it("sends no ping when opted out (heartbeatMs=0)", async () => {
     await connectWithHeartbeat(false);
     await jest.advanceTimersByTimeAsync(HB * 2);
     expect(pingsSent(mockSockets[0])).toBe(0);

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -1,0 +1,187 @@
+import { LiveTemplateClient } from "../livetemplate-client";
+
+// Liveness heartbeat tests. The heartbeat detects a dead OR zombie socket (one
+// that still reports OPEN but whose TCP is gone and fires no close event) by
+// sending an app-level {action:"__ping__"} and reconnecting if the {pong:true}
+// reply doesn't arrive within the deadline. Mirrors visibility-reconnect.test.ts
+// (same MockWebSocket + fake-timer harness).
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  url: string;
+  readyState: number = MockWebSocket.CONNECTING;
+  sent: string[] = [];
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.(new CloseEvent("close", { code: 1000 }));
+  }
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+  // Deliver a server → client message through the transport's onmessage.
+  deliver(obj: unknown) {
+    this.onmessage?.(
+      new MessageEvent("message", { data: JSON.stringify(obj) })
+    );
+  }
+}
+
+let mockSockets: MockWebSocket[] = [];
+
+function installMockWebSocket() {
+  mockSockets = [];
+  const WS = jest.fn().mockImplementation((url: string) => {
+    const sock = new MockWebSocket(url);
+    mockSockets.push(sock);
+    return sock;
+  }) as any;
+  WS.CONNECTING = 0;
+  WS.OPEN = 1;
+  WS.CLOSING = 2;
+  WS.CLOSED = 3;
+  (global as any).WebSocket = WS;
+}
+
+function installFetchStub() {
+  if (typeof (globalThis as any).fetch !== "function") {
+    (globalThis as any).fetch = () => {};
+  }
+  jest
+    .spyOn(globalThis as any, "fetch")
+    .mockImplementation((...args: unknown[]) => {
+      const opts = args[1] as any;
+      if (opts?.method === "HEAD") {
+        return Promise.resolve(
+          new Response(null, {
+            status: 200,
+            headers: { "X-LiveTemplate-WebSocket": "enabled" },
+          })
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    });
+}
+
+function createWrapper(): HTMLDivElement {
+  const wrapper = document.createElement("div");
+  wrapper.setAttribute("data-lvt-id", "test-heartbeat");
+  document.body.appendChild(wrapper);
+  return wrapper;
+}
+
+const HB = 10000; // heartbeat interval; pong deadline = max(2000, HB/2) = 5000
+
+describe("Liveness heartbeat", () => {
+  let client: LiveTemplateClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.replaceChildren();
+    installMockWebSocket();
+    installFetchStub();
+    history.replaceState(null, "", "/test");
+  });
+
+  afterEach(() => {
+    client?.disconnect();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  // Connect with the heartbeat enabled (heartbeatMs is set pre-connect, exactly
+  // as autoInit does from the data-lvt-heartbeat-ms attribute).
+  async function connectWithHeartbeat(enabled: boolean): Promise<void> {
+    createWrapper();
+    client = new LiveTemplateClient({ logLevel: "error" });
+    if (enabled) (client as any).heartbeatMs = HB;
+    const connectPromise = client.connect();
+    await jest.advanceTimersByTimeAsync(0); // resolve HEAD fetch
+    mockSockets[0]?.simulateOpen();
+    await connectPromise;
+  }
+
+  function pingsSent(sock: MockWebSocket): number {
+    return sock.sent.filter((m) => m.includes("__ping__")).length;
+  }
+
+  it("sends no ping when not opted in", async () => {
+    await connectWithHeartbeat(false);
+    await jest.advanceTimersByTimeAsync(HB * 2);
+    expect(pingsSent(mockSockets[0])).toBe(0);
+    expect(mockSockets.length).toBe(1);
+  });
+
+  it("sends a ping each interval when opted in", async () => {
+    await connectWithHeartbeat(true);
+    await jest.advanceTimersByTimeAsync(HB);
+    expect(pingsSent(mockSockets[0])).toBe(1);
+    // Answer the pong so the next interval sends again.
+    mockSockets[0].deliver({ pong: true });
+    await jest.advanceTimersByTimeAsync(HB);
+    expect(pingsSent(mockSockets[0])).toBe(2);
+  });
+
+  it("stays connected when the pong arrives in time", async () => {
+    await connectWithHeartbeat(true);
+    await jest.advanceTimersByTimeAsync(HB); // tick → ping + deadline armed
+    mockSockets[0].deliver({ pong: true }); // alive
+    await jest.advanceTimersByTimeAsync(6000); // past the 5s deadline
+    expect(mockSockets.length).toBe(1); // no reconnect
+    expect(client.isReady()).toBe(true);
+  });
+
+  it("reconnects when the pong never arrives (zombie: OPEN but silent)", async () => {
+    await connectWithHeartbeat(true);
+    expect(mockSockets.length).toBe(1);
+
+    // Tick fires a ping; the socket stays OPEN (readyState 1) but never replies —
+    // the defining zombie case that no close/visibility event would ever catch.
+    await jest.advanceTimersByTimeAsync(HB);
+    expect(pingsSent(mockSockets[0])).toBe(1);
+
+    // After the pong deadline (5s), the heartbeat declares it dead → reconnect.
+    await jest.advanceTimersByTimeAsync(5000);
+    await jest.advanceTimersByTimeAsync(0); // resolve reconnect's HEAD fetch
+    expect(mockSockets.length).toBe(2);
+
+    // Completing the new socket restores readiness.
+    mockSockets[1].simulateOpen();
+    await jest.advanceTimersByTimeAsync(0);
+    expect(client.isReady()).toBe(true);
+  });
+
+  it("reconnects when the socket is CLOSED at tick time", async () => {
+    await connectWithHeartbeat(true);
+    // Socket dies but (in this path) we only notice at the next heartbeat tick.
+    mockSockets[0].readyState = MockWebSocket.CLOSED;
+    await jest.advanceTimersByTimeAsync(HB);
+    await jest.advanceTimersByTimeAsync(0); // resolve reconnect
+    expect(mockSockets.length).toBe(2);
+  });
+
+  it("stops the heartbeat on disconnect (no pings after teardown)", async () => {
+    await connectWithHeartbeat(true);
+    const sock = mockSockets[0];
+    client.disconnect();
+    await jest.advanceTimersByTimeAsync(HB * 2);
+    expect(pingsSent(sock)).toBe(0);
+    expect(mockSockets.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

An opt-*out* liveness heartbeat. Every interval the client sends `{action:"__ping__"}` and expects `{pong:true}` within half the interval; a missing pong — or a non-`OPEN` socket at tick time — means the socket is dead, so it reconnects via the existing visibility-reconnect path (which re-opens the WS; the server pushes a fresh render on connect, re-syncing whatever was missed).

- **On by default** at `DEFAULT_HEARTBEAT_MS` (20s). Opt out with `data-lvt-heartbeat-ms="0"`; any value ≥ 1000 tunes the interval.
- Bounded by the `reconnecting` guard (one attempt in flight; next tick retries) — a gentle self-heal, **not** the tight loop `autoReconnect` (still off) guards against.

## Why

A dropped WebSocket while the tab stays **foreground** (a mobile/tailnet blip) left the UI frozen: `autoReconnect` is off and the only reconnect trigger was `visibilitychange`, so nothing fired. Worst is a **zombie socket** — reports `OPEN` while its TCP is gone — which emits no close event at all, so neither `onDisconnected` nor `visibilitychange` can catch it. A silently-dead socket should recover in every app, not only ones that opted in.

## Depends on

Server half: livetemplate/livetemplate#477 (the `__ping__`/pong echo).

## Tests

`tests/heartbeat.test.ts`: default-on, opt-out (`="0"`), ping-per-interval, pong-keeps-alive, the zombie (`OPEN`-but-silent) reconnect, closed-at-tick reconnect, teardown-on-disconnect. Full suite green (792 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)