### PR TITLE
fix(release): run tests before mutating, restore files on abort

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -128,11 +128,56 @@ bump_version() {
     echo "${major}.${minor}.${patch}"
 }
 
+# Restore the release-managed files if the run aborts between writing them and
+# committing. Without this, a failure in verify_build, verify_package_contents or
+# `gh release create` leaves VERSION, package.json, package-lock.json and
+# CHANGELOG.md rewritten in the worktree — and main() refuses to start on a dirty
+# tree, so the next attempt fails for a reason unrelated to why this one did.
+release_files_written=false
+release_committed=false
+
+restore_release_files() {
+    [ "$release_files_written" = true ] || return 0
+    [ "$release_committed" = false ] || return 0
+
+    log_warn "Release aborted before committing — restoring version and changelog files"
+
+    # Restore from HEAD, not from the index: commit_and_tag stages these files
+    # before committing, so if the commit itself fails they are already staged
+    # and a plain `git checkout --` would restore them from the index — copying
+    # the modified versions back over themselves.
+    #
+    # One path per invocation. `git checkout HEAD -- a b` resolves the pathspec
+    # first and bails before touching the worktree if any entry is missing from
+    # HEAD, so a single call would restore *none* of them when one is untracked.
+    # git's stderr is left visible; a generic "couldn't restore" would send the
+    # next person down the wrong trail.
+    local f
+    for f in VERSION package.json package-lock.json CHANGELOG.md; do
+        if git cat-file -e "HEAD:$f" 2>/dev/null; then
+            git checkout HEAD -- "$f" || \
+                log_warn "Could not restore $f; revert it by hand before retrying"
+        elif [ -f "$f" ]; then
+            # Absent from HEAD but on disk means this run created it: main()
+            # refuses to start on a dirty tree and `git status --porcelain`
+            # lists untracked files, so it cannot have pre-existed. Removing it
+            # restores the exact pre-run state. Both steps are needed —
+            # commit_and_tag may already have staged it, and a bare `rm` would
+            # leave an "A " entry that still counts as dirty.
+            git rm -f --quiet --ignore-unmatch -- "$f" 2>/dev/null || true
+            rm -f "$f"
+            log_warn "Removed $f, which this run created"
+        fi
+    done
+}
+trap restore_release_files EXIT
+
 # Update all version files
 update_versions() {
     local new_version=$1
 
     log_step "Updating VERSION file to $new_version"
+    release_files_written=true
     echo "$new_version" > VERSION
 
     log_step "Updating package.json to $new_version"
@@ -202,6 +247,11 @@ Release @livetemplate/client v$new_version
 This release follows the core library version: $(get_major_minor "$new_version").x
 
 🤖 Generated with automated release script"
+
+    # Set immediately after the commit: from here the changes live in history,
+    # so restoring the worktree from HEAD would be a no-op at best and would
+    # discard the release commit's content at worst.
+    release_committed=true
 
     log_step "Creating git tag v$new_version"
     git tag -a "v$new_version" -m "Release v$new_version"
@@ -599,9 +649,14 @@ main() {
 
     # Execute release steps. Note: npm publish runs in CI (publish.yml),
     # triggered by the GitHub release created in publish_github below.
+    # Tests and the build run first, on the pre-bump tree, so a failing test
+    # aborts before VERSION/package.json/CHANGELOG.md are touched at all. The
+    # dist bundle embeds no version string, so building ahead of the bump is
+    # equivalent. verify_build still runs after, since it asserts package.json
+    # carries the new version.
+    build_and_test
     update_versions "$new_version"
     generate_changelog "$new_version"
-    build_and_test
     verify_build "$new_version"
     verify_package_contents
     commit_and_tag "$new_version"


### PR DESCRIPTION
Ports the fix that landed in the core library's `release.sh` ([livetemplate#499](https://github.com/livetemplate/livetemplate/pull/499)) to the client, where it had never been applied.

## Two problems, both hit while releasing v0.19.1

**1. Files were mutated before tests ran.** `update_versions` and `generate_changelog` ran ahead of `build_and_test`, so a failing test left VERSION, package.json, package-lock.json and CHANGELOG.md already rewritten. `main()` refuses to start on a dirty tree — so the *next* attempt fails for a reason unrelated to why the first one did.

Tests and the build now run first, on the pre-bump tree.

**2. No recovery for post-write failures.** Reordering can't help with anything that fails *after* the write — `verify_build`, `npm pack`, `gh release create`. An EXIT trap now restores the four release-managed files when the run aborts before committing, and stands down once `commit_and_tag` has run.

## Ordering constraint the client has and core doesn't

`verify_build` asserts `package.json`'s version equals the new one, so it genuinely must run post-bump. Moving the build ahead of the bump was only safe after confirming **the dist bundle embeds no version string** — otherwise dist would ship stamped with the old version. Verified: no `__VERSION__` substitution, no package.json import in the TS sources. Final order:

```
build_and_test          # tests + build, pre-bump — fails before touching anything
update_versions         # sets release_files_written
generate_changelog
verify_build            # asserts package.json == new version, so must be post-bump
verify_package_contents
commit_and_tag          # sets release_committed — trap stands down
publish_github
```

## Two subtleties carried over from the core fix

- **Restore from HEAD, not the index.** `commit_and_tag` stages the files before committing, so if the commit itself fails a plain `git checkout --` would restore them *from the index* — copying the modified versions back over themselves.
- **One path per invocation.** `git checkout HEAD -- a b c` resolves the whole pathspec first and bails before touching the worktree if any entry is missing from HEAD, so a single call would restore *none* of them when one is untracked.

## Verification

Both directions exercised against a real worktree:

```
# pre-commit abort
--- dirty before abort: 3 files
WARN: Release aborted before committing — restoring version and changelog files
--- after trap: 1 dirty files      (only scripts/release.sh, the actual edit)

# post-commit abort (release_committed=true)
--- VERSION after: 9.9.9           (untouched, correctly — it's in history now)
```

The second case matters as much as the first: a trap that fired after the commit would discard the release commit's content.

`bash -n` clean; `--dry-run` reaches the same decision points as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG