### PR TITLE
feat: lvt-fx:viewport-report directive for read-progress reporting

### DIFF
--- a/dom/directives.ts
+++ b/dom/directives.ts
@@ -2803,6 +2803,127 @@ export function teardownTextSelectForRoot(rootElement: Element): void {
   }
 }
 
+// ─── viewport-report (read-progress reporting) ──────────────────────────────
+// `lvt-fx:viewport-report="<action>"` on a SCROLL CONTAINER reports, debounced,
+// the `data-key` of the topmost and bottommost tracked descendant currently
+// intersecting the container's viewport, so the SERVER can track how far the
+// user has read and where they left off. Deliberately DUMB — it only reports
+// keys; all logic (read-range accumulation, high-water mark, restore target)
+// lives server-side, which keeps it a general primitive and makes the behaviour
+// unit-testable without a browser.
+//
+// Which descendants count is chosen by `data-lvt-viewport-items` (a CSS
+// selector, default "[data-key]"); each must carry a `data-key`. A report fires
+// on scroll (debounced), once on attach (the initial viewport), and on resize.
+// The payload is `{ topKey, bottomKey }`; a report is suppressed while the
+// visible extremes are unchanged.
+type ViewportReportEntry = {
+  action: string;
+  cleanup: () => void;
+  updateSend: (send: AreaSelectSendFn) => void;
+};
+const viewportReportArmed = new Map<Element, ViewportReportEntry>();
+const VIEWPORT_REPORT_DEBOUNCE_MS = 250;
+
+function attachViewportReport(
+  container: HTMLElement,
+  action: string,
+  initialSend: AreaSelectSendFn
+): ViewportReportEntry {
+  let send = initialSend;
+  const itemSelector =
+    container.getAttribute("data-lvt-viewport-items") || "[data-key]";
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastTop = "";
+  let lastBottom = "";
+
+  const compute = () => {
+    const view = container.getBoundingClientRect();
+    let topKey = "";
+    let bottomKey = "";
+    // Items are in document order, so the FIRST with any vertical overlap is the
+    // topmost visible and the LAST is the bottommost.
+    container.querySelectorAll<HTMLElement>(itemSelector).forEach((it) => {
+      const key = it.getAttribute("data-key");
+      if (!key) return;
+      const r = it.getBoundingClientRect();
+      if (r.bottom <= view.top || r.top >= view.bottom) return; // fully off-screen
+      if (topKey === "") topKey = key;
+      bottomKey = key;
+    });
+    if (topKey === "" && bottomKey === "") return; // nothing tracked in view yet
+    if (topKey === lastTop && bottomKey === lastBottom) return; // no change
+    lastTop = topKey;
+    lastBottom = bottomKey;
+    send({ action, data: { topKey, bottomKey } });
+  };
+
+  const schedule = () => {
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(compute, VIEWPORT_REPORT_DEBOUNCE_MS);
+  };
+
+  container.addEventListener("scroll", schedule, { passive: true });
+  window.addEventListener("resize", schedule, { passive: true });
+  schedule(); // capture the initial viewport once layout settles
+
+  return {
+    action,
+    updateSend: (s) => {
+      send = s;
+    },
+    cleanup: () => {
+      if (debounceTimer !== null) clearTimeout(debounceTimer);
+      container.removeEventListener("scroll", schedule);
+      window.removeEventListener("resize", schedule);
+      viewportReportArmed.delete(container);
+    },
+  };
+}
+
+/**
+ * Apply `lvt-fx:viewport-report` directives: arm each matching scroll container
+ * once (idempotent across re-renders — an existing entry with the same action
+ * just refreshes its send callback), and sweep entries whose element left the
+ * DOM or lost the attribute.
+ */
+export function handleViewportReportDirectives(
+  rootElement: Element,
+  send: AreaSelectSendFn
+): void {
+  for (const [element, entry] of Array.from(viewportReportArmed)) {
+    if (
+      !element.isConnected ||
+      !element.hasAttribute("lvt-fx:viewport-report")
+    ) {
+      entry.cleanup();
+    }
+  }
+  rootElement
+    .querySelectorAll<HTMLElement>("[lvt-fx\\:viewport-report]")
+    .forEach((el) => {
+      const action = el.getAttribute("lvt-fx:viewport-report");
+      if (!action) {
+        console.warn("lvt-fx:viewport-report requires an action name");
+        return;
+      }
+      const existing = viewportReportArmed.get(el);
+      if (existing && existing.action === action) {
+        existing.updateSend(send);
+        return;
+      }
+      if (existing) existing.cleanup();
+      viewportReportArmed.set(el, attachViewportReport(el, action, send));
+    });
+}
+
+/** Cancel viewport-report listeners for every armed element under root. */
+export function teardownViewportReportForRoot(rootElement: Element): void {
+  for (const [element, entry] of Array.from(viewportReportArmed)) {
+    if (rootElement.contains(element)) entry.cleanup();
+  }
+}
+
 // proxyBridgeArmed mirrors the area/region-select singletons: one entry per
 // armed `lvt-fx:proxy-bridge` element, swept on disconnect. sync runs on every
 // render to re-apply the pin-layer transform morphdom wipes + relay a "locate

--- a/livetemplate-client.ts
+++ b/livetemplate-client.ts
@@ -17,6 +17,7 @@ import {
   handleProxyBridgeDirectives,
   handleRegionSelectDirectives,
   handleTextSelectDirectives,
+  handleViewportReportDirectives,
   handleScrollDirectives,
   handleShadowRootHydration,
   handleToastDirectives,
@@ -27,6 +28,7 @@ import {
   teardownProxyBridgeForRoot,
   teardownRegionSelectForRoot,
   teardownTextSelectForRoot,
+  teardownViewportReportForRoot,
   teardownURLHashForRoot,
   teardownAutoClickTimers,
   setupToastClickOutside,
@@ -729,6 +731,7 @@ export class LiveTemplateClient {
       teardownResizeForRoot(this.wrapperElement);
       teardownRegionSelectForRoot(this.wrapperElement);
       teardownTextSelectForRoot(this.wrapperElement);
+      teardownViewportReportForRoot(this.wrapperElement);
       teardownProxyBridgeForRoot(this.wrapperElement);
       teardownIframeAutoHeightForRoot(this.wrapperElement);
       teardownPreviewBridgeForRoot(this.wrapperElement);
@@ -2250,6 +2253,10 @@ export class LiveTemplateClient {
     // wiring; uses window.getSelection rather than a drawn box, so it covers
     // mouse, touch, and keyboard from one path.
     handleTextSelectDirectives(element, (message) => this.send(message));
+    // viewport-report tracks how far the reviewer has scrolled/read and reports
+    // the visible line keys to the server (read-progress). Same send wiring;
+    // dumb reporter, server owns the logic.
+    handleViewportReportDirectives(element, (message) => this.send(message));
     // proxy-bridge is the --external live-site bridge: it relays the proxied
     // page's nav (→ setProxyURL) and scroll (→ pin-layer transform, no server
     // hop) from the cross-origin beacon. Same send-callback wiring; the only

--- a/tests/viewport-report.test.ts
+++ b/tests/viewport-report.test.ts
@@ -1,0 +1,139 @@
+/**
+ * lvt-fx:viewport-report directive — unit coverage for the deterministic
+ * reporting logic: it reports the topmost + bottommost visible tracked key,
+ * suppresses unchanged repeats, re-arms idempotently, and tears down cleanly.
+ * jsdom has no layout, so each element's getBoundingClientRect is mocked to
+ * position it relative to the container's viewport.
+ */
+import {
+  handleViewportReportDirectives,
+  teardownViewportReportForRoot,
+} from "../dom/directives";
+
+function rect(top: number, bottom: number): DOMRect {
+  return {
+    top,
+    bottom,
+    left: 0,
+    right: 0,
+    width: 0,
+    height: bottom - top,
+    x: 0,
+    y: top,
+    toJSON() {},
+  } as DOMRect;
+}
+
+// The container viewport is 0..100; each line carries its own [top,bottom].
+function makeContainer(lines: { key: string; top: number; bottom: number }[]) {
+  document.body.replaceChildren();
+  const c = document.createElement("main");
+  c.setAttribute("lvt-fx:viewport-report", "reportViewport");
+  c.setAttribute("data-lvt-viewport-items", ".line");
+  c.getBoundingClientRect = () => rect(0, 100);
+  for (const l of lines) {
+    const el = document.createElement("div");
+    el.className = "line";
+    el.setAttribute("data-key", l.key);
+    el.getBoundingClientRect = () => rect(l.top, l.bottom);
+    c.appendChild(el);
+  }
+  document.body.appendChild(c);
+  return c;
+}
+
+const SAMPLE = [
+  { key: "L1-1", top: -40, bottom: -20 }, // fully above the viewport
+  { key: "L2-2", top: -10, bottom: 10 }, // overlaps the top edge
+  { key: "L3-3", top: 30, bottom: 50 }, // fully inside
+  { key: "L4-4", top: 90, bottom: 110 }, // overlaps the bottom edge
+  { key: "L5-5", top: 120, bottom: 140 }, // fully below the viewport
+];
+
+beforeEach(() => jest.useFakeTimers());
+afterEach(() => {
+  teardownViewportReportForRoot(document.body);
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe("lvt-fx:viewport-report", () => {
+  it("reports the topmost and bottommost visible line keys", () => {
+    const sends: any[] = [];
+    makeContainer(SAMPLE);
+    handleViewportReportDirectives(document.body, (m) => sends.push(m));
+    jest.advanceTimersByTime(300); // past the 250ms debounce (initial schedule)
+    expect(sends).toEqual([
+      { action: "reportViewport", data: { topKey: "L2-2", bottomKey: "L4-4" } },
+    ]);
+  });
+
+  it("suppresses a duplicate report when the visible extremes are unchanged", () => {
+    const sends: any[] = [];
+    const c = makeContainer(SAMPLE);
+    handleViewportReportDirectives(document.body, (m) => sends.push(m));
+    jest.advanceTimersByTime(300); // initial report
+    c.dispatchEvent(new Event("scroll")); // same geometry (mocks unchanged)
+    jest.advanceTimersByTime(300);
+    expect(sends).toHaveLength(1);
+  });
+
+  it("reports again when the visible range changes (a real scroll)", () => {
+    const sends: any[] = [];
+    const c = makeContainer(SAMPLE);
+    handleViewportReportDirectives(document.body, (m) => sends.push(m));
+    jest.advanceTimersByTime(300);
+    // Simulate scrolling down: L4/L5 now straddle the viewport, L2 leaves.
+    const relayout: Record<string, [number, number]> = {
+      "L1-1": [-140, -120],
+      "L2-2": [-110, -90],
+      "L3-3": [-70, -50],
+      "L4-4": [-10, 10],
+      "L5-5": [20, 40],
+    };
+    c.querySelectorAll<HTMLElement>(".line").forEach((el) => {
+      const [t, b] = relayout[el.getAttribute("data-key")!];
+      el.getBoundingClientRect = () => rect(t, b);
+    });
+    c.dispatchEvent(new Event("scroll"));
+    jest.advanceTimersByTime(300);
+    expect(sends).toHaveLength(2);
+    expect(sends[1]).toEqual({
+      action: "reportViewport",
+      data: { topKey: "L4-4", bottomKey: "L5-5" },
+    });
+  });
+
+  it("re-arm is idempotent — no duplicate listeners", () => {
+    const sends: any[] = [];
+    const c = makeContainer(SAMPLE);
+    handleViewportReportDirectives(document.body, (m) => sends.push(m));
+    handleViewportReportDirectives(document.body, (m) => sends.push(m)); // re-scan
+    jest.advanceTimersByTime(300);
+    expect(sends).toHaveLength(1); // only the single initial report
+    // A scroll that changes the range fires exactly once, not twice.
+    c.querySelectorAll<HTMLElement>(".line").forEach((el) => {
+      el.getBoundingClientRect = () => rect(200, 220); // all below → nothing visible
+    });
+    // put one back in view so there IS a change
+    (c.querySelector('[data-key="L3-3"]') as HTMLElement).getBoundingClientRect =
+      () => rect(40, 60);
+    c.dispatchEvent(new Event("scroll"));
+    jest.advanceTimersByTime(300);
+    expect(sends).toHaveLength(2);
+  });
+
+  it("teardown stops reporting", () => {
+    const sends: any[] = [];
+    const c = makeContainer(SAMPLE);
+    handleViewportReportDirectives(document.body, (m) => sends.push(m));
+    jest.advanceTimersByTime(300);
+    teardownViewportReportForRoot(document.body);
+    c.querySelectorAll<HTMLElement>(".line").forEach((el) => {
+      el.getBoundingClientRect = () => rect(40, 60);
+    });
+    c.dispatchEvent(new Event("scroll"));
+    jest.advanceTimersByTime(300);
+    expect(sends).toHaveLength(1); // no new reports after teardown
+  });
+});


### PR DESCRIPTION
Adds a debounced **viewport-report** directive so a scroll container can report which tracked descendants are visible back to the server — the primitive behind prereview's read-progress feature ([livetemplate/prereview#128](https://github.com/livetemplate/prereview/issues/128)).

## What

`lvt-fx:viewport-report="<action>"` on a scroll container reports, debounced, the `data-key` of the **topmost** and **bottommost** tracked descendant currently intersecting the container's viewport:

```
send({ action, data: { topKey, bottomKey } })
```

- Tracked descendants are chosen by `data-lvt-viewport-items` (a CSS selector, default `"[data-key]"`); each must carry a `data-key`.
- Fires on scroll (250ms debounce), once on attach (the initial viewport), and on resize.
- Suppresses reports while the visible extremes are unchanged.

## Design: deliberately a dumb reporter

It emits keys only — **all logic** (read-range accumulation, high-water mark, restore-target selection) lives server-side in the consumer. This keeps it a general primitive and, crucially, makes the *behaviour* unit-testable without a browser (the consumer feeds synthetic report actions to its controller). Armed once per container (idempotent re-arm), swept on disconnect / attribute removal — mirrors the existing `text-select` / `area-select` directive lifecycle.

## Tests

`tests/viewport-report.test.ts` (5 cases): reports the top/bottom visible keys; suppresses unchanged repeats; reports again on a real range change; idempotent re-arm (no duplicate listeners); teardown stops reporting. Geometry is mocked (jsdom has no layout); the live scroll is covered end-to-end by the prereview chromedp test.

Full suite: 38 suites / 800 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ey41dRwDpRgLtVHZjhYLKt