### PR TITLE
ci(review): keep the review run log so failures are diagnosable

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,6 +59,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: claude-review-execution-log
-          path: ${{ steps.claude-review.outputs.execution_file }}
+          # Falls back to the action's documented temp path: a step that FAILED
+          # never sets its outputs, so execution_file is empty in exactly the
+          # case this upload exists for.
+          path: ${{ steps.claude-review.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,3 +45,20 @@ jobs:
           claude_args: |
             --max-turns 20
             --allowedTools "Read,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      # The run's turn-by-turn log, kept whatever the outcome. When the review
+      # fails, the job log reports only the aggregate — `is_error: true` with a
+      # `permission_denials_count` — and never names the tool that was denied,
+      # which is the one fact needed to fix it. That detail lives in this file,
+      # written to the runner's temp dir and otherwise discarded with the runner.
+      # Runs are cheap to re-trigger but not to reproduce: which tool the model
+      # reaches for varies per PR, so a failure not captured when it happens may
+      # not recur on demand.
+      - name: Upload review execution log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-review-execution-log
+          path: ${{ steps.claude-review.outputs.execution_file }}
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,19 +49,38 @@ jobs:
       # The run's turn-by-turn log, kept whatever the outcome. When the review
       # fails, the job log reports only the aggregate — `is_error: true` with a
       # `permission_denials_count` — and never names the tool that was denied,
-      # which is the one fact needed to fix it. That detail lives in this file,
-      # written to the runner's temp dir and otherwise discarded with the runner.
-      # Runs are cheap to re-trigger but not to reproduce: which tool the model
-      # reaches for varies per PR, so a failure not captured when it happens may
-      # not recur on demand.
+      # which is the one fact needed to fix it.
+      #
+      # The file is located rather than assumed. The action's `execution_file`
+      # output is empty even on success, and the path it prints during the run
+      # ("Log saved to $RUNNER_TEMP/claude-execution-output.json") holds nothing
+      # by the time a later step looks. So search, and when the search comes up
+      # empty say where it looked — a step that silently uploads nothing is worse
+      # than no step, since it reads as "captured" on the next failure.
+      - name: Collect review execution log
+        if: always()
+        run: |
+          mkdir -p /tmp/claude-review-log
+          found=$(find "${RUNNER_TEMP}" "${GITHUB_WORKSPACE}/.." -maxdepth 4 \
+            -name 'claude-execution-output*.json' -o -name 'claude-*output*.json' 2>/dev/null | head -20)
+          if [ -n "$found" ]; then
+            echo "$found" | while read -r f; do
+              cp "$f" "/tmp/claude-review-log/$(echo "$f" | tr '/' '_')" 2>/dev/null || true
+            done
+            echo "Collected:"; ls -la /tmp/claude-review-log
+          else
+            echo "No execution log found. Searched RUNNER_TEMP=${RUNNER_TEMP} and the workspace parent."
+            echo "--- RUNNER_TEMP contents ---"
+            ls -la "${RUNNER_TEMP}" 2>/dev/null | head -40 || echo "(unreadable)"
+            echo "--- *.json anywhere under RUNNER_TEMP ---"
+            find "${RUNNER_TEMP}" -name '*.json' -maxdepth 3 2>/dev/null | head -20 || true
+          fi
+
       - name: Upload review execution log
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: claude-review-execution-log
-          # Falls back to the action's documented temp path: a step that FAILED
-          # never sets its outputs, so execution_file is empty in exactly the
-          # case this upload exists for.
-          path: ${{ steps.claude-review.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}
+          path: /tmp/claude-review-log/
           if-no-files-found: warn
           retention-days: 14


### PR DESCRIPTION
Adds a step capturing the review run's execution log as an artifact, so the next failure can be diagnosed instead of guessed at.

## Why

When the review job fails, the job log gives only the aggregate:

```
"is_error": true,
"num_turns": 4,
"total_cost_usd": 0.1639,
"permission_denials_count": 1
```

It never names the tool that was denied — and that is the one fact needed to fix it. The detail lives in the execution output file, written to the runner temp dir and thrown away with the runner.

## What this rules out

Diagnosing the current failures eliminated three plausible causes, none of which held:

- **Not auth.** The run initializes (`"model": "claude-sonnet-5"`) and bills real budget. (The empty `ANTHROPIC_API_KEY` in the env dump is a red herring — these workflows authenticate via `claude_code_oauth_token`, so that variable is *expected* to be blank.)
- **Not quota.** An exhausted quota fails at init or returns 429; it does not run four turns and charge $0.16.
- **Not an action upgrade.** All three repos pin the floating `@v1` tag, but that tag last moved at `2026-07-19T02:57:33Z` — hours *before* the last green run. Same version succeeded and failed.

What remains is the permission denial itself, which is precisely the part not recorded anywhere durable.

## Note on why capture beats re-running

Re-triggering a run is cheap; reproducing a *specific* failure is not. Which tool the model reaches for varies per PR, so a denial not captured when it happens may simply not recur on demand. Hence `if: always()` rather than only-on-failure — a green run's log is also useful as the baseline to diff against.

Companion PRs apply the same step to the other two repos, since all three fail the same way and each has a differently-scoped allowlist worth comparing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ui2cwpeGkrUfRt8rh2FgGG