### PR TITLE
docs: pin the README CDN snippets, and make the release own them

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install @livetemplate/client
 ### CDN
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.1.0/dist/livetemplate-client.browser.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.20.0/dist/livetemplate-client.browser.js"></script>
 ```
 
 ## Quick Start
@@ -42,7 +42,7 @@ npm install @livetemplate/client
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.1.0/dist/livetemplate-client.browser.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.20.0/dist/livetemplate-client.browser.js"></script>
 </head>
 <body>
     <div id="app"></div>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -172,7 +172,7 @@ restore_release_files() {
     # git's stderr is left visible; a generic "couldn't restore" would send the
     # next person down the wrong trail.
     local f
-    for f in VERSION package.json package-lock.json CHANGELOG.md; do
+    for f in VERSION package.json package-lock.json CHANGELOG.md README.md; do
         if git cat-file -e "HEAD:$f" 2>/dev/null; then
             git checkout HEAD -- "$f" || \
                 log_warn "Could not restore $f; revert it by hand before retrying"
@@ -201,6 +201,19 @@ update_versions() {
 
     log_step "Updating package.json to $new_version"
     npm version "$new_version" --no-git-tag-version --allow-same-version > /dev/null 2>&1
+
+    # The README's CDN snippets carry a literal version, and nothing was
+    # updating them: they advertised 0.1.0 for nineteen minor releases, and the
+    # docs site mirrors this file verbatim to /client/, so every reader there
+    # was told to load a bundle from 2024. A literal that no release step owns
+    # will always drift, so the release owns it now.
+    if [ -f README.md ]; then
+        log_step "Updating README CDN pins to $new_version"
+        sed -i.bak -E \
+            "s#(@livetemplate/client@)[0-9]+\.[0-9]+\.[0-9]+#\1${new_version}#g" \
+            README.md
+        rm -f README.md.bak
+    fi
 
     log_info "All version files updated to $new_version"
 }


### PR DESCRIPTION
`README.md` advertised `@livetemplate/client@0.1.0` in both CDN snippets while the package was on **0.20.0** — nineteen minor versions of drift.

That is not only a stale README. The docs site mirrors this file verbatim to [/client/](https://livetemplate.fly.dev/client/), so every reader there was told to load a bundle from long before the current wire format, against a server that would not speak it. There is no runtime handshake between server and client, so the failure mode is a silently broken app rather than a version warning.

## Why the bump alone is not the fix

Nothing in the release path touched `README.md`. `update_version_files()` rewrote `VERSION` and `package.json`; the literal in the README was owned by nobody, so it was guaranteed to rot again on the next tag — exactly how it reached 0.1.0-vs-0.20.0 in the first place.

So the release owns it now:

- `update_version_files()` rewrites the pins alongside `VERSION` and `package.json`.
- `README.md` joins the list restored when a release aborts midway. Without that, a failed run leaves the tree dirty and the next attempt refuses to start — the same trap #151 fixed for the other files.

The substitution is anchored to `@livetemplate/client@<semver>`, so the unpinned `npm install @livetemplate/client` line and any unrelated scoped package are untouched. Verified against a fixture covering all three cases before wiring it in:

```
@livetemplate/client@0.20.0/dist/...  ->  @livetemplate/client@0.21.0/dist/...   (rewritten)
npm install @livetemplate/client       ->  unchanged
@livetemplate/other@1.2.3              ->  unchanged
```

`sed -i.bak` rather than bare `-i` so it behaves identically on macOS.

## Verification

`npm test`: 824 passed across 39 suites, 1 skipped. `bash -n scripts/release.sh` clean. Pre-commit (lint + full suite) green.

Found while auditing dead and stale links across the docs site (livetemplate/docs#130), which fixed 118 broken mirrored links but could not fix this one — the docs repo mirrors this README, so the correction has to happen here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzC2djPjPHkNJgPzFpMX7v