### PR TITLE
ci: pin npm to the 11 line in publish workflow (Node 20 compat)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,14 @@ jobs:
       # CLI sends setup-node's placeholder NODE_AUTH_TOKEN to the registry
       # instead of falling through to the OIDC exchange, and publish fails
       # with a misleading E404 PUT error.
+      #
+      # Pin to the npm 11 line (NOT @latest): npm 12 dropped Node 20 support
+      # (engines: node ^22.22.2 || ^24.15.0 || >=26.0.0), so `npm@latest` on
+      # this Node 20 runner fails to install with EBADENGINE and the publish
+      # job never runs. Every npm 11.x supports Node ^20.17.0 AND OIDC
+      # (>= 11.5.1), so this stays compatible until the runner moves to Node 22+.
       - name: Upgrade npm to a version that supports OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Problem
The npm publish job fails at the **"Upgrade npm to a version that supports OIDC trusted publishing"** step:

```
npm error code EBADENGINE
npm error notsup Not compatible with your version of node/npm: npm@12.0.0
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

`npm install -g npm@latest` now resolves to **npm 12**, which dropped Node 20 support. The runner uses Node 20.x, so the install aborts with `EBADENGINE` and the publish job never runs. Concrete impact: **v0.16.3 was tagged and GitHub-released but never published to npm** (v0.16.2 published fine, before npm 12).

## Fix
Pin to the **npm 11 line** instead of `@latest`:
```diff
- run: npm install -g npm@latest
+ run: npm install -g npm@11
```
Every `npm@11.x` (through 11.18.0) declares `engines.node: ^20.17.0 || >=22.9.0` — compatible with the Node 20.20 runner — **and** supports OIDC trusted publishing (≥ 11.5.1). So publishing works again without moving the runner off Node 20 (kept consistent with `test.yml` / `cross-repo-test.yml`).

Bumping the runner to Node 22+ and returning to `@latest` is the natural future cleanup (Node 20 is heading to EOL), but that's a broader change than this hotfix.

## Note
This makes **future** releases publish correctly. `v0.16.3` is already tagged + GitHub-released (publish failed), so getting it onto npm needs a re-trigger after merge (re-create the release) or a follow-up patch. prereview is unaffected either way — it vendors the built bundle directly, not from npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)