### PR TITLE
fix: preserve one-shot scroll/autofocus guards across morphdom

### DIFF
--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -1855,6 +1855,33 @@ export class LiveTemplateClient {
           return false;
         }
 
+        // Preserve the one-shot scroll/autofocus guards across morphdom. The
+        // guards — data-lvt-iv-done (for lvt-fx:scroll="into-view") and
+        // data-lvt-autofocused (for lvt-autofocus) — are runtime-only attributes
+        // the server never emits, so morphdom would strip them on every render
+        // (toEl lacks them), making BOTH directives re-fire on every unrelated
+        // re-render: re-scrolling the page / re-stealing focus to a stale target
+        // (e.g. a 750ms status poll yanking the viewport back to the last-jumped
+        // comment). Copy the guard onto toEl WHILE its directive is still present
+        // so morphdom keeps it; if the server dropped the directive the guard
+        // falls away naturally and the directive re-arms when re-applied (so
+        // deliberately re-navigating to the same element still scrolls). This is
+        // why lvt-fx:animate is immune — it guards via a WeakSet that survives
+        // morphdom; these two guard via attributes, which do not.
+        if (
+          fromEl.nodeType === Node.ELEMENT_NODE &&
+          toEl.nodeType === Node.ELEMENT_NODE
+        ) {
+          const f = fromEl as Element;
+          const t = toEl as Element;
+          if (f.getAttribute("data-lvt-iv-done") === "1" && t.hasAttribute("lvt-fx:scroll")) {
+            t.setAttribute("data-lvt-iv-done", "1");
+          }
+          if (f.getAttribute("data-lvt-autofocused") === "true" && t.hasAttribute("lvt-autofocus")) {
+            t.setAttribute("data-lvt-autofocused", "true");
+          }
+        }
+
         // Track newly-introduced directive attributes so the post-render
         // scan can wire any new lvt-fx:/lvt-on:/lvt-el: bindings even on
         // renders that wouldn't otherwise trigger a wrapper-wide scan.

--- a/tests/scroll-guard-preserve.test.ts
+++ b/tests/scroll-guard-preserve.test.ts
@@ -1,0 +1,86 @@
+/**
+ * One-shot scroll/autofocus guards must survive morphdom.
+ *
+ * `lvt-fx:scroll="into-view"` and `lvt-autofocus` are meant to fire ONCE per
+ * element. Their guards are runtime-only attributes the client stamps on the live
+ * DOM (`data-lvt-iv-done`, `data-lvt-autofocused`) — the server never emits them.
+ * Without preservation, morphdom strips them on every render (the incoming `toEl`
+ * lacks them), so both directives re-fire on unrelated re-renders (re-scrolling /
+ * re-stealing focus to a stale target — e.g. a background status poll yanking the
+ * viewport back to the last-jumped element).
+ *
+ * onBeforeElUpdated copies the guard onto `toEl` WHILE the directive is still
+ * present, so morphdom keeps it; when the server drops the directive the guard
+ * falls away naturally and the directive re-arms on re-add.
+ */
+
+import { LiveTemplateClient } from "../livetemplate-client";
+
+describe("one-shot scroll/autofocus guards survive morphdom", () => {
+  let client: LiveTemplateClient;
+  let wrapper: HTMLElement;
+  let scrollSpy: jest.Mock;
+
+  beforeEach(() => {
+    // jsdom has no scrollIntoView; mock it so the into-view directive can fire and
+    // we can count how often it scrolls (the whole point: it must fire once, not
+    // on every re-render).
+    scrollSpy = jest.fn();
+    (Element.prototype as any).scrollIntoView = scrollSpy;
+    client = new LiveTemplateClient();
+    document.body.replaceChildren();
+    wrapper = document.createElement("div");
+    wrapper.setAttribute("data-lvt-id", "test-guard");
+    document.body.appendChild(wrapper);
+  });
+
+  it("scrolls once, then NOT again on an unrelated re-render (guard preserved)", () => {
+    client.updateDOM(wrapper, {
+      s: [`<div class="target" lvt-fx:scroll="into-view">x</div><span class="sib">`, `</span>`],
+      0: "a",
+    });
+    const target = wrapper.querySelector(".target") as HTMLElement;
+    expect(target).not.toBeNull();
+    expect(scrollSpy).toHaveBeenCalledTimes(1); // fired once on first paint
+    expect(target.dataset.lvtIvDone).toBe("1"); // directive stamped its guard
+
+    // Unrelated update: only the sibling text changes; the target keeps the directive.
+    client.updateDOM(wrapper, { 0: "b" });
+
+    const after = wrapper.querySelector(".target") as HTMLElement;
+    expect(after).toBe(target); // morphdom reused the node
+    expect(after.dataset.lvtIvDone).toBe("1"); // guard PRESERVED across the render
+    expect(scrollSpy).toHaveBeenCalledTimes(1); // NOT re-scrolled — the bug's fix
+    expect(wrapper.querySelector(".sib")!.textContent).toBe("b"); // real update applied
+  });
+
+  it("re-arms and scrolls again after the directive is removed then re-added", () => {
+    client.updateDOM(wrapper, { s: [`<div class="target" lvt-fx:scroll="into-view">`, `</div>`], 0: "x" });
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+
+    // Server drops the directive (scroll target moved elsewhere) → guard must fall away.
+    client.updateDOM(wrapper, { s: [`<div class="target">`, `</div>`], 0: "x" });
+    const mid = wrapper.querySelector(".target") as HTMLElement;
+    expect(mid.hasAttribute("lvt-fx:scroll")).toBe(false);
+    expect(mid.dataset.lvtIvDone).toBeUndefined(); // dropped
+
+    // Server re-targets this element → it must scroll AGAIN (re-armed).
+    client.updateDOM(wrapper, { s: [`<div class="target" lvt-fx:scroll="into-view">`, `</div>`], 0: "x" });
+    expect(scrollSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves data-lvt-autofocused while lvt-autofocus stays present", () => {
+    client.updateDOM(wrapper, {
+      s: [`<textarea class="target" lvt-autofocus></textarea><span class="sib">`, `</span>`],
+      0: "a",
+    });
+    const target = wrapper.querySelector(".target") as HTMLElement;
+    target.setAttribute("data-lvt-autofocused", "true");
+
+    client.updateDOM(wrapper, { 0: "b" });
+
+    const after = wrapper.querySelector(".target") as HTMLElement;
+    expect(after.getAttribute("data-lvt-autofocused")).toBe("true"); // no re-focus
+    expect(wrapper.querySelector(".sib")!.textContent).toBe("b");
+  });
+});


### PR DESCRIPTION
## Problem

`lvt-fx:scroll="into-view"` and `lvt-autofocus` are meant to fire **once** per element. Their guards — `data-lvt-iv-done` and `data-lvt-autofocused` — are runtime-only attributes the client stamps on the live DOM; the server never emits them. So morphdom's attribute diff **strips them on every render** (the incoming `toEl` lacks them), and both directives **re-fire on essentially every unrelated re-render** — re-scrolling the page / re-stealing focus to a stale target.

Downstream symptom (prereview): a 750ms background status poll re-rendered the page and repeatedly yanked the viewport back to the last-jumped comment + stole focus; resolving a comment jumped to the top. `lvt-fx:animate` is immune because it guards via a `WeakSet` that survives morphdom — these two guard via attributes, which don't.

## Fix

`onBeforeElUpdated` copies the guard onto `toEl` **while its directive is still present**, so morphdom keeps it. When the server drops the directive the guard falls away naturally, so the directive **re-arms** on re-add (deliberately re-navigating to the same element still scrolls).

## Tests

`tests/scroll-guard-preserve.test.ts`:
- scrolls once, then **not** again on an unrelated re-render (guard preserved)
- **re-arms** and scrolls again after the directive is removed then re-added
- autofocus guard preserved across an unrelated re-render

Verified failing without the fix (scrolled 2×, `data-lvt-autofocused` stripped). Full suite: 795 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)